### PR TITLE
ci: pin v006 board nightly, newer lld misplaces tb_version

### DIFF
--- a/firmware/boards/osc-dev-v006/rust-toolchain.toml
+++ b/firmware/boards/osc-dev-v006/rust-toolchain.toml
@@ -1,3 +1,5 @@
 [toolchain]
-channel    = "nightly"
+# Pinned. The 2026-08-10 nightly's rust-lld places .tb_version in RAM on top
+# of .bss and the link fails. 2026-08-04 is the last known good nightly.
+channel    = "nightly-2026-08-04"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
The v006 cross-build started failing with rust-lld putting .tb_version on top of .bss. Nothing in the repo changed, the nightly did. 2026-08-04 was green and 2026-08-10 fails, so this pins the board toolchain to the last good one until I dig into the linker script.