### PR TITLE
mech: cad tooling, stenciljig, carrier scaffold, encbench rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ venv/
 
 # Root-level Rust build (subdir Rust crates have their own)
 /target
+
+# Generated board BOM outputs (ibom etc.)
+hardware/boards/*/bom/

--- a/firmware/lib/core/src/services/bus/tests/mod.rs
+++ b/firmware/lib/core/src/services/bus/tests/mod.rs
@@ -336,8 +336,8 @@ fn profile_read_over_ceiling_rejects_limit() {
     let shared = Shared::new();
     // 5 x 63 B = 315 B > MAX_PAYLOAD.
     shared.table.with_mut(|t| {
-        for w in 0..5 {
-            t.profile.slots.words[w] = span_word(0, 63);
+        for w in &mut t.profile.slots.words[..5] {
+            *w = span_word(0, 63);
         }
     });
     let mut staged = StagedWrites::new();

--- a/firmware/lib/integration/src/sim/mod.rs
+++ b/firmware/lib/integration/src/sim/mod.rs
@@ -734,8 +734,8 @@ impl Sim {
     }
 
     fn deliver_garble(&mut self, byte: u8) {
-        for j in 0..self.servos.len() {
-            self.handles[j].ring.push(byte);
+        for h in &self.handles {
+            h.ring.push(byte);
         }
         if let Some(h) = &self.host {
             h.ring.push(byte);

--- a/mechanical/README.md
+++ b/mechanical/README.md
@@ -13,6 +13,27 @@ One folder per project; each project writes its printable outputs
   (hardware/boards/encoder-board): base, sled, clamp, discs, shims,
   paper patterns. Parametric over motor dims (imports
   `sg90.measurements`) and quadrature-phase presets.
+- `carrier/` - tier-2 encoder carrier: printed pot replacement (stator
+  body with coupon shelf + magnet cup rotor) around purchased 1.4mm rod
+  and brass tube stock; imports `sg90.measurements`, dims pending the
+  donor measurement session.
+- `stenciljig/` - solder-paste stencil jig, build123d implementation
+  of the mechanism from bobstay's parametric jig
+  (printables.com/model/1209372, credited with thanks). Heat-set
+  inserts swapped for captive M3 nuts, plate screws top-driven via
+  under-base nut bars. One part per file, shared spec in
+  `common.py`, mating cavities offset from the owning part's
+  profile; every part exports pre-oriented and support-free (all
+  internal ceilings are 45-degree tents, hoppers or cones). Two
+  stacking parts: the jig stands on screw-on feet next to an open
+  tote (`box.py`) standing on four of the same feet, holding the
+  thickness adapters, low-profile standing-wedge squeegees, stencil
+  sheets and spares; for transport the jig stacks onto the box as
+  its lid - the rear feet's hook noses latch the box wall and two
+  printed quarter-turn cam knobs seat under the box's descending
+  ceiling tents to draw it down tight, no hardware in the joint.
+  TPU desk pads snap into the feet's through bores (one pad and one
+  foot model everywhere).
 - `render.py` - shared headless STL preview.
 
 ## Setup

--- a/mechanical/blueprint.py
+++ b/mechanical/blueprint.py
@@ -1,0 +1,127 @@
+"""2D blueprint SVG from a part: third-angle front/top/right views,
+hidden lines dashed, overall dimensions. python blueprint.py part.step
+[out.svg], or blueprint(part, path) from a build script."""
+import sys
+
+from build123d import GeomType, import_step
+
+D = 1000.0                 # parallel projection - distance is arbitrary
+
+# view: (label, viewport_origin offset, up) in the part frame; screen
+# axes come out as front=(X,Z), top=(X,Y), right=(Y,Z)
+VIEWS = (
+    ("FRONT", (0, -D, 0), (0, 0, 1)),
+    ("TOP", (0, 0, D), (0, 1, 0)),
+    ("RIGHT", (D, 0, 0), (0, 0, 1)),
+)
+MARGIN = 12.0
+GAP = 14.0                 # between views; dims live in it
+FONT = 3.0
+DIM_OFF = 7.0              # dimension line offset from the view
+
+
+def _polyline(e):
+    n = 1 if e.geom_type == GeomType.LINE else 48
+    return [(p.X, p.Y) for p in (e @ (i / n) for i in range(n + 1))]
+
+
+def _project(part, origin, up):
+    c = part.center()
+    vis, hid = part.project_to_viewport(
+        (c.X + origin[0], c.Y + origin[1], c.Z + origin[2]),
+        viewport_up=up, look_at=c)
+    vis = [_polyline(e) for e in vis]
+    hid = [_polyline(e) for e in hid]
+    xs = [x for pl in vis + hid for x, _ in pl]
+    ys = [y for pl in vis + hid for _, y in pl]
+    return vis, hid, (min(xs), min(ys), max(xs), max(ys))
+
+
+def _paths(rows, polylines, dx, dy, scale, sheet_h, cls):
+    for pl in polylines:
+        d = " ".join(f"{'M' if i == 0 else 'L'}"
+                     f"{(x * scale + dx):.2f},{(sheet_h - (y * scale + dy)):.2f}"
+                     for i, (x, y) in enumerate(pl))
+        rows.append(f'<path class="{cls}" d="{d}"/>')
+
+
+def _hdim(rows, x0, x1, y, sheet_h, label):
+    y = sheet_h - y
+    rows += [
+        f'<path class="d" d="M{x0:.2f},{y:.2f} L{x1:.2f},{y:.2f}"/>',
+        f'<path class="d" d="M{x0:.2f},{y - 1.2:.2f} L{x0:.2f},{y + 1.2:.2f}'
+        f' M{x1:.2f},{y - 1.2:.2f} L{x1:.2f},{y + 1.2:.2f}"/>',
+        f'<text x="{(x0 + x1) / 2:.2f}" y="{y - 1.0:.2f}" '
+        f'text-anchor="middle">{label}</text>',
+    ]
+
+
+def _vdim(rows, y0, y1, x, sheet_h, label):
+    ya, yb = sheet_h - y1, sheet_h - y0
+    rows += [
+        f'<path class="d" d="M{x:.2f},{ya:.2f} L{x:.2f},{yb:.2f}"/>',
+        f'<path class="d" d="M{x - 1.2:.2f},{ya:.2f} L{x + 1.2:.2f},{ya:.2f}'
+        f' M{x - 1.2:.2f},{yb:.2f} L{x + 1.2:.2f},{yb:.2f}"/>',
+        f'<text x="{x - 1.0:.2f}" y="{(ya + yb) / 2:.2f}" text-anchor="middle"'
+        f' transform="rotate(-90 {x - 1.0:.2f} {(ya + yb) / 2:.2f})">'
+        f'{label}</text>',
+    ]
+
+
+def blueprint(part, out_path, name=None):
+    views = {lbl: _project(part, o, up) for lbl, o, up in VIEWS}
+    bb = part.bounding_box()
+    w, dep, h = bb.size.X, bb.size.Y, bb.size.Z
+    scale = next(s for s in (5, 2, 1, 0.5)
+                 if max(w, dep) * s <= 180 and (h + dep) * s <= 190)
+
+    def sized(lbl):
+        _, _, (x0, y0, x1, y1) = views[lbl]
+        return (x1 - x0) * scale, (y1 - y0) * scale
+
+    fw, fh = sized("FRONT")
+    tw, th = sized("TOP")
+    rw, rh = sized("RIGHT")
+    # third angle: TOP above FRONT (X shared), RIGHT beside FRONT (Z shared)
+    fx, fy = MARGIN + DIM_OFF, MARGIN + DIM_OFF
+    tx, ty = fx, fy + fh + GAP
+    rx, ry = fx + fw + GAP, fy
+    sheet_w = max(rx + rw, tx + tw) + MARGIN
+    sheet_h = ty + th + MARGIN + 2 * FONT
+
+    rows = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{sheet_w:.0f}mm" '
+        f'height="{sheet_h:.0f}mm" viewBox="0 0 {sheet_w:.2f} {sheet_h:.2f}">',
+        '<style>path{fill:none;stroke:black}'
+        '.v{stroke-width:0.35}.h{stroke-width:0.18;stroke-dasharray:1.2 0.8}'
+        '.d{stroke-width:0.13}'
+        f'text{{font:{FONT}px sans-serif;fill:black}}</style>',
+        f'<rect width="{sheet_w:.2f}" height="{sheet_h:.2f}" fill="white"/>',
+    ]
+    for lbl, (ox, oy) in (("FRONT", (fx, fy)), ("TOP", (tx, ty)),
+                          ("RIGHT", (rx, ry))):
+        vis, hid, (x0, y0, _, _) = views[lbl]
+        dx, dy = ox - x0 * scale, oy - y0 * scale
+        _paths(rows, hid, dx, dy, scale, sheet_h, "h")
+        _paths(rows, vis, dx, dy, scale, sheet_h, "v")
+        rows.append(f'<text x="{ox:.2f}" '
+                    f'y="{sheet_h - (oy - 1.5):.2f}">{lbl}</text>')
+    _hdim(rows, fx, fx + fw, fy - DIM_OFF + 2.5, sheet_h, f"{w:.2f}")
+    _vdim(rows, fy, fy + fh, fx - DIM_OFF + 2.5, sheet_h, f"{h:.2f}")
+    _hdim(rows, rx, rx + rw, ry - DIM_OFF + 2.5, sheet_h, f"{dep:.2f}")
+    title = name or getattr(part, "label", "") or "part"
+    rows.append(
+        f'<text x="{sheet_w - MARGIN:.2f}" y="{sheet_h - 3:.2f}" '
+        f'text-anchor="end">{title} | mm | '
+        f'{scale:g}:1 | third angle</text>')
+    rows.append("</svg>")
+    with open(out_path, "w") as f:
+        f.write("\n".join(rows))
+    return out_path
+
+
+if __name__ == "__main__":
+    step = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else step.rsplit(".", 1)[0] + "_bp.svg"
+    part = import_step(step)
+    print("saved", blueprint(part, out, name=step.rsplit("/", 1)[-1]))

--- a/mechanical/carrier/__init__.py
+++ b/mechanical/carrier/__init__.py
@@ -1,0 +1,1 @@
+"""Tier-2 encoder carrier: printed pot replacement for the SG90."""

--- a/mechanical/carrier/__main__.py
+++ b/mechanical/carrier/__main__.py
@@ -1,0 +1,18 @@
+"""Build all carrier parts: python -m carrier (from mechanical/)."""
+import pathlib
+
+from build123d import export_step, export_stl
+
+from blueprint import blueprint
+
+from . import body, cup, assembly
+
+out = pathlib.Path(__file__).parent / "build"
+out.mkdir(exist_ok=True)
+for mod, name in ((body, "carrier_body"), (cup, "carrier_cup"),
+                  (assembly, "carrier_assembly")):
+    part = mod.build()
+    export_step(part, str(out / f"{name}.step"))
+    export_stl(part, str(out / f"{name}.stl"), tolerance=0.01)
+    blueprint(part, str(out / f"{name}_bp.svg"), name=name)
+    print(f"{name} -> {out}")

--- a/mechanical/carrier/assembly.py
+++ b/mechanical/carrier/assembly.py
@@ -1,0 +1,99 @@
+"""Full tier-2 stack: carrier + rotor + purchased parts + gear references."""
+from build123d import *
+
+from sg90 import measurements as m
+from . import params as p
+from . import body as body_mod
+from . import cup as cup_mod
+
+
+def _cyl(r, z0, z1):
+    return Pos(0, 0, z0) * Cylinder(
+        r, z1 - z0, align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+
+def build() -> Compound:
+    body = body_mod.build()
+    cup = cup_mod.build()
+    pin = _cyl(p.PIN_D / 2, p.PIN_BOT_Z, p.PIN_TOP_Z)
+    # jig-filed D-flat on the gear4 zone (form closure, protocol above)
+    pin -= Pos(p.PIN_FLAT_ACROSS - p.PIN_D / 2, 0,
+               p.PIN_TOP_Z - p.PIN_FLAT_L) * Box(
+        p.PIN_D, p.PIN_D + 1, p.PIN_FLAT_L + 1,
+        align=(Align.MIN, Align.CENTER, Align.MIN))
+    bush = _cyl(p.BUSH_OD / 2, p.BUSH_Z, p.BUSH_Z + p.BUSH_L) \
+        - _cyl(p.BUSH_ID / 2, p.BUSH_Z - 1, p.BUSH_Z + p.BUSH_L + 1)
+    magnet = _cyl(p.MAG_D / 2, p.MAG_TOP_Z - p.MAG_H, p.MAG_TOP_Z)
+
+    # round board shown in the installed position: tabs twisted 35 deg
+    coupon = _cyl(p.COUPON_D / 2, p.COUPON_TOP_Z - p.COUPON_T,
+                  p.COUPON_TOP_Z)
+    for a in (35, 215):
+        coupon += Rot(0, 0, a) * Pos(
+            (p.COUPON_D / 2 + p.TAB_R_OUT) / 2 - 0.05, 0,
+            p.COUPON_TOP_Z - p.COUPON_T) * Box(
+            p.TAB_R_OUT - p.COUPON_D / 2 + 0.3, p.TAB_W, p.COUPON_T,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+    sensor = Pos(0, 0, p.COUPON_TOP_Z) * Box(
+        p.SENSOR_SZ, p.SENSOR_SZ, p.SENSOR_H,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+    # gear references: plain cylinders, positions approximate
+    g2_z = p.GEAR2_SEAT_Z
+    g4_z = g2_z + m.GEAR2_TOTAL_H + 0.1
+    sleeve = _cyl(p.G2_SLEEVE_OD / 2, g2_z, g4_z) \
+        - _cyl(p.G2_SLEEVE_ID / 2, g2_z - 1, g4_z + 1)
+    gear2 = _cyl(m.GEAR2_D / 2, g2_z, g2_z + m.GEAR2_H)
+    gear2 += _cyl(m.GEAR2_PINION_D / 2, g2_z + m.GEAR2_H,
+                  g2_z + m.GEAR2_TOTAL_H)
+    gear2 -= _cyl(p.G2_SLEEVE_OD / 2 + 0.05, g2_z - 1,
+                  g2_z + m.GEAR2_TOTAL_H + 1)
+    gear4 = _cyl(m.GEAR4_D / 2, g4_z, g4_z + m.GEAR4_H)
+    gear4 += _cyl(m.GEAR4_BOSS_D / 2, g4_z + m.GEAR4_H,
+                  g4_z + m.GEAR4_TOTAL_H)
+    gear4 -= _cyl(p.PIN_D / 2, g4_z - 1, g4_z + p.GEAR4_BORE_DEPTH_EST)
+
+    for part, label, color in (
+            (body, "body", (0.20, 0.25, 0.35)),
+            (cup, "cup", (0.85, 0.45, 0.10)),
+            (pin, "pin", (0.75, 0.75, 0.78)),
+            (sleeve, "g2_sleeve", (0.80, 0.66, 0.35)),
+            (bush, "bushing", (0.72, 0.58, 0.28)),
+            (magnet, "magnet", (0.35, 0.35, 0.38)),
+            (coupon, "coupon", (0.15, 0.45, 0.25)),
+            (sensor, "sensor", (0.10, 0.10, 0.10)),
+            (gear2, "gear2_ref", (0.88, 0.88, 0.84)),
+            (gear4, "gear4_ref", (0.88, 0.88, 0.84))):
+        part.label = label
+        part.color = Color(*color)
+    return Compound(label="tier2_carrier", children=[
+        body, cup, pin, sleeve, bush, magnet, coupon, sensor, gear2, gear4])
+
+
+def build_section() -> Compound:
+    """+X half removed, for reviewing the internal stack."""
+    half = Pos(15, 0, 0) * Box(30, 30, 60)
+    kids = []
+    for child in build().children:
+        cut = child - half
+        cut.label, cut.color = child.label, child.color
+        kids.append(cut)
+    return Compound(label="tier2_carrier_section", children=kids)
+
+
+if __name__ == "__main__":
+    import pathlib
+    out = pathlib.Path(__file__).parent / "build"
+    out.mkdir(exist_ok=True)
+    part = build()
+    export_step(part, str(out / "carrier_assembly.step"))
+    export_stl(part, str(out / "carrier_assembly.stl"), tolerance=0.01)
+    from blueprint import blueprint
+    blueprint(part, str(out / "carrier_assembly_bp.svg"),
+              name="carrier_assembly")
+    sec = build_section()
+    export_step(sec, str(out / "carrier_section.step"))
+    export_stl(sec, str(out / "carrier_section.stl"), tolerance=0.01)
+    blueprint(sec, str(out / "carrier_section_bp.svg"),
+              name="carrier_section")
+    print(f"carrier_assembly + carrier_section -> {out}")

--- a/mechanical/carrier/body.py
+++ b/mechanical/carrier/body.py
@@ -1,0 +1,84 @@
+"""Carrier stator: pot-envelope body, bearing bore, arms, coupon shelf."""
+import math
+
+from build123d import *
+
+from . import params as p
+
+
+def _sector(r_in, r_out, half_deg):
+    # annular sector opening toward +Y
+    a = math.radians(half_deg)
+    span = 2 * r_out
+    wedge = Polygon((0, 0), (span * math.sin(a), span * math.cos(a)),
+                    (-span * math.sin(a), span * math.cos(a)), align=None)
+    return (Circle(r_out) - Circle(r_in)) & wedge
+
+
+def _under_structure() -> Part:
+    """Arc shells + ledge + bayonet features below the body.
+
+    Everything except the snap hooks stays inside OPENING_R so the part
+    inserts through the shell floor opening; the hooks ride on slotted
+    fingers (the arcs themselves are hoop-stiff and cannot flex).
+    """
+    shell = Pos(0, 0, p.ARM_BOT_Z) * extrude(
+        Circle(p.ARM_R_OUT) - Circle(p.ARM_R_IN), -p.ARM_BOT_Z)
+    # board seat: underside at COUPON_TOP_Z sets the sensor gap
+    shell += Pos(0, 0, p.COUPON_TOP_Z) * extrude(
+        Circle(p.ARM_R_IN + 0.05) - Circle(p.LEDGE_R_IN), p.LEDGE_H)
+    # tab gaps at +/-X, full height
+    for a in (-90, 90):
+        shell -= Rot(0, 0, a) * Pos(0, 0, p.ARM_BOT_Z - 1) * extrude(
+            _sector(p.LEDGE_R_IN - 0.3, p.ARM_R_OUT + 1, p.GAP_HALF_DEG),
+            -p.ARM_BOT_Z + 2)
+    # bayonet bands: tabs twist from the gaps toward the end stops
+    for a in (-90, 90):
+        shell -= Rot(0, 0, a) * Pos(0, 0, p.BAY_BOT_Z) * extrude(
+            _sector(p.ARM_R_IN - 0.1, p.ARM_R_OUT + 1, p.BAY_HALF_DEG),
+            p.BAY_TOP_Z - p.BAY_BOT_Z)
+    # free a snap finger out of each arc at +/-Y
+    for s in (1, -1):
+        for sx in (1, -1):
+            shell -= Pos(sx * (p.FINGER_W / 2 + p.FINGER_SLOT / 2),
+                         s * 3.85, p.FINGER_SLOT_BOT_Z) * Box(
+                p.FINGER_SLOT, 1.4, -p.FINGER_SLOT_BOT_Z + 1,
+                align=(Align.CENTER, Align.CENTER, Align.MIN))
+        shell -= Pos(0, s * 3.85, -0.40) * Box(
+            p.FINGER_W + 2 * p.FINGER_SLOT, 1.4, 0.38,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+        shell += Pos(0, s * (p.ARM_R_OUT + p.HOOK_T / 2),
+                     p.HOOK_TOP_Z - p.HOOK_H / 2) * Box(
+            2.0, p.HOOK_T, p.HOOK_H)
+    # detents behind the seated tab's trailing edge (tab spans 20-50 deg
+    # at the end stop); crush-height, the click is a light yield
+    for a in (18, 198):
+        shell += Rot(0, 0, a) * Pos(3.85, 0, p.BAY_BOT_Z) * Box(
+            0.4, 0.5, 0.05, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    return shell
+
+
+def build() -> Part:
+    body = Cylinder(p.BODY_D / 2, p.BODY_H,
+                    align=(Align.CENTER, Align.CENTER, Align.MIN))
+    # printed gear2 thrust seat; z-exact, so the tube can press in flush
+    body += Pos(0, 0, p.BODY_H) * Cylinder(
+        p.SEAT_BOSS_D / 2, p.SEAT_BOSS_H_EST,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    body -= Cylinder((p.BUSH_OD - p.BUSH_PRESS) / 2, 3 * p.BODY_H)
+    # ear insets: open to the rim so they drop over the shell ears
+    for s in (1, -1):
+        body -= Pos(s * (p.BODY_D / 2 - 1.9 + p.EAR_INSET_W / 2), 0, 0) * Box(
+            p.EAR_INSET_W + 1.0, p.EAR_INSET_L, 2 * p.EAR_INSET_DEPTH)
+    body += _under_structure()
+    return body
+
+
+if __name__ == "__main__":
+    import pathlib
+    out = pathlib.Path(__file__).parent / "build"
+    out.mkdir(exist_ok=True)
+    part = build()
+    export_step(part, str(out / "carrier_body.step"))
+    export_stl(part, str(out / "carrier_body.stl"), tolerance=0.01)
+    print(f"carrier_body: volume {part.volume:.0f} mm^3 -> {out}")

--- a/mechanical/carrier/cup.py
+++ b/mechanical/carrier/cup.py
@@ -1,0 +1,70 @@
+"""Magnet cup rotor: crush-rib grip on the pin, snap-captive magnet.
+
+Pocket opens DOWN: magnet clicks past three nubs and sits captive
+between the pocket ceiling and the nubs; bare magnet face toward the
+sensor, no printed floor in the magnetic gap.
+"""
+from build123d import *
+
+from . import params as p
+
+
+def build() -> Part:
+    cup = Pos(0, 0, p.CUP_RIM_Z) * Cylinder(
+        p.CUP_OD / 2, p.CUP_TOP_Z - p.CUP_RIM_Z,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    cup += Pos(0, 0, p.CUP_TOP_Z) * Cylinder(
+        p.CUP_HUB_D / 2, p.CUP_HUB_TOP_Z - p.CUP_TOP_Z,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    web_bot = p.MAG_TOP_Z + p.CUP_BUMP_H
+    # pin bore, ribs added back after the cut
+    cup -= Pos(0, 0, web_bot) * Cylinder(
+        (p.PIN_D + 0.1) / 2, p.CUP_HUB_TOP_Z - web_bot + 1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    # magnet pocket, up to the web underside
+    cup -= Pos(0, 0, web_bot) * Cylinder(
+        (p.MAG_D + 0.1) / 2, web_bot - p.CUP_RIM_Z + 1,
+        align=(Align.CENTER, Align.CENTER, Align.MAX))
+    # three crush ribs in the pin bore
+    rib_h = p.CUP_HUB_TOP_Z - web_bot
+    for a in (0, 120, 240):
+        rib_mid = (p.PIN_D - p.CUP_RIB_GRIP + p.PIN_D + 0.2) / 4
+        cup += Rot(0, 0, a) * Pos(0, rib_mid, web_bot) * Box(
+            0.45, (p.PIN_D + 0.2) / 2 - (p.PIN_D - p.CUP_RIB_GRIP) / 2 + 0.1,
+            rib_h, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    # ceiling crush bumps: yield under the anvil press, clamp the magnet
+    for a in (0, 120, 240):
+        cup += Rot(0, 0, a) * Pos(0, 0.9, web_bot) * Box(
+            0.5, 0.5, p.CUP_BUMP_H,
+            align=(Align.CENTER, Align.CENTER, Align.MAX))
+    # petal-spring radial ribs on the pocket wall, one per petal
+    for a in (60, 180, 300):
+        rib_mid = (p.MAG_D - p.CUP_POCKET_RIB + p.MAG_D + 0.1) / 4
+        cup += Rot(0, 0, a) * Pos(0, rib_mid, web_bot) * Box(
+            0.5, (p.MAG_D + 0.1) / 2 - (p.MAG_D - p.CUP_POCKET_RIB) / 2 + 0.1,
+            web_bot - (p.CUP_RIM_Z + 0.3),
+            align=(Align.CENTER, Align.CENTER, Align.MAX))
+    # three snap nubs at the pocket mouth
+    nub_top = p.CUP_RIM_Z + 0.05 + p.CUP_NUB_H
+    for a in (60, 180, 300):
+        nub_mid = (p.CUP_NUB_D + p.MAG_D + 0.1) / 4
+        cup += Rot(0, 0, a) * Pos(0, nub_mid, nub_top) * Box(
+            0.9, (p.MAG_D + 0.1) / 2 - p.CUP_NUB_D / 2 + 0.1, p.CUP_NUB_H,
+            align=(Align.CENTER, Align.CENTER, Align.MAX))
+    # petal slots between the nubs: rim -> just under the pocket ceiling
+    for a in (0, 120, 240):
+        cup -= Rot(0, 0, a) * Pos(0, (p.MAG_D + p.CUP_OD) / 4,
+                                  p.CUP_RIM_Z - 0.5) * Box(
+            p.CUP_SLOT_W, p.CUP_OD / 2, p.MAG_TOP_Z - 0.1 - p.CUP_RIM_Z + 0.5,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+    return cup
+
+
+if __name__ == "__main__":
+    import pathlib
+    out = pathlib.Path(__file__).parent / "build"
+    out.mkdir(exist_ok=True)
+    part = build()
+    export_step(part, str(out / "carrier_cup.step"))
+    export_stl(part, str(out / "carrier_cup.stl"), tolerance=0.01)
+    print(f"carrier_cup: volume {part.volume:.1f} mm^3 -> {out}")

--- a/mechanical/carrier/params.py
+++ b/mechanical/carrier/params.py
@@ -1,0 +1,133 @@
+"""Tier-2 carrier parameters.
+
+Replaces the SG90 feedback pot: printed stator body in the pot envelope,
+steel pin shaft, brass tube bearing, printed magnet cup, coupon shelf.
+Purchased metal is AliExpress stock; donor envelope imports from
+sg90.measurements. Same *_EST convention: unverified until measured or
+bench-fit (press/running fits get a printed ladder before they are
+trusted).
+
+z layout: carrier back face (ear seating plane) = 0, front face up,
+matching sg90/pot.py. Wiper-leg direction = -Y; shell ears assumed at
++/-X (CASE_POT_EAR_ANGLE_EST), hanger arms at +/-Y in the ear gaps.
+"""
+from sg90 import measurements as m
+
+# --- purchased metal ---
+PIN_D = 1.4            # H62 brass rod (donor shaft class)
+PIN_L = 14.0           # cut length; donor shaft spans 12.79
+PIN_FLAT_ACROSS = 1.02 # D-flat filed on the top gear4 zone (jig-defined
+                       # depth, steel wear strips): form closure, NOT
+                       # friction - gear4 is the load-bearing gear and
+                       # POM stress relaxation loosens press fits, which
+                       # would read as encoder zero drift
+PIN_FLAT_L = 3.5       # matches gear4 engagement
+BUSH_OD = 2.5          # brass tube, 0.5 wall stock
+BUSH_ID = 1.5          # pin running fit; pick stock that spins free
+G2_SLEEVE_OD = 1.8     # gear2 journal sleeve - CONTINGENT on the gear2
+G2_SLEEVE_ID = 1.5     # bore measurement (likely stepped, wheel ~1.4 /
+                       # pinion relief ~1.9): bore >=1.45 -> DELETE, gear2
+                       # rides the pin; bore ~1.9 -> keep. NEVER ream
+                       # gear2 (~0.12 pinion wall, the tooth-strip stage)
+MAG_D = 3.0            # D3x1.5 diametral NdFeB
+MAG_H = 1.5
+
+# --- axial layout ---
+BODY_D = m.POT_BODY_D          # 9.92 keeps the shell pocket fit
+BODY_H = m.POT_BODY_L          # 4.30 keeps the shell stack unchanged
+BUSH_L = 4.0                   # cut length; pressed until FLUSH with the
+                               # front face (flat plate against the face
+                               # = its own depth stop), so the ~0.3
+                               # bottom recess is pure clearance - tube
+                               # axial position is NON-critical, the
+                               # tube is a radial bearing only
+BUSH_TOP_Z = BODY_H
+BUSH_Z = BODY_H - BUSH_L
+SEAT_BOSS_D = 3.0              # printed gear2 thrust seat on the front
+SEAT_BOSS_H_EST = 0.2          # UNVERIFIED - donor shoulder height is a
+                               # PRECISION copy target (+0.3 ear-inset
+                               # offset): the shoulder plane = gear1 wheel
+                               # top, sets gear2's mesh engagement; the
+                               # donor stacks every gear face-to-face off
+                               # the shaft steps (D-start = gear2 pinion
+                               # top -> gear4 press-jig depth, same rule)
+GEAR2_SEAT_Z = BODY_H + SEAT_BOSS_H_EST
+PIN_TOP_Z = 12.1               # inside the gear4 D-bore
+PIN_BOT_Z = PIN_TOP_Z - PIN_L  # -1.9, cup grips this end
+GEAR4_BORE_DEPTH_EST = 3.5     # UNVERIFIED - sets PIN_TOP_Z for real
+
+# --- fits (bench ladder) ---
+BUSH_PRESS = 0.08      # bore = BUSH_OD - this
+CUP_RIB_GRIP = 0.10    # rib crest dia = PIN_D - this
+CUP_HUB_CLEAR = 0.12   # cup hub in the body bore
+
+# --- magnet cup (rotor) ---
+CUP_OD = 4.6
+CUP_HUB_D = BUSH_OD - BUSH_PRESS - CUP_HUB_CLEAR
+CUP_HUB_TOP_Z = 0.10           # labyrinth stub only, never a thrust
+                               # face; >=0.1 clear of the tube bottom
+CUP_TOP_Z = 0.0                # shoulder plane = up-thrust against the
+                               # body back face (printed, z-exact);
+                               # down-stop = gear stack on the seat
+                               # boss; end float is baked in by the two
+                               # hard-stop presses, no press-by-feel
+CUP_WEB_T = 0.3                # between pin end and magnet
+CUP_NUB_H = 0.13               # snap nubs under the magnet mouth
+CUP_NUB_D = MAG_D - 0.3        # nub crest opening (0.15/side engagement)
+CUP_SLOT_W = 0.8               # petal slots: 3 cuts make the rim 3
+                               # cantilevers so the nubs can deflect
+                               # (~0.15 tip travel, few % strain);
+                               # closed rim is hoop-stiff, would crack
+CUP_POCKET_RIB = 0.10          # petal-spring radial ribs: crest dia =
+                               # MAG_D - this, petals preload the magnet
+                               # sideways after snap-in (centers it and
+                               # friction-locks rotation)
+CUP_BUMP_H = 0.06              # ceiling crush bumps: anvil press yields
+                               # them, eats z tolerance, leaves the
+                               # magnet clamped bumps-vs-nubs, zero float
+MAG_TOP_Z = PIN_BOT_Z - 0.1 - CUP_WEB_T - CUP_BUMP_H  # nominal magnet top
+CUP_RIM_Z = MAG_TOP_Z - MAG_H - 0.02 - CUP_NUB_H - 0.05
+
+# --- shell interface ---
+EAR_H = m.CASE_POT_EAR_H_EST
+WEB_TOP_Z = -EAR_H
+WEB_BOT_Z = -EAR_H - m.CASE_POT_SEAT_T_EST
+OPENING_R = m.CASE_POT_SEAT_ID_EST / 2   # 4.3, everything hanging below
+                                         # must insert through this
+# the shell EARS are the anti-rotation key: two insets in the bottom
+# face at +/-X drop over them, so the ears give both the z-datum (inset
+# floor seats on ear top) and the rotational lock (inset side walls);
+# a protruding key stub had no room in the shell
+EAR_INSET_L = m.CASE_POT_EAR_L + 0.4   # circumferential clearance
+EAR_INSET_W = m.CASE_POT_EAR_W + 0.4   # radial clearance
+EAR_INSET_DEPTH = 0.3  # MUST stay < min ear height (0.5 eyeball) or the
+                       # back face bottoms on the pocket floor web and
+                       # the z-datum goes ambiguous
+
+# --- arc shells + round coupon, bayonet mount ---
+# two arc walls hang from the body (gaps at +/-X, under the ear
+# insets); round board pushes up through the gaps and twists ~35deg so
+# its two rim tabs ride under the arcs to an end stop - board top lands
+# on a printed ledge, so the magnet-sensor gap is one printed dimension
+ARM_R_IN = 3.55
+ARM_R_OUT = 4.15
+ARM_BOT_Z = -6.3
+GAP_HALF_DEG = 20.0    # gap sectors at +/-X, tabs pass through here
+HOOK_T = 0.35          # snap bump past the opening edge
+HOOK_H = 0.5
+HOOK_TOP_Z = WEB_BOT_Z - 0.05
+FINGER_W = 2.4         # snap finger freed from the arc (arcs are
+FINGER_SLOT = 0.7      # hoop-stiff, same lesson as the cup rim)
+FINGER_SLOT_BOT_Z = -4.2
+COUPON_D = 7.0         # round board, fits inside the arcs
+COUPON_T = 1.0
+COUPON_TOP_Z = -4.95   # = ledge underside and bayonet ceiling
+TAB_W = 2.0            # board rim tabs at 180 deg
+TAB_R_OUT = 4.2
+BAY_HALF_DEG = 50.0    # bayonet band from each gap; travel ~35, stop 50
+BAY_TOP_Z = COUPON_TOP_Z
+BAY_BOT_Z = COUPON_TOP_Z - COUPON_T - 0.03
+LEDGE_R_IN = 3.3       # board seat ring under the arc inner face
+LEDGE_H = 0.5
+SENSOR_SZ = 1.6        # SC4251 DFN-6 body
+SENSOR_H = 0.4

--- a/mechanical/encbench/bench.py
+++ b/mechanical/encbench/bench.py
@@ -7,24 +7,35 @@ modeled at the NOMINAL (topmost, 90 deg) position.
 
 Parts (one print each, color per part):
 - base: desk-clamp plate (no holes) + motor saddle + M2 clamp ears +
-  rear fin with two M3 screw holes; M3 hex nuts drop into pockets in
-  the fin's back face, retained by the screws.
+  rear fin with two M3 screw holes; M3 hex nuts press into pockets in
+  the fin's back face, permanent once seated.
 - sled (BLACK PETG - the wall is the optical shroud): rectangular wall
   with the coupon pocket stamped from the real PCB outline (projected
   from encbench/build/encoder-board.step, regenerate with `kicad-cli
   pcb export step --subst-models -o mechanical/encbench/build/encoder-board.step
   hardware/boards/encoder-board/encoder-board.kicad_pcb`), sensor
-  windows + J1 tail relief in the 0.4 front wall, and two wings whose
+  windows + J1 tail relief in the 0.8 front wall, and two wings whose
   open-top slots hang on the fin screws. Slots are cut snug to the M3
   shank (3.3 drawn) - the screws themselves register the sled laterally.
   Topmost position (screws at the slot bottoms) = 90 deg quadrature.
-  Press the board in with the sled OFF the stand.
-- clamp: bridges the motor top flat, 0.1 squeeze, two M2 screws into
-  nuts inserted from BELOW the ears. Print upside down.
-- discs: Ø10 (presets 90/62) and Ø20 (preset 31); press on the pinion
-  against a flat table until the shaft tip touches - flush.
-- shims: height gauges under the sled wings; the shim, not screw
-  friction, carries the position (notch count = preset index).
+  Press the board in with the sled OFF the stand, front face on a flat
+  surface, until the back edge snaps behind the side leaf-spring
+  detents; to remove, push evenly from the front through the windows.
+- clamp: bridges the motor top flat, CLAMP_SQUEEZE, two M2 screws into
+  nuts inserted from BELOW the ears. Print SIDEWAYS - see build_clamp.
+  The rear of the motor stays open (terminal PCB adapter); axial
+  position comes from the base's front register wall.
+- discs: two-color prints (black base + eccentric white cap, filament
+  swap at z 1.4): Ø10 disc2_62 (the production-geometry ring) and Ø20
+  disc2_31; blind bore, seated with the press guide.
+- press: disc press guide - squares the disc to the shaft; depth stop
+  = shaft tip on the blind bore floor (see build_press).
+- clip: neck clip that backs the pinion during the press - without it
+  the broach force slides the pinion down the shaft (see build_clip).
+- shims: L-shaped height gauges under the sled wings, dropped into
+  fence corrals on the base; the seat, not screw friction, carries the
+  position and the upright leg stops sled pitch (notch count on the
+  leg top edge = preset index).
 
 Height presets - sled drop D moves the sensor chord below the axis by
 d = 1.5 + D, phase = 2*atan(1.5/d), pattern radius r = hypot(1.5, d):
@@ -34,10 +45,13 @@ d = 1.5 + D, phase = 2*atan(1.5/d), pattern radius r = hypot(1.5, d):
 Firmware ellipse-cal absorbs non-90 phases; measured A/B phase is the
 truth after any height change.
 
-x chain at nominal: rear face 0, shaft tip 15.6 = disc face, paper 0.1,
-air gap 1.0, sensor faces 16.7 (0.25 proud of the 16.95 wall face),
-coupon front face 17.35. The coupon faces -X; the motor slides axially
-in the saddle to set the gap, the disc rides through the saddle bore.
+x chain, motor registered front-face against the base wall at FRONT_X
+10.8: shaft tip 14.1, white cap face 14.7 (press guide puts it
+PRESS_CAN_TO_CAP 3.90 from the same front-face datum), gap 2.0
+(DISC_GAP), sensor faces 16.7 (0.15 recessed behind the 16.55 wall
+face - each window is a light well), coupon front face 17.35. The
+coupon faces -X; rear can face lands at -1.55, terminal PCB in free
+air behind it.
 """
 import math
 import pathlib
@@ -51,11 +65,33 @@ BOARD_W = 25.0
 BOARD_T = 1.6
 SENSOR_H = 0.65            # ITR1204 body [ds]
 SENSOR_BODY = (1.4, 1.9)   # body footprint: across pin pair, along dies
+# Window map along the die axis, + toward J1 (up in the stand). Vector-
+# measured from the ds p3 drawing (both axes agree on scale); the
+# windows are NOT symmetric. PT = pads 1/2 end = away from J1 = DOWN
+# (pcb nets + step-verified board map). The LED self-apertures at 0.37,
+# already narrower than any useful slit - only the PT is worth slitting.
+PT_OFF = -0.43             # PT window center; inner aperture 0.60
+PT_WIN = 0.60
+LED_OFF = 0.47             # LED window center; inner 0.37, outer 0.47
+LED_WIN = 0.37
+RIB = (-0.08, 0.23)        # opaque divider, offset toward the LED
 SENSE_CHORD = 3.0          # U1-U2 centers
 CHORD_UP = 5.0             # sensor chord above the board's low edge
 WIN_CLEAR = 0.3            # per side, sensor windows (small holes shrink)
-POCKET_CLEAR = 0.25        # total outline growth; MK3S+ PETG pockets
-                           # under-print ~0.15 -> true snug press
+POCKET_CLEAR = 0.12        # seat growth; pockets under-print ~0.15 (0.25
+                           # drawn benched gravity-loose) -> light grip
+POCKET_LIP = 0.0           # detent face growth: prints ~0.075/side bite
+POCKET_MOUTH = 0.6         # funnel entry: drop-in loose
+LIP_BAND = 0.4             # detent flat length along insertion
+SEAT_SLACK = 0.1           # detent flat behind the board back face; the
+                           # seat-side ramp toe preloads the board forward
+SPRING_T = 1.0             # leaf between pocket wall and slit
+SLIT_W = 0.9
+SPRING_Z = (21.0, 31.0)    # slit span: fixed-fixed leaf, ~0.8% strain at
+                           # full detent deflection - elastic, reusable
+BUMP_Z = (23.0, 29.0)
+PAD_Y = 16.6               # outboard pad backs the slit rim; starts above
+PAD_Z = (21.0, 33.0)       # the M3 slot mouth (shank tops out ~20.4)
 
 PAPER_T_EST = 0.1
 AIR_GAP_EST = 1.0
@@ -69,9 +105,14 @@ BOARD_X = SENSE_X + SENSOR_H       # 17.35 coupon front face
 PRESETS = (("90", 1.5, 10.0), ("62", 2.487, 10.0), ("31", 5.39, 20.0))
 
 # --- sled wall + wings ---
-FACE_WALL = 0.4            # front wall = 2 clean 0.2 layers (printed
-                           # flat); sensors poke 0.25 proud
-WALL_X = (BOARD_X - FACE_WALL, BOARD_X + BOARD_T + 0.35)  # 16.95 .. 19.3
+SKIN_T = 0.4               # aperture skin, 2 layers: one layer pinholes
+                           # IR between extrusion lines; pocket shift
+                           # tracks this so face clearance is unchanged
+FACE_WALL = 0.8            # front wall = 4 clean 0.2 layers (printed
+                           # flat); sensors recess 0.15 -> each window is
+                           # a light well; wall face clears paper by 0.85
+WALL_X = (BOARD_X - FACE_WALL, BOARD_X + BOARD_T + 1.05)  # 16.95 .. 20.0;
+                           # +1.05 = lip band + funnel behind the board
 WALL_W = 39.0              # spans the wing footprint: sled prints flat,
                            # front face down, support-free
 WALL_Z = (6.0, 34.5)       # nominal; drops by up to ~5.8
@@ -82,14 +123,26 @@ M3_SCREW_Y = 16.1
 M3_SCREW_Z = 13.0
 M3_SLOT_W = 3.3            # prints ~3.15 -> snug on the shank = registration
 M3_HOLE = 3.6              # horizontal hole in the fin, sags oval
-M3_NUT_AF = 6.0            # 5.5 nut + fit, horizontal-axis pocket
-M3_NUT_T = 2.8             # 2.4 nut + fit
+M3_NUT_AF = 5.4            # 0.1 under the 5.5 nut: steel broaches the seat.
+                           # Straight-flat pockets print ~true (5.7 benched
+                           # drop-out; the 0.15-under model is a round-hole
+                           # artifact), so interference is drawn, not shrunk
+M3_NUT_T = 2.5             # 2.4 nut pressed to floor sits 0.1 under flush
 
 # --- disc ---
 DISC_T = 2.0               # 3d-printed
 DISC_BORE = 2.2            # prints ~2.0-2.1 -> broach fit on the 2.23
                            # pinion tip circle
-DISC_RECESS_T = 0.4        # paper pattern seat
+PATTERN_ECC = 0.5          # radial edge travel of the eccentric pattern;
+                           # 0.35 benched 630/840mV pk-pk - noise-limited,
+                           # so trade linearity for amplitude
+WHITE_T = 0.6              # 3 layers; thinner passes 940nm through to
+                           # the black base
+BACK_T = 1.0               # extra full-diameter back thickness: bore
+                           # grows to 2.4 of the 2.65 shaft (1.4 alone
+                           # = hand-rockable wobble on the tooth tips).
+                           # Full OD = zero bridging; 1.0 not 1.3 so
+                           # the disc clears the register wall rib
 
 # --- motor saddle + clamp (M2 screws, nuts from below) ---
 SADDLE_X = (1.9, 10.2)     # ~70% of the 12.3 can, slide room both ways
@@ -99,12 +152,39 @@ EAR_Y = (5.6, 12.4)        # wide enough for the nut chimney
 SCREW_X = (SADDLE_X[0] + SADDLE_X[1]) / 2
 SCREW_Y = 9.0              # ear center
 M2_HOLE = 2.4
-M2_NUT_AF = 4.5            # 4.0 nut + XY shrink allowance
-M2_NUT_T = 1.9             # 1.6 nut + fit
+M2_NUT_AF = 3.9            # 0.1 under the 4.0 nut (4.1 benched drop-out):
+                           # the screw draws it in and it broaches; must
+                           # resist screw-start push or it drops down the
+                           # chimney
+M2_NUT_T = 2.1             # 1.6 nut + 0.5 cone -> full-flat engagement
 M2_NUT_Z = 8.4             # hex pocket floor
 CHIMNEY_D = 5.2            # prints ~5.0; nut corner circle 4.62
 CLAMP_Z = (12.3, 19.6)     # bottom floats 0.3 over the ears = travel
-CLAMP_SQUEEZE = 0.1        # interference at the motor top flat
+CLAMP_SQUEEZE = 0.2        # interference at the motor top flat (0.1
+                           # benched roll-slip with the clamp tight)
+DISC_GAP = 2.0             # white cap face -> sensor face; geometric
+                           # via the base's front register wall. 1mm
+                           # dead-zones the ecc-0.5 disc (benched H2
+                           # 34-61%); ~5mm is clean but SNR-starved at
+                           # 4k7 - 2.0 splits with margin for the
+                           # 0.05-0.20 shaft end play
+PRESS_CAN_TO_CAP = (TIP_X - m.MOTOR_BODY_L) + WHITE_T  # 3.90: front can
+                           # face -> white cap face when the pinion tip
+                           # bottoms on the disc's blind bore floor -
+                           # the press stop. The floor is table-backed
+                           # (pure compression, no doming)
+FRONT_X = SENSE_X - DISC_GAP - PRESS_CAN_TO_CAP  # front can face
+                           # against the base register wall; rear stays
+                           # open (terminal PCB adapter lives there)
+CLIP_T = 0.45              # < the 0.53 boss-to-pinion gap it enters;
+                           # the press jams on it CLIP_T - 0.30 = 0.15
+                           # shy of nominal depth (disc back to boss is
+                           # 0.30 at full depth) - accept the 2.15 gap
+                           # or pry the clip and push the last 0.15
+CLIP_OD = 6.5              # 1.25 rim beyond the Ø4 boss = tweezer grab
+CLIP_BORE = 1.1            # loose on the 1.0 shaft; the 0.85 mouth
+CLIP_MOUTH = 0.85          # (prints tighter) snaps over it and retains
+REG_WALL_T = 1.25
 
 BASE_T = 4.0
 
@@ -136,15 +216,36 @@ def board_outline_face() -> Face:
 def build_base() -> Part:
     flat_half = m.MOTOR_BODY_FLAT / 2
 
-    p = Pos(9.0, 0, -BASE_T) * extrude(RectangleRounded(44.0, 41.0, 4.0),
+    p = Pos(9.0, 0, -BASE_T) * extrude(RectangleRounded(44.0, 46.0, 4.0),
                                        BASE_T)
 
-    # motor saddle: bore floor exact at the bottom flat, sides +0.25
-    p += _box(SADDLE_X[0], SADDLE_X[1], -6.5, 6.5, 0, 12.0)
-    prof = Circle(m.MOTOR_BODY_D / 2 + SADDLE_CLEAR) & Pos(0, 25 - flat_half) \
-        * Rectangle(40, 50)
-    p -= Pos(SADDLE_X[0] - 0.1, 0, AXIS_Z) * extrude(
-        Plane.YZ * prof, SADDLE_X[1] - SADDLE_X[0] + 0.2)
+    # motor saddle: bore floor exact at the bottom flat; sides +0.25
+    # except two 1.2-wide stations bored at +0.06 - the tight bands
+    # re-register the can in yaw (0.25 benched ~3 deg axis swing in
+    # plan) while the motor still slides axially through them. Cut
+    # segment-wise so the bands are part of the trough wall, not
+    # added tabs (printable: no mid-air geometry)
+    p += _box(SADDLE_X[0], FRONT_X, -6.5, 6.5, 0, 12.0)
+    segs = ((SADDLE_X[0] - 0.1, 2.4, SADDLE_CLEAR),
+            (2.4, 3.6, 0.06),
+            (3.6, 8.6, SADDLE_CLEAR),
+            (8.6, 9.8, 0.06),
+            (9.8, FRONT_X + 0.01, SADDLE_CLEAR))
+    for x0, x1, clear in segs:
+        prof = Circle(m.MOTOR_BODY_D / 2 + clear) & Pos(0, 25 - flat_half) \
+            * Rectangle(40, 50)
+        p -= Pos(x0, 0, AXIS_Z) * extrude(Plane.YZ * prof, x1 - x0)
+
+    # front register wall: the can front face bears on its back face -
+    # slide the motor forward to the stop, tighten the clamp, and the
+    # disc-to-sensor gap is DISC_GAP by construction (press guide sets
+    # the disc at PRESS_CAN_TO_CAP from the same datum). Wall top is 2
+    # below the axis, so the boss and shaft pass over it and the motor
+    # still drops straight in; contact = the can face's lower flank.
+    # Stepped profile: full thickness below the disc envelope, a 0.6
+    # rib beside it (thick-disc back face spins 0.3 off the rib)
+    p += _box(FRONT_X, FRONT_X + 0.6, -6.5, 6.5, 0, 12.0)
+    p += _box(FRONT_X, FRONT_X + REG_WALL_T, -6.5, 6.5, 0, 3.7)
 
     # clamp ears: solid columns, support-free; the nut rides up the
     # chimney from under the base, a cone lead-in centers it, the screw
@@ -165,8 +266,10 @@ def build_base() -> Part:
             M2_HOLE / 2, EAR_TOP - M2_NUT_Z + 0.1,
             align=(Align.CENTER, Align.CENTER, Align.MIN))
 
-    # rear fin: M3 through-holes, hex pockets sunk from the back face
-    p += _box(FIN_X[0], FIN_X[1], -19.5, 19.5, 0, WING_Z[1])
+    # rear fin: M3 through-holes, hex pockets sunk from the back face;
+    # pocket corner reaches y 19.2 - keep >=2 wall outboard or the
+    # press splits the layers (19.5 edge benched crack)
+    p += _box(FIN_X[0], FIN_X[1], -21.5, 21.5, 0, WING_Z[1])
     for s in (1, -1):
         p -= Pos(FIN_X[0] - 0.1, s * M3_SCREW_Y, M3_SCREW_Z) * Rot(0, 90, 0) \
             * Cylinder(M3_HOLE / 2, FIN_X[1] - FIN_X[0] + 0.2,
@@ -175,55 +278,132 @@ def build_base() -> Part:
             * extrude(RegularPolygon(M3_NUT_AF / math.sqrt(3), 6),
                       M3_NUT_T + 0.1)
 
+    # shim fence: three 1.5-tall ridges + the fin = a corral per side;
+    # the L-shims drop in with 0.2 play and stand captive. 1.5 clears
+    # the sled at its deepest drop (wall bottom 2.11 at preset 31)
+    for s in (1, -1):
+        p += _box(14.65, 15.35, s * 12.2, s * 20.4, 0, 1.5)
+        p += _box(14.65, 21.35, s * 12.2, s * 12.9, 0, 1.5)
+        p += _box(14.65, 21.35, s * 19.7, s * 20.4, 0, 1.5)
+
     p.label = "encbench_base"
     p.color = Color(0.35, 0.38, 0.42)
     return p
 
 
-def build_sled(outline: Face) -> Part:
+def build_sled(outline: Face, slit: float | None = None) -> Part:
     """Wall + wings at the NOMINAL (90 deg, topmost) position. One flat
     part: full height over the board span, wing-height extensions
-    outboard (so the slots stay open at the top for drop-on)."""
-    p = _box(WALL_X[0], WALL_X[1], -15.0, 15.0, WALL_Z[0], WALL_Z[1])
+    outboard (so the slots stay open at the top for drop-on).
+
+    slit: aperture variant - a SKIN_T front skin spans each window,
+    slitting ONLY the PT (a slit of this height at chord_z + PT_OFF);
+    the LED gets a full clearance opening, since its own 0.37 aperture
+    is narrower than any useful slit. Sensing region = overlap of the
+    LED patch and the choked PT view: narrows the spot radially (the
+    modulation direction). Board pocket shifts back SKIN_T so the
+    coupon seats on the pocket floor, not the skin. Costs some light -
+    re-pick the load R after. slit < PT_WIN (0.60) to actually choke."""
+    shift = SKIN_T if slit is not None else 0.0
+    wx1 = WALL_X[1] + shift
+    loc = Pos(shift, 0, 0) * BOARD_LOC
+    board_x = BOARD_X + shift
+
+    p = _box(WALL_X[0], wx1, -15.0, 15.0, WALL_Z[0], WALL_Z[1])
     for s in (1, -1):
-        p += _box(WALL_X[0], WALL_X[1], s * 15.0, s * WALL_W / 2,
+        p += _box(WALL_X[0], wx1, s * 15.0, s * WALL_W / 2,
                   WING_Z[0], WING_Z[1])
 
-    # pocket = projected pcb outline grown by the press fit, from the back
-    grown = BOARD_LOC * offset(outline, POCKET_CLEAR / 2)
-    pocket = extrude(grown, WALL_X[1] - BOARD_X + 0.1)
-    if pocket.bounding_box().min.X < BOARD_X - 0.05:
-        pocket = extrude(grown, -(WALL_X[1] - BOARD_X + 0.1))
+    # pocket = projected pcb outline: funnel mouth over a plain seat;
+    # retention comes from the side leaf-spring detents, not the ring
+    seat_f = loc * offset(outline, POCKET_CLEAR / 2)
+    sgn = 1.0
+    if extrude(seat_f, 0.2).bounding_box().min.X < board_x - 0.05:
+        sgn = -1.0
+    fun_x = BOARD_T + SEAT_SLACK + LIP_BAND
+    fun_f = Pos(fun_x, 0, 0) * loc * offset(outline, POCKET_CLEAR / 2)
+    mouth_f = Pos(wx1 - board_x + 0.1, 0, 0) * loc \
+        * offset(outline, POCKET_MOUTH / 2)
+    pocket = extrude(seat_f, sgn * (fun_x + 0.01))
+    pocket += loft([fun_f, mouth_f])
     p -= pocket
 
-    # front-wall openings: sensor windows + J1 tail relief
+    # front-wall openings: sensor windows + J1 tail relief; slit
+    # variant keeps a SKIN_T skin at the front face and cuts the slit
+    # through it (front face stays planar - prints face-down as before)
     chord_z = AXIS_Z - 1.5
     wy = SENSOR_BODY[0] + 2 * WIN_CLEAR
     wz = SENSOR_BODY[1] + 2 * WIN_CLEAR
+    win_x0 = WALL_X[0] + shift if slit is not None else WALL_X[0] - 0.1
     for s in (1, -1):
-        p -= _box(WALL_X[0] - 0.1, BOARD_X + 0.05,
-                  s * SENSE_CHORD / 2 - wy / 2, s * SENSE_CHORD / 2 + wy / 2,
+        yc = s * SENSE_CHORD / 2
+        p -= _box(win_x0, board_x + 0.05, yc - wy / 2, yc + wy / 2,
                   chord_z - wz / 2, chord_z + wz / 2)
+        if slit is not None:
+            zc = chord_z + PT_OFF
+            p -= _box(WALL_X[0] - 0.1, WALL_X[0] + SKIN_T + 0.1,
+                      yc - wy / 2, yc + wy / 2,
+                      zc - slit / 2, zc + slit / 2)
+            zl = chord_z + LED_OFF
+            p -= _box(WALL_X[0] - 0.1, WALL_X[0] + SKIN_T + 0.1,
+                      yc - wy / 2, yc + wy / 2, zl - 0.3, zl + 0.3)
+            # crosstalk rib: lands on the package's center divider
+            # (which is offset toward the LED) and walls off the skin-
+            # to-package gap - without it LED light waveguides across
+            # the 0.15 gap into the PT window (benched: DC up,
+            # modulation -4x on the ribless 1-layer skin)
+            p += _box(WALL_X[0] + SKIN_T, WALL_X[0] + SKIN_T + 0.15,
+                      yc - wy / 2, yc + wy / 2,
+                      chord_z + RIB[0], chord_z + RIB[1])
     # J1 pin tails protrude 1.4 past the sensor face (step-verified
     # -3.8..4.4 x 30.2..30.8 in stand yz)
-    p -= _box(WALL_X[0] - 0.1, BOARD_X + 0.05, -4.7, 5.3, 29.5, 31.5)
+    p -= _box(WALL_X[0] - 0.1, board_x + 0.05, -4.7, 5.3, 29.5, 31.5)
 
     # wings: doubler pads fully backed by the widened wall (flat print);
     # open-top slots cut through the full sled - heads bear on the front
     for s in (1, -1):
-        p += _box(WALL_X[1], FIN_X[0], s * WING_Y[0], s * WING_Y[1],
+        p += _box(wx1, FIN_X[0], s * WING_Y[0], s * WING_Y[1],
                   WING_Z[0], WING_Z[1])
         p -= _box(WALL_X[0] - 0.1, FIN_X[0] + 0.1,
                   s * M3_SCREW_Y - M3_SLOT_W / 2,
                   s * M3_SCREW_Y + M3_SLOT_W / 2,
                   M3_SCREW_Z - M3_SLOT_W / 2, WING_Z[1] + 0.1)
 
-    p.label = "encbench_sled"
+    # side leaf springs: a slit isolates a fixed-fixed strip beside the
+    # pocket; detent bumps on it snap over the board back edge, ramped
+    # both ways so removal flexes the leaf instead of shearing it
+    wall_y = BOARD_W / 2 + POCKET_CLEAR / 2
+    bx = board_x + BOARD_T
+    for s in (1, -1):
+        p += _box(WALL_X[0], wx1, s * 14.9, s * PAD_Y,
+                  PAD_Z[0], PAD_Z[1])
+        p -= _box(WALL_X[0] - 0.1, wx1 + 0.1,
+                  s * (wall_y + SPRING_T),
+                  s * (wall_y + SPRING_T + SLIT_W),
+                  SPRING_Z[0], SPRING_Z[1])
+        yd = s * (BOARD_W / 2 + POCKET_LIP / 2)
+        yw = s * (wall_y + 0.14)
+        bump = Polygon((bx - 0.2, s * wall_y), (bx + SEAT_SLACK, yd),
+                       (bx + SEAT_SLACK + LIP_BAND, yd),
+                       (bx + SEAT_SLACK + LIP_BAND + 0.3, s * wall_y),
+                       (bx + SEAT_SLACK + LIP_BAND + 0.3, yw),
+                       (bx - 0.2, yw), align=None)
+        p += Pos(0, 0, BUMP_Z[0]) * extrude(bump, BUMP_Z[1] - BUMP_Z[0])
+
+    p.label = "encbench_sled" if slit is None else \
+        f"encbench_sled_slit{round(slit * 10):02d}"
     p.color = Color(0.08, 0.08, 0.08)
     return p
 
 
 def build_clamp() -> Part:
+    """Bridges the motor top flat, CLAMP_SQUEEZE interference, two M2
+    screws into nuts inserted from BELOW the ears. Axial position comes
+    from the base's front register wall, so the rear stays fully open
+    for the terminal PCB adapter. Print SIDEWAYS (on an ear end): the
+    clamped motor pushes the bridge up, and flat/upside-down print
+    orientations put that tension across the layer lines - the bridge
+    root delaminates. Sideways aligns the layers with the bending."""
     flat_half = m.MOTOR_BODY_FLAT / 2
     p = _box(SADDLE_X[0] + 1.1, SADDLE_X[1] - 0.7, -EAR_Y[1], EAR_Y[1],
              CLAMP_Z[0], CLAMP_Z[1])
@@ -242,70 +422,199 @@ def build_clamp() -> Part:
     return p
 
 
-def build_disc(dia: float) -> Part:
-    p = extrude(Circle(dia / 2), DISC_T)
-    p -= Pos(0, 0, DISC_T - DISC_RECESS_T) * Cylinder(
-        (dia - 0.6) / 2, DISC_RECESS_T + 0.1,
+def build_disc2(dia: float, r_sense: float, name: str,
+                ecc: float = PATTERN_ECC) -> Part:
+    """Two-color pattern disc: black base, eccentric white cap = the
+    pattern in material instead of ink. Print face up, filament swap
+    at z = BACK_T + DISC_T - WHITE_T. White top sits at
+    the old paper plane; the black field prints WHITE_T recessed
+    (farther = darker, contrast stacks). Iron/smooth the white, leave
+    the black matte. Bore is blind (unbroken white face), runs the
+    2.4 of the 2.65 shaft. Seat with the press guide. Press-fit
+    only - discs stay swappable for experiments."""
+    p = Pos(0, 0, -BACK_T) * extrude(Circle(dia / 2),
+                                     BACK_T + DISC_T - WHITE_T)
+    p += Pos(ecc, 0, DISC_T - WHITE_T) * extrude(
+        Circle(r_sense), WHITE_T)
+    p -= Pos(0, 0, -BACK_T - 0.1) * Cylinder(
+        DISC_BORE / 2, BACK_T + DISC_T - WHITE_T + 0.1,
         align=(Align.CENTER, Align.CENTER, Align.MIN))
-    p -= Cylinder(DISC_BORE / 2, 3 * DISC_T)
-    p -= Cone(DISC_BORE / 2 + 0.35, DISC_BORE / 2, 0.4,
-              align=(Align.CENTER, Align.CENTER, Align.MIN))
-    p.label = f"encbench_disc{dia:.0f}"
+    p -= Pos(0, 0, -BACK_T) * Cone(
+        DISC_BORE / 2 + 0.35, DISC_BORE / 2, 0.4,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p.label = f"encbench_disc2_{name}"
+    p.color = Color(0.15, 0.15, 0.15)
+    return p
+
+
+BAND_W0 = 1.2              # band mean width; min w0-w1 = 0.5 = two clean
+BAND_W1 = 0.7              # 0.25 perimeters, max 1.9 stays inside the spot
+
+
+def build_disc3(dia: float, r_sense: float, name: str, cycles: int = 1,
+                w0: float = BAND_W0, w1: float = BAND_W1,
+                coarse: float = 0.0) -> Part:
+    """Width-modulated ring disc: white band at the sensor radius,
+    width w0 + w1*cos(cycles*th) (+ coarse*cos(th) for N>1 sector
+    disambiguation). The spot integrates area, and a moving average
+    of a sine is a sine - the signal is harmonic-free at ANY gap /
+    spot shape, unlike disc2's eccentric edge (harmonics by
+    construction, needs the right blur). Radial runout moves the band
+    inside the spot without changing coverage - press eccentricity
+    drops out to first order. Requirements: spot covers the full band
+    width; spot arc < ~1/3 wavelength or the average eats the
+    fundamental (Ø20 ring, N=9: wavelength 3.9). Channel phase =
+    cycles x sensor separation - shim the height so it lands 90.
+    Slicer: aligned seam, so the zit sits at one fixed angle the cal
+    absorbs. Same base/bore/press as disc2 EXCEPT the bore is
+    through: the band does not cover the center and a white
+    press-floor plug would put a static (and, press-eccentric, 1/rev)
+    reflector at the spot's inner tail - the clip stop is the only
+    press stop. Never press past it: with no floor the next stop is
+    the shaft tip finding the table through the bore."""
+    assert w0 - w1 - abs(coarse) >= 0.5, "band pinches below 2 perimeters"
+    p = Pos(0, 0, -BACK_T) * extrude(Circle(dia / 2),
+                                     BACK_T + DISC_T - WHITE_T)
+    steps = 720
+    outer, inner = [], []
+    for i in range(steps):
+        th = 2 * math.pi * i / steps
+        w = w0 + w1 * math.cos(cycles * th) + coarse * math.cos(th)
+        outer.append(((r_sense + w / 2) * math.cos(th),
+                      (r_sense + w / 2) * math.sin(th)))
+        inner.append(((r_sense - w / 2) * math.cos(th),
+                      (r_sense - w / 2) * math.sin(th)))
+    band = Polygon(*outer, align=None) - Polygon(*inner, align=None)
+    p += Pos(0, 0, DISC_T - WHITE_T) * extrude(band, WHITE_T)
+    p -= Pos(0, 0, -BACK_T - 0.1) * Cylinder(
+        DISC_BORE / 2, BACK_T + DISC_T - WHITE_T + 0.1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p -= Pos(0, 0, -BACK_T) * Cone(
+        DISC_BORE / 2 + 0.35, DISC_BORE / 2, 0.4,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p.label = f"encbench_disc3_{name}"
+    p.color = Color(0.15, 0.15, 0.15)
+    return p
+
+
+def build_press(dia: float, name: str) -> Part:
+    """Disc press guide - depth and squareness come from the tool, not
+    the thumb (hand-pressing benched visible disc wobble). Disc lies
+    white-face-down on a flat table, tool over it, motor into the top
+    bore. Snap the neck clip on first (build_clip) - the bore
+    broaches onto the pinion at more force than the pinion's own fit
+    on the shaft, so an unbacked press slides the pinion into the can
+    (benched: 1mm slide, grinding); the clip backs it against the
+    boss. Press until it stops firm - that is the disc back face
+    pinching the clip against the boss, 0.15 shy of nominal depth
+    (see CLIP_T). Either accept that gap or pry the clip off and push
+    the last 0.15 until the shaft tip bottoms on the disc's blind
+    bore floor; the floor is table-backed - pure compression through
+    the white column, no doming - so bottoming IS the exact depth
+    stop: PRESS_CAN_TO_CAP by construction. The long bore keeps the
+    shaft square; the dia+0.4 pocket
+    pre-centers the disc to +/-0.2 so the disc's entry cone (catch
+    +/-0.35) finishes the job - one press per disc diameter. No
+    internal shoulder: any shoulder that can stop the can also traps
+    the pressed assembly (disc below it, can above, neither passes) -
+    the straight bore lets motor + disc withdraw together. press10
+    prints either way up; press20 upside down or its wide pocket roof
+    is a 5mm annular bridge."""
+    p = extrude(Circle((dia + 7.0) / 2), 16.0)
+    p -= Pos(0, 0, 3.15) * Cylinder(
+        10.3 / 2, 16.0 - 3.15 + 0.1,        # can guide: Ø10 round sides,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))  # flats never touch
+    p -= Pos(0, 0, -0.1) * Cylinder(
+        (dia + 0.4) / 2, 3.25,              # disc pocket: pre-centers,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))  # roof 3.15 clears t=3.0
+    p.label = f"encbench_press{name}"
+    p.color = Color(0.35, 0.38, 0.42)
+    return p
+
+
+def build_clip() -> Part:
+    """Neck clip: C-washer snapped around the shaft between the
+    motor's Ø4 front boss and the pinion back face for the press.
+    Sandwiched, the pinion clamps it against the boss and the press
+    force loops disc -> pinion -> clip -> boss -> can -> hand; the
+    pinion gives up only the clamp slack (<=0.53 - CLIP_T, stays
+    clear of the boss). The press jams on it just shy of nominal
+    depth - see build_press for the endgame. Grab the rim past the
+    boss to pry it off. The flared mouth pushes on over the shaft.
+    Prints flat; expendable - print a few."""
+    p = extrude(Circle(CLIP_OD / 2), CLIP_T)
+    p -= Pos(0, 0, -0.1) * Cylinder(
+        CLIP_BORE / 2, CLIP_T + 0.2,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    hm = CLIP_MOUTH / 2
+    p -= Pos(0, 0, -0.1) * extrude(Polygon(  # ccw or extrude goes -z
+        (0, -hm), (2.2, -hm), (CLIP_OD / 2 + 0.1, -0.9),
+        (CLIP_OD / 2 + 0.1, 0.9), (2.2, hm), (0, hm),
+        align=None), CLIP_T + 0.2)
+    p.label = "encbench_clip"
     p.color = Color(0.85, 0.83, 0.78)
     return p
 
 
 def build_shim(drop: float, notches: int) -> Part:
-    """Sits on the base under a sled wing: height = WING_Z[0] - drop.
-    The shim, not screw friction, carries the sled position. Print two."""
+    """L-shim under a sled wing: the seat sets height = WING_Z[0] - drop
+    (the shim, not screw friction, carries the position); the upright
+    leg stands 0.2 in front of the sled face and stops it pitching on
+    loose screws. Drops into the base fence. Notches on the leg's top
+    edge = preset index, centered so the part equals its own mirror -
+    print two, either side.
+
+    The 0.8 rear blade alone snaps in handling; the forward doubler
+    triples the section. Its underside slopes (apex at the rear face)
+    so it prints upright without a flat overhang and rides over the
+    fence cross-ridge (top 1.5) with 0.2 to spare."""
     h = WING_Z[0] - drop
-    p = _box(WALL_X[1] + 0.2, FIN_X[0] - 0.2, 0, 6.0, 0, h)
+    p = _box(15.55, 21.1, 13.1, 19.5, 0, h)
+    p += _box(15.55, 16.35, 13.1, 19.5, 0, h + 5.0)
+    prof = Polygon((14.55, 3.0), (14.55, h + 5.0), (15.55, h + 5.0),
+                   (15.55, 1.7), align=None)
+    p += Pos(0, 13.1, 0) * extrude(Plane.XZ * prof, 6.4)
+    y0 = 16.3 - 0.8 * (notches - 1)
     for i in range(notches):
-        p -= Pos((WALL_X[1] + FIN_X[0]) / 2, 1.2 + 1.6 * i, h) * Box(
-            2.2, 0.8, 1.0)
+        p -= Pos(15.45, y0 + 1.6 * i, h + 5.0) * Box(2.2, 0.8, 1.2)
     p.label = f"encbench_shim_d{drop:.1f}"
     p.color = Color(0.85, 0.83, 0.78)
     return p
 
 
-def write_pattern_svg(path, r_sense, recess_d, ecc=0.35, copies=4):
-    """Paper pattern: black disc, white eccentric circle at the sensing
-    radius. Print 100% scale, cut on the grey line, punch the center."""
-    r_cut = recess_d / 2
-    pitch = 2 * r_cut + 3.0
-    rows = [
-        f'<svg xmlns="http://www.w3.org/2000/svg" width="{copies * pitch}mm"',
-        f'  height="{pitch}mm" viewBox="0 0 {copies * pitch} {pitch}">',
-    ]
-    for i in range(copies):
-        cx = pitch / 2 + i * pitch
-        cy = pitch / 2
-        rows += [
-            f'<circle cx="{cx}" cy="{cy}" r="{r_cut}" fill="black" '
-            'stroke="grey" stroke-width="0.1"/>',
-            f'<circle cx="{cx + ecc}" cy="{cy}" r="{r_sense:.3f}"'
-            ' fill="white"/>',
-            f'<circle cx="{cx}" cy="{cy}" r="0.25" fill="grey"/>',
-        ]
-    rows.append('</svg>')
-    with open(path, "w") as f:
-        f.write("\n".join(rows))
-
-
 if __name__ == "__main__":
     out = pathlib.Path(__file__).parent / "build"
     out.mkdir(exist_ok=True)
+    outline = board_outline_face()
     parts = [(build_base(), "encbench_base"),
-             (build_sled(board_outline_face()), "encbench_sled"),
-             (build_clamp(), "encbench_clamp")]
-    for dia in sorted({d for _, _, d in PRESETS}):
-        parts.append((build_disc(dia), f"encbench_disc{dia:.0f}"))
+             (build_sled(outline), "encbench_sled"),
+             (build_sled(outline, slit=0.3), "encbench_sled_slit03"),
+             (build_sled(outline, slit=0.4), "encbench_sled_slit04"),
+             (build_clamp(), "encbench_clamp"),
+             (build_press(10.0, "10"), "encbench_press10"),
+             (build_press(20.0, "20"), "encbench_press20"),
+             (build_clip(), "encbench_clip")]
     for i, (name, d, dia) in enumerate(PRESETS):
         parts.append((build_shim(d - 1.5, i + 1), f"encbench_shim{name}"))
-        r = math.hypot(1.5, d)
-        write_pattern_svg(out / f"encbench_pattern{name}.svg", r, dia - 0.6)
+        if name != "90":  # 90 preset retired: firmware measures phase
+            r = math.hypot(1.5, d)
+            parts.append((build_disc2(dia, r, name), f"encbench_disc2_{name}"))
+    # small-ecc variant for the registered 1.0 gap: the tighter spot
+    # there flat-tops the 0.5 pattern (benched: H2 34% on B at ~1mm)
+    parts.append((build_disc2(10.0, math.hypot(1.5, 2.487), "62e35",
+                              ecc=0.35), "encbench_disc2_62e35"))
+    # width-modulated rings: n1 = pure-sine drop-ins (production Ø10 +
+    # bench Ø20), n9 = 9-lobe fine track (error / 9; ~80 deg native
+    # phase at the 31 preset, shim toward 90)
+    parts.append((build_disc3(10.0, math.hypot(1.5, 2.487), "62n1"),
+                  "encbench_disc3_62n1"))
+    parts.append((build_disc3(20.0, math.hypot(1.5, 5.39), "31n1"),
+                  "encbench_disc3_31n1"))
+    parts.append((build_disc3(20.0, math.hypot(1.5, 5.39), "31n9",
+                              cycles=9), "encbench_disc3_31n9"))
+    from blueprint import blueprint
     for part, name in parts:
         export_step(part, str(out / f"{name}.step"))
         export_stl(part, str(out / f"{name}.stl"), tolerance=0.01)
+        blueprint(part, str(out / f"{name}_bp.svg"), name=name)
         print(f"{name}: volume {part.volume:.0f} mm^3 -> {out}")
-    print(f"patterns -> {out}")

--- a/mechanical/preview.py
+++ b/mechanical/preview.py
@@ -1,0 +1,59 @@
+"""Live OCP viewer preview: python preview.py stenciljig.knob [more.modules]
+
+Calls every build*() in the listed modules and pushes the parts to the
+OCP CAD Viewer (start the viewer panel in VS Code first), then re-runs
+on any .py save under mechanical/. Each refresh is a fresh subprocess,
+so edits to any imported file are picked up. --once builds and exits.
+"""
+import importlib
+import pathlib
+import subprocess
+import sys
+import time
+
+ROOT = pathlib.Path(__file__).parent
+SKIP = {".venv", "__pycache__", "build", "reference"}
+
+
+def _parts(mod_name):
+    mod = importlib.import_module(mod_name)
+    fns = sorted(n for n in vars(mod)
+                 if n == "build" or n.startswith("build_"))
+    return [vars(mod)[n]() for n in fns if callable(vars(mod)[n])]
+
+
+def _show(mod_names):
+    from ocp_vscode import Camera, set_defaults, show
+    set_defaults(reset_camera=Camera.KEEP)
+    parts = [p for m in mod_names for p in _parts(m)]
+    names = [getattr(p, "label", "") or f"part{i}"
+             for i, p in enumerate(parts)]
+    show(*parts, names=names)
+
+
+def _mtimes():
+    return {p: p.stat().st_mtime for p in ROOT.rglob("*.py")
+            if not SKIP.intersection(p.parts)}
+
+
+def main():
+    args = sys.argv[1:]
+    if args and args[0] == "--once":
+        _show(args[1:])
+        return
+    if not args:
+        sys.exit(__doc__)
+    seen = None
+    while True:
+        now = _mtimes()
+        if now != seen:
+            seen = now
+            r = subprocess.run(
+                [sys.executable, __file__, "--once", *args], cwd=ROOT)
+            print("refreshed" if r.returncode == 0 else "BUILD FAILED",
+                  time.strftime("%H:%M:%S"), flush=True)
+        time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    main()

--- a/mechanical/render_blender.py
+++ b/mechanical/render_blender.py
@@ -1,0 +1,63 @@
+"""Headless Blender render of STLs to PNG:
+
+    blender -b -P render_blender.py -- part.stl [more.stl ...] [out.png]
+
+Workbench engine with studio light + cavity shading: fast, crisp edges,
+reads like a technical viewport. Multiple STLs render as one scene in
+their modeled positions (pass an exploded/assembly export for those
+views). Output defaults to first STL's name with .png.
+"""
+import math
+import pathlib
+import sys
+
+import bpy
+from mathutils import Vector
+
+argv = sys.argv[sys.argv.index("--") + 1:]
+stls = [a for a in argv if a.lower().endswith(".stl")]
+outs = [a for a in argv if a.lower().endswith(".png")]
+if not stls:
+    sys.exit(__doc__)
+out = outs[0] if outs else str(pathlib.Path(stls[0]).with_suffix(".png"))
+
+bpy.ops.wm.read_factory_settings(use_empty=True)
+for f in stls:
+    bpy.ops.wm.stl_import(filepath=str(pathlib.Path(f).resolve()))
+meshes = [o for o in bpy.data.objects if o.type == "MESH"]
+for o in meshes:
+    with bpy.context.temp_override(object=o):
+        bpy.ops.object.shade_smooth_by_angle(angle=math.radians(30))
+
+pts = [o.matrix_world @ Vector(c) for o in meshes for c in o.bound_box]
+lo = Vector((min(p[i] for p in pts) for i in range(3)))
+hi = Vector((max(p[i] for p in pts) for i in range(3)))
+center, size = (lo + hi) / 2, max(hi - lo)
+
+cam = bpy.data.objects.new("cam", bpy.data.cameras.new("cam"))
+bpy.context.scene.collection.objects.link(cam)
+cam.data.lens = 85
+direction = Vector((1, -1, 0.8)).normalized()
+dist = size / 2 / math.tan(cam.data.angle / 2) + size
+cam.location = center + direction * dist
+cam.rotation_euler = direction.to_track_quat("Z", "Y").to_euler()
+cam.data.clip_end = dist + size * 4
+bpy.context.scene.camera = cam
+
+scene = bpy.context.scene
+scene.render.engine = "BLENDER_WORKBENCH"
+shading = scene.display.shading
+shading.light = "STUDIO"
+shading.show_cavity = True
+shading.cavity_type = "BOTH"
+shading.color_type = "SINGLE"
+shading.single_color = (0.75, 0.75, 0.78)
+scene.display.render_aa = "16"
+scene.render.resolution_x = 1600
+scene.render.resolution_y = 1200
+scene.render.film_transparent = False
+scene.world = bpy.data.worlds.new("w")
+scene.world.color = (1, 1, 1)
+scene.render.filepath = str(pathlib.Path(out).resolve())
+bpy.ops.render.render(write_still=True)
+print("saved", scene.render.filepath)

--- a/mechanical/sg90/case.py
+++ b/mechanical/sg90/case.py
@@ -267,4 +267,6 @@ if __name__ == "__main__":
     part = build()
     export_step(part, str(out / "sg90_case.step"))
     export_stl(part, str(out / "sg90_case.stl"), tolerance=0.01)
+    from blueprint import blueprint
+    blueprint(part, str(out / "sg90_case_bp.svg"), name="sg90_case")
     print(f"sg90_case: volume {part.volume:.0f} mm^3 -> {out}")

--- a/mechanical/sg90/fence.py
+++ b/mechanical/sg90/fence.py
@@ -68,4 +68,6 @@ if __name__ == "__main__":
     part = build()
     export_step(part, str(out / "sg90_fence.step"))
     export_stl(part, str(out / "sg90_fence.stl"), tolerance=0.01)
+    from blueprint import blueprint
+    blueprint(part, str(out / "sg90_fence_bp.svg"), name="sg90_fence")
     print(f"sg90_fence: volume {part.volume:.0f} mm^3 -> {out}")

--- a/mechanical/sg90/gears.py
+++ b/mechanical/sg90/gears.py
@@ -150,4 +150,6 @@ if __name__ == "__main__":
     part = build()
     export_step(part, str(out / "sg90_gears.step"))
     export_stl(part, str(out / "sg90_gears.stl"), tolerance=0.01)
+    from blueprint import blueprint
+    blueprint(part, str(out / "sg90_gears_bp.svg"), name="sg90_gears")
     print(f"sg90_gears: volume {part.volume:.0f} mm^3 -> {out}")

--- a/mechanical/sg90/measurements.py
+++ b/mechanical/sg90/measurements.py
@@ -10,7 +10,8 @@ guesses are named *_EST and must be replaced by measurement before a part
 is trusted.
 """
 
-# --- FF-M20 motor (flat can) ---
+# --- M10 motor (flat can; donor = short variant of the FF-M20SA dwg,
+# sold as "M10 motor": 8x10 can, dual-rated 3V/18k + 5V/30k, Kv 6000) ---
 MOTOR_BODY_L = 12.3        # [cal] donor short variant (15mm-type dwg: 15.0)
 MOTOR_BODY_D = 10.0        # [dwg], [cal] "two circular tip" 10.0
 MOTOR_BODY_FLAT = 8.0      # [dwg], [cal] across flats
@@ -207,9 +208,24 @@ AXIS_POT_ARBOR = 5.865     # [der] re-measured span 7.39 - (1.85 + 1.20)/2
                            # (first span reading 7.13 discarded)
 AXIS_ARBOR_MOTOR = 5.65    # [der] 6.75 - (1.20 + 1.00)/2
 
+# --- pot pocket ears (middle shell, pot z-datum) ---
+CASE_POT_EAR_L = 3.0        # [cal] 2x3 tab; 3.0 = circumferential (split assumed)
+CASE_POT_EAR_W = 2.0        # [cal] radial
+CASE_POT_EAR_PAIR_DEG = 180 # [cal] two ears, opposite
+CASE_POT_EAR_H_EST = 0.8    # [cal] eyeballed 0.5-1, midpoint
+CASE_POT_EAR_ANGLE_EST = 0  # UNVERIFIED - assumed +/-X: must dodge the
+                            # leg zone (-90 +/- 48 deg, wiper at -Y)
+
 # --- pot shaft, disassembled (supersedes assembled-state guesses) ---
 POT_SHAFT_TOTAL_L = 12.79  # [cal] incl rear magnet boss
-POT_SHAFT_MAIN_D = 1.85    # [cal] base section (gear2 rides here)
+POT_SHAFT_MAIN_D = 1.85    # [cal] gear2's z-stop shoulder (z-stop requires
+                           # gear2 wheel bore < 1.85); 1.35 above is nominal
+                           # (confirmed across donors), gear4 D-bore mates
+                           # there. Gear2 bore UNMEASURED and load-bearing:
+                           # the old 1.9 figure may be derived, likely a
+                           # STEPPED bore (wheel ~1.4 / pinion relief ~1.9);
+                           # either way pinion wall ~0.12 (8T m0.30 root
+                           # 1.65), the tooth-strip stage - NEVER ream
 POT_SHAFT_TIP_D = 1.35     # [cal] tip round section (gear4 D-bore)
 POT_SHAFT_TIP_FLAT = 1.00  # [cal] across the D flat
 # step position along the shaft: not yet measured

--- a/mechanical/sg90/motor.py
+++ b/mechanical/sg90/motor.py
@@ -207,4 +207,6 @@ if __name__ == "__main__":
     part = build()
     export_step(part, str(out / "sg90_motor.step"))
     export_stl(part, str(out / "sg90_motor.stl"), tolerance=0.01)
+    from blueprint import blueprint
+    blueprint(part, str(out / "sg90_motor_bp.svg"), name="sg90_motor")
     print(f"sg90_motor: volume {part.volume:.0f} mm^3 -> {out}")

--- a/mechanical/sg90/motor.py
+++ b/mechanical/sg90/motor.py
@@ -1,4 +1,5 @@
-"""FF-M20 flat-can motor. Axis = Z, rear face at z=0, shaft up."""
+"""M10 flat-can motor (8x10x12.3 donor; FF-M20SA dwg is the 15mm
+sibling). Axis = Z, rear face at z=0, shaft up."""
 import math
 
 from build123d import *

--- a/mechanical/sg90/pot.py
+++ b/mechanical/sg90/pot.py
@@ -134,4 +134,6 @@ if __name__ == "__main__":
     part = build()
     export_step(part, str(out / "sg90_pot.step"))
     export_stl(part, str(out / "sg90_pot.stl"), tolerance=0.01)
+    from blueprint import blueprint
+    blueprint(part, str(out / "sg90_pot_bp.svg"), name="sg90_pot")
     print(f"sg90_pot: volume {part.volume:.0f} mm^3 -> {out}")

--- a/mechanical/stenciljig/__init__.py
+++ b/mechanical/stenciljig/__init__.py
@@ -1,0 +1,61 @@
+"""PCB solder-paste stencil jig + tool tote. Independent build123d
+implementation of the mechanism from "PCB Stencil Jig for applying
+solder paste (parametric, works with double-sided boards)" by
+bobstay, https://www.printables.com/model/1209372 - credited with
+thanks as the origin of the design idea. Same overall mechanism;
+changes for this shop:
+- heat-set inserts -> plain M3 nuts in printed pockets (encbench
+  benched flat-pocket numbers: 5.7 drop-out, 5.4 broach). Every nut
+  SEAT is press fit (FIT_PRESS); deep pockets ride the nut up a
+  loose shaft first, and the screw from the far side drags it home
+- bobstay's under-base thumbscrews -> T-nut style: socket screws
+  drive from the TOP through low ear tabs on the plate's outer foot,
+  through the rail slot, into a nut bar sliding under the base. One
+  allen key runs the whole jig from above, the plate top stays
+  unbroken for the stencil
+- keel rail added between the rail slots: a dovetail ridge on the
+  base rides a matching groove under each plate, so a loosened plate
+  stays square AND cannot lift
+- freestanding tray + separate bench caddy -> a two-part stack: the
+  jig stands on four screw-on feet beside an open tote box (box.py)
+  standing on four of the SAME feet (finger room underneath to lift
+  it), and stacks onto it as the lid for transport. The jig's rear
+  feet carry hook noses that latch slots in the box wall; two
+  quarter-turn cam knobs at the front seat under the box's
+  descending ceiling tents and draw the base down onto the wall
+  tops - clamped by geometry and PETG spring. TPU desk pads snap
+  into the feet's through bores (one pad model, geometry retains it)
+- credit-card squeegee -> printed standing wedge, both faces at 60
+  deg: attack angle from geometry, not the hand
+- side plates are thickness-agnostic and identical left/right; board
+  thickness lives in screw-down adapter planks, one thickness per
+  long edge (flip 180 to swap): 1.6/1.0, 1.2/0.8, 0.6/0.4, 2.0/1.6 -
+  the full JLC rigid ladder
+
+Mechanism: two side plates slide on slotted rails to clamp the board
+width; the board rests on 1 mm ledges with UNDER mm free beneath
+(double-sided boards). The frameless stencil slides under the rear
+clamp plate, gets aligned by eye, and is clamped down. Boards then
+swap out the front - the ejection tongue shoves the pasted board
+forward - so one alignment covers a batch.
+
+Screws: M3 button head (ISO 7380), one allen key; M3x16 everywhere
+except the twelve M3x10s (eight feet, four adapter planks). Nuts: 4
+(nut bars) + 4 (captive in the side plates) + 2..7 (clamp plate -
+two is enough); foot screws thread-form their host pilots, no nut. Print 1 base, 2 side plates (same part), 2
+planks per thickness pair, 2 nut bars, 1 clamp plate, 1 tongue, a
+squeegee per stencil size, 8 feet
+(6 plain + 2 hooked), 1 box, 2 cam knobs (each a flat-printed
+handle keyed onto a standing-printed rod, spined by an M3x16
+self-tapped down the shaft - steel carries the cam tension), 8 pads
+(TPU, the one non-PETG part). bobstay recommends PETG, 6 walls, 1.6 top/bottom -
+especially around the rail slots.
+
+Layout: one part per file, every shared dimension in common.py,
+mating cavities offset() from the owning part's profile, and every
+part exports pre-oriented for the slicer (python -m stenciljig).
+
+First target: osc-dev-m007, 50 x 50 x 1.579 board, QFN-20 - the 1.5
+ledge drop seats it 0.08 proud so the stencil rests on the board.
+Board max 120 x 120; stencil max 168 wide (the JLC 100 x 100
+frameless sheet fits with 34 to spare each side)."""

--- a/mechanical/stenciljig/__main__.py
+++ b/mechanical/stenciljig/__main__.py
@@ -1,0 +1,55 @@
+"""Export every part's STL: python -m stenciljig [name...] (from
+mechanical/; names filter by substring). Each part is rotated to its
+module's PRINT pose and dropped onto the bed, so every STL slices
+as-is with no flipping in the slicer."""
+import pathlib
+import sys
+
+from build123d import Pos, export_stl
+
+from stenciljig import (adapter, base, box, clamp_plate, foot, knob,
+                        nutbar, pad, side_plate, squeegee, tongue,
+                        tray)
+from stenciljig.common import AD_PAIRS
+
+BUILDERS = {
+    "base": (base.build_base, base.PRINT),
+    "side": (side_plate.build_side_plate, side_plate.PRINT),
+    "clamp": (clamp_plate.build_clamp_plate, clamp_plate.PRINT),
+    "tongue": (tongue.build_tongue, tongue.PRINT),
+    "nutbar": (nutbar.build_nutbar, nutbar.PRINT),
+    "foot": (foot.build_foot, foot.PRINT),
+    "hookfoot": (lambda: foot.build_foot(True), foot.PRINT),
+    "pad": (pad.build_pad, pad.PRINT),
+    "box": (box.build_box, box.PRINT),
+    "tray": (tray.build_tray, tray.PRINT),
+    "knobrod": (knob.build_rod, knob.PRINT),
+    "knobhandle": (knob.build_handle, knob.PRINT),
+}
+for ta, tb in AD_PAIRS:
+    BUILDERS[f"adapter{round(ta * 10):02d}_{round(tb * 10):02d}"] = \
+        (lambda ta=ta, tb=tb: adapter.build_adapter(ta, tb),
+         adapter.PRINT)
+for w, k in squeegee.SQ_SIZES:
+    BUILDERS[f"squeegee{round(w):02d}"] = \
+        (lambda w=w, k=k: squeegee.build_squeegee(w, k), squeegee.PRINT)
+
+
+def print_pose(part, rot):
+    q = rot * part if rot else part
+    bb = q.bounding_box()
+    return Pos(-(bb.min.X + bb.max.X) / 2, -(bb.min.Y + bb.max.Y) / 2,
+               -bb.min.Z) * q
+
+
+if __name__ == "__main__":
+    picks = sys.argv[1:]
+    out = pathlib.Path(__file__).parent / "build"
+    out.mkdir(exist_ok=True)
+    for name, (build, rot) in BUILDERS.items():
+        if picks and not any(a in name for a in picks):
+            continue
+        part = build()
+        posed = print_pose(part, rot)
+        export_stl(posed, str(out / f"{part.label}.stl"), tolerance=0.01)
+        print(f"{part.label}: volume {part.volume / 1000:.1f} cm^3 -> {out}")

--- a/mechanical/stenciljig/adapter.py
+++ b/mechanical/stenciljig/adapter.py
@@ -1,0 +1,85 @@
+"""Board-thickness adapter: a flat plank screwed onto the plate top,
+one thickness per long edge - flip it 180 to swap edges, so four
+planks cover the full JLC rigid ladder. The board rides LEDGE_PROUD
+high on the inboard edge's ledge (bearing on the strip, the step face
+takes the clamp); the outboard edge's ledge is the other thickness,
+parked. Two M3x10 on the centerline drop into nuts captive in the
+side plate; the screw rows are symmetric about the plate center so
+either orientation lands on the same holes, and the snug shank holes
+locate the plank. Each thickness label runs along its own edge, digit
+tops toward that edge, and repeats at both ends (4 per plank), so
+whichever edge is inboard - and whichever end faces the viewer - its
+label reads.
+
+Reach audit: deck top 23.0, head seat 1.95 down, M3x10 tip at 11.05 -
+through the plate-top wall and the whole nut (14.2..16.6) with 0.65
+of relief floor to spare (side_plate.py owns the channel).
+
+Prints flat, ledges up (the old standing tower sheared its layers -
+tall and skinny wobbles): the deck top and ledge strips are top skin,
+so the drop between them is an exact layer count - slice at 0.10 so
+every drop lands on a boundary. 0.25 nozzle for the label engraving.
+Print 2 per pair."""
+from build123d import *
+
+from stenciljig.common import (_box, AD_SCREW_Y, BORDER, BTN_CBORE,
+                               BTN_CBORE_D, CAP_T, LEDGE, LEDGE_PROUD,
+                               M3_HOLE, PCB_D, PCB_TOP, PCB_W,
+                               PLATE_YC, SIDE_W, WHITE)
+
+AD_CBORE = BTN_CBORE + 0.25  # head 0.25 sub-flush: only the 0.1-proud
+                             # board edge meets the stencil
+ENGRAVE = 0.4              # thickness label depth
+ENGRAVE_SIZE = 6.0
+
+# silk PLA per design (MIKA3D bundle), color weight tracks thickness;
+# both copies of a pair print the same color
+AD_COLORS = {
+    (0.6, 0.4): WHITE,
+    (1.2, 0.8): Color(0.85, 0.72, 0.10),   # yellow
+    (1.6, 1.0): Color(0.08, 0.52, 0.62),   # peacock blue
+    (2.0, 1.6): Color(0.72, 0.08, 0.08),   # red
+}
+
+PRINT = None               # flat as modeled, ledges up
+
+
+def build_adapter(ta=1.6, tb=1.0) -> Part:
+    """ta ledges the inboard (modeled) edge, tb the outboard."""
+    x0 = PCB_W / 2 - LEDGE
+    xc = x0 + SIDE_W / 2
+    p = Pos(xc, PLATE_YC, PCB_TOP - CAP_T) * extrude(
+        RectangleRounded(SIDE_W, PCB_D, 3.0), CAP_T)
+    p = chamfer(p.faces().sort_by(Axis.Z)[-1].edges(), 0.5)
+    p = chamfer(p.faces().sort_by(Axis.Z)[0].edges(), 0.3)
+
+    # ledge: drop LEDGE mm of the top along each edge so that edge's
+    # board rides LEDGE_PROUD high
+    for xa, xb, t in ((x0 - 0.1, x0 + LEDGE, ta),
+                      (x0 + SIDE_W - LEDGE, x0 + SIDE_W + 0.1, tb)):
+        p -= _box(xa, xb, BORDER - 0.1, BORDER + PCB_D + 0.1,
+                  PCB_TOP - (t - LEDGE_PROUD), PCB_TOP + 0.1)
+
+    for y in AD_SCREW_Y:
+        p -= Pos(xc, y, PCB_TOP - CAP_T - 0.1) * Cylinder(
+            M3_HOLE / 2, CAP_T + 0.2,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+        p -= Pos(xc, y, PCB_TOP - AD_CBORE) * Cylinder(
+            BTN_CBORE_D / 2, AD_CBORE + 0.1,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+    # labels run along their edges, digit tops toward the edge, at
+    # both ends: the mounted pair is mirrored, so single-ended labels
+    # leave one hand blank-first; edge-aligned text is the only layout
+    # where two labels fit the 18-wide deck side by side
+    for t, s in ((ta, 1), (tb, -1)):
+        for e in (1, -1):
+            plane = Plane((xc - s * 4.5,
+                           PLATE_YC - e * (PCB_D / 2 - 9.0), PCB_TOP),
+                          x_dir=(0, s, 0), z_dir=(0, 0, 1))
+            p -= extrude(plane * Text(f"{t:.1f}", ENGRAVE_SIZE),
+                         -ENGRAVE)
+
+    p.label = f"stenciljig_adapter{round(ta * 10):02d}_{round(tb * 10):02d}"
+    p.color = AD_COLORS.get((ta, tb), WHITE)
+    return p

--- a/mechanical/stenciljig/base.py
+++ b/mechanical/stenciljig/base.py
@@ -1,0 +1,104 @@
+"""Jig base: rail bed, rear stencil deck, keel rail, and the sockets
+for every bolt-on - foot nuts pocket into the underside, cam
+keyholes pass the knob's T, nut bars slide underneath. The top face
+keeps only its original through-cuts; every underside pocket closes
+as a 45 deg hopper or cone, so the base prints as modeled with zero
+bridges.
+
+Screws through this part: side plates clamp with M3x16 through the
+ear tabs into nut bars (reach audit: 4 ear + 6 base + 2 bar web +
+2.4 nut = 14.4, tip lands flush with the bar underside); clamp plate
+M3x16 into bottom-entry deck pockets (nuts broach up from the
+underside, tips ride into the loose shafts); feet take M3x10 from
+below (foot.py) thread-forming the underside pilots. Everything else
+runs from above with one allen key."""
+from build123d import *
+
+from stenciljig.common import (_box, _nut_broach, _plate,
+                               _dovetail_rail, BASE_D, BASE_T, BASE_W,
+                               BORDER, CAM_KEY_FIT, CAM_XY,
+                               CLAMP_HOLES, FOOT_POSE, LEDGE,
+                               LEDGE_PROUD, M3_HOLE, NOTCH_EXTRA,
+                               OUTLINE_R, PCB_T, PCB_TOP, RAIL_H,
+                               RAIL_ROOT, RAIL_W, RAIL_X, RAIL_Y,
+                               REAR_HW, REAR_Y, SLOT_LEN, SLOT_W,
+                               SLOT_X0, SLOT_Y, TONGUE_CLEAR,
+                               TONGUE_W, BLACK)
+from stenciljig.foot import mount_cutter
+from stenciljig.knob import t_slot
+
+PRINT = None               # underside down, as modeled
+
+
+def plan():
+    """Base outline; the box shares it as its own plan."""
+    return Pos(0, BASE_D / 2) * RectangleRounded(BASE_W, BASE_D,
+                                                 OUTLINE_R)
+
+
+def build_base() -> Part:
+    p = extrude(plan(), BASE_T)
+    e = p.edges().group_by(Axis.Z)
+    p = chamfer(e[0] + e[-1], 1.0)
+
+    # rear plate: stencil clamping deck, top = the stencil plane
+    p += _box(-REAR_HW, REAR_HW, REAR_Y[0], REAR_Y[1], BASE_T, PCB_TOP)
+
+    # keel rail: dovetail riding the groove under each side plate - a
+    # loose plate stays square AND held down; plates slide on from the
+    # rail ends (root sunk 0.1 for the boolean)
+    p += Pos(0, RAIL_Y, BASE_T - 0.1) * _dovetail_rail(
+        RAIL_ROOT, RAIL_W, RAIL_H + 0.1, RAIL_X, lead=0.8)
+
+    # board rear ledge: 1 mm notch the board backs into - the y datum.
+    # Floor is cut for the thickest board and supports its rear edge;
+    # thinner boards float above it, corners on the side ledges, floor
+    # as a backstop if the squeegee flexes the rear edge down
+    p -= _box(-REAR_HW - 0.1, REAR_HW + 0.1, REAR_Y[0] - LEDGE,
+              REAR_Y[0] + LEDGE, PCB_TOP - (PCB_T - LEDGE_PROUD) - NOTCH_EXTRA,
+              PCB_TOP + 0.1)
+
+    # ejection tongue groove through the rear plate deck
+    gw = TONGUE_W / 2 + TONGUE_CLEAR
+    p -= _box(-gw, gw, REAR_Y[0] - 0.1, REAR_Y[1] + 0.1,
+              PCB_TOP - PCB_T - TONGUE_CLEAR, PCB_TOP + 0.1)
+
+    # rail slots, one continuous slot per row per side
+    for s in (1, -1):
+        for y in SLOT_Y:
+            p -= Pos(s * (SLOT_X0 - SLOT_LEN / 2), y, -0.1) * extrude(
+                SlotOverall(SLOT_LEN + SLOT_W, SLOT_W), BASE_T + 0.2)
+
+    # clamp nut pockets, bottom-entry: loose hex shaft up from the
+    # underside, press band + 45 hopper carrying the clamp tension,
+    # M3_HOLE web up to the deck; the screw from the top drags each
+    # nut to seat, x16 tips ride into the loose shaft. The centre
+    # pocket hangs from the tongue groove floor instead, so its nut
+    # sits fully recessed and the tongue slides over a bare M3 hole
+    for x, y in CLAMP_HOLES:
+        top = PCB_TOP - PCB_T - TONGUE_CLEAR if x == 0.0 else PCB_TOP
+        seat = top - 2.6           # 1.0 hopper + 1.6 web over the nut
+        p -= Pos(x, y, 0) * _nut_broach(seat)
+        p -= Pos(x, y, seat) * Cylinder(
+            M3_HOLE / 2, top - seat + 0.1,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+    # foot mounts, all in the underside (the top face gains nothing;
+    # the rear pair sits under the deck where top access would be
+    # impossible anyway): the shared cutter's tap pilot + pin socket
+    # fit the bare 6 slab
+    cut = mount_cutter()
+    for x, y, a, hook in FOOT_POSE:
+        p -= Pos(x, y, 0) * Rot(0, 0, a) * cut
+
+    # cam keyholes: the knob's T drops through into the box's gusset
+    # cavity; a quarter turn seats its wing roof under the box's
+    # descending ceiling tents and draws the seam tight (knob.py,
+    # box.py). Unstacked, the knobs live in the box's hardware bin
+    for s in (1, -1):
+        p -= Pos(s * CAM_XY[0], CAM_XY[1], -0.1) * extrude(
+            offset(t_slot(), CAM_KEY_FIT), BASE_T + 0.2)
+
+    p.label = "stenciljig_base"
+    p.color = BLACK
+    return p

--- a/mechanical/stenciljig/box.py
+++ b/mechanical/stenciljig/box.py
@@ -1,0 +1,212 @@
+"""Open tool tote the jig stacks onto - two parts, side by side on
+the bench, locked together for storage and transport:
+- BOX: an open tub sharing the base's plan (base.plan() offset by
+  the wall = the interior, minus the gusset footprints = the cavity,
+  so nothing can poke past the outer rounds). The pocketed deck
+  inside holds every loose tool in reach while the jig works next to
+  it. The jig's base seats on the wall tops as the lid, full
+  perimeter plus the gusset tops; its feet drop just inside the rim
+  and hover over the tools, and its nut bars sweep -6..0 clear above
+  the deck
+- LOCK: gabled slots in the rear wall catch the hook noses on the
+  jig's rear feet (set down rear-first at a shallow tilt, lower the
+  front); a corner gusset behind the front wall hides a swing cavity
+  each for a knob's T-bar. The cavity ceiling is a fan of 45 deg
+  sector tents DESCENDING CAM_RISE over the quarter turn - the
+  ceiling itself is the cam. Drop the knob through base keyhole and
+  entry slot, quarter turn clockwise to the -90 stop, and its wing
+  roof seats face-on-face under ever lower tents, drawing the base
+  onto the walls; the last RISE - CLEAR is PETG-spring preload and
+  the shallow step-to-step descent cannot shake open
+- layout: adapter slots split 3 per side wall (the six benched
+  planks on edge, records in a crate, proud of the rim for the
+  grab); the whole middle rear is the bay, split by height:
+  stencils to 125 square lie flat in a sheet well at the deep
+  floor, and a lift-out tray (tray.py) rides the well's side
+  ledges at the tool floor, hauling boards + bench sundries flush
+  with the rim. The bay grows a centered finger alcove toward the
+  small squeegee pocket (which keeps its own wall), floor flush
+  with the well's - pinch the tray's front wall there to lift it
+  out, fish sheets down the same hole once it's gone. Squeegees
+  front-left + center, loose hardware
+  front-right (the knobs live there between stackings). The tongue
+  is not stored: it lives in its groove
+
+Walls are 6 perimeters of a 0.6 nozzle; 0% infill slices the deck as
+skins over air - any infill welcome for stiffness. Prints as
+modeled: every ceiling is a 45 deg tent, gable, or cone, the widest
+flat down-face is the ~3.6 strip atop a sector tent."""
+from build123d import *
+
+from stenciljig.base import plan
+from stenciljig.common import (_box, BASE_D, BASE_T, BASE_W,
+                               CAM_ENTRY_FIT, CAM_LID, CAM_RISE,
+                               CAM_TENT, CAM_XY, CAP_T, FIT_LOOSE,
+                               FOOT_H, ORANGE, FOOT_INSET, FOOT_POSE,
+                               PCB_D, SIDE_W)
+from stenciljig.foot import mount_cutter, HOOK_H, HOOK_W
+from stenciljig.knob import t_slot
+from stenciljig.squeegee import (SQ_BASE, SQ_CHEEK_REACH, SQ_CHEEK_T,
+                                 SQ_SIZES)
+
+WALL = 3.6                 # 6 perimeters of a 0.6 nozzle
+DIV = 2.4                  # pocket dividing walls
+PKT = 0.8                  # pocket clearance per side, drop-in
+
+EXT = BASE_W / 2           # shares the base plan, 103
+BOX_H = 38.0
+IX = EXT - WALL            # interior half-width
+IY = (WALL, BASE_D - WALL) # interior front / rear faces
+RIM = -13.0                # deck top: a stored plank tops out at
+                           # -9.2, 3.8 proud for the grab
+FLOOR_Z = -25.4            # common tool floor + the bay's tray ledges
+SHEET_Z = -29.6            # sheet well's deep floor, 2.4 over the slab
+
+AD_SLOTS = 6               # the six benched planks; the mounted pair
+                           # rides the jig
+AD_SLOT_W = CAP_T + 2 * PKT
+AD_DIV = 1.8               # slot fins, 3 perimeters
+AD_D = PCB_D + 2 * PKT     # slot length, plank on edge
+AD_Z = RIM - SIDE_W + 3.8  # slot floor: a plank stands SIDE_W tall,
+                           # 3.8 proud of the rim for the grab; the
+                           # slab below keeps the 8.4 the stack needs
+# slots split 3 per side wall so the whole middle is the bay
+_AD_GRP = 3 * AD_SLOT_W + 2 * AD_DIV
+AD_XS = tuple(-IX + 2.0 + i * (AD_SLOT_W + AD_DIV) for i in range(3)) \
+    + tuple(IX - 2.0 - _AD_GRP + i * (AD_SLOT_W + AD_DIV)
+            for i in range(3))
+SHEET = 125.0              # max square sheet stored - the bay front
+                           # is pinned by the sq60 pocket + divider,
+                           # not by width (151.2 between slot groups)
+
+# pocket anchors: wall-adjacent pockets inset 2 so their rounded
+# corners stay clear of the cavity's corner rounds
+BAY_Y1 = IY[1] - 2.0       # rear edge of bay + adapter slots
+BAY_X0 = -IX + 2.0 + _AD_GRP + DIV
+BAY_W = 2 * -BAY_X0        # 151.2, symmetric
+BAY_D = SHEET + 2 * PKT
+SQ_XY0 = (-75.6, WALL + 2.0)            # squeegee row start
+HW_BIN = (20.4, WALL + 2.0, 75.6, 35.2) # loose hardware, x0 y0 x1 y1
+NOTCH = (-7.6, 18.0)       # finger alcove, centered: the bay grows
+                           # a front stem over the small squeegee
+                           # pocket's span - the pocket keeps its
+                           # own rear wall, the floor is well-deep
+
+# cam gussets (front corners, tops seat the base)
+GUS = (78.0, 29.6)         # gusset inner corner |x|, y
+CAV_Z0 = -11.0             # swing cavity band floor
+CAM_STEPS = range(0, -91, -6)           # sector fan, locked at -90
+
+# rear-foot hook slots (rear wall)
+TSLOT_D = 2.6              # into the wall, 1.0 of exterior skin kept
+TSLOT_TOP = -FOOT_H + HOOK_H + FIT_LOOSE  # mouth edge over the nose
+
+# the box stands on the SAME screw-on feet as the jig (4 plain), one
+# per corner, long axis along the side walls so the r10 pad ends
+# nest under the r10 corner rounds; the 8.4 stance leaves finger
+# room to lift the box from below
+BOX_FOOT_POSE = tuple(
+    (s * (EXT - FOOT_INSET), y, -s * 90.0)
+    for s in (1, -1) for y in (FOOT_INSET, BASE_D - FOOT_INSET))
+
+PRINT = None               # open top up, as modeled
+
+
+def _pocket(x0, y0, w, d, floor):
+    # corner r must intrude less than the PKT clearance: square-
+    # cornered tenants (stencil sheets, squeegee cheeks) sit flush
+    return Pos(x0 + w / 2, y0 + d / 2, floor) * extrude(
+        RectangleRounded(w, d, 2.0), RIM - floor + 1)
+
+
+def build_box() -> Part:
+    p = Pos(0, 0, -BOX_H) * extrude(plan(), BOX_H)
+
+    # cavity = interior (plan offset by the wall) minus the gusset
+    # footprints: walls, corner rounds and gussets all fall out of
+    # one sketch boolean, clipped to the outline by construction
+    cav = offset(plan(), -WALL)
+    for s in (1, -1):
+        cav -= _gusset_rect(s)
+    p -= Pos(0, 0, RIM) * extrude(cav, -RIM + 0.1)
+    e = p.edges().group_by(Axis.Z)
+    p = chamfer(e[0] + e[-1], 0.5)          # seat lead-in + bed edge,
+                                            # before cuts break them up
+
+    # cam swing cavities: entry slot through the ceiling band, then a
+    # fan of sector cuts whose 45 deg tents step down CAM_RISE toward
+    # the -90 stop - the descending tents are the cam surface. Both
+    # sides cut at the same absolute angles so ONE knob model locks
+    # clockwise on either side (mirroring would flip its handedness)
+    eslot = offset(t_slot(), CAM_ENTRY_FIT)
+    desc = CAM_RISE / (len(CAM_STEPS) - 1)
+    for s in (1, -1):
+        at = Pos(s * CAM_XY[0], CAM_XY[1])
+        p -= at * Pos(0, 0, -CAM_LID - 0.1) * extrude(eslot, CAM_LID + 0.2)
+        for k, a in enumerate(CAM_STEPS):
+            sk = Rot(0, 0, a) * eslot
+            zb = -CAM_LID - desc * k
+            p -= at * Pos(0, 0, CAV_Z0) * extrude(sk, zb - CAV_Z0)
+            p -= at * Pos(0, 0, zb) * extrude(sk, CAM_TENT, taper=45)
+
+    # rear-foot hook slots: mouth in the rear wall's inner face; the
+    # roof gables up 45 deg from the mouth, so the catch is the
+    # mouth's crisp printed edge, never a drooping bridge
+    for x, y, a, hook in FOOT_POSE:
+        if not hook:
+            continue
+        # cutter runs 1.6 proud of the wall face: the interior corner
+        # round bulges past the face there and would clip the nose
+        p -= _box(x - HOOK_W / 2 - 0.4, x + HOOK_W / 2 + 0.4,
+                  IY[1] - 1.6, IY[1] + TSLOT_D,
+                  -FOOT_H - 0.5, TSLOT_TOP)
+        roof = Polygon((IY[1] - 0.1, TSLOT_TOP),
+                       (IY[1] + TSLOT_D, TSLOT_TOP + TSLOT_D + 0.1),
+                       (IY[1] + TSLOT_D, TSLOT_TOP), align=None)
+        p -= Pos(x, 0, 0) * extrude(Plane.YZ * roof,
+                                    HOOK_W / 2 + 0.4, both=True)
+
+    # bay, split by height: a full-width shelf at the tool floor
+    # over a BAY_D-square sheet well - the side steps are the
+    # ledges the tray rides on
+    p -= _pocket(BAY_X0, BAY_Y1 - BAY_D, BAY_W, BAY_D, FLOOR_Z)
+    p -= _pocket(-BAY_D / 2, BAY_Y1 - BAY_D, BAY_D, BAY_D, SHEET_Z)
+    # access: centered finger alcove between the small squeegee
+    # pocket and the bay, floor flush with the sheet well (a DIV
+    # wall keeps the pocket enclosed): pinch the tray's front wall
+    # to lift it, reach sheets to the bottom of the stack
+    p -= _box(NOTCH[0], NOTCH[1], 30.4,
+              BAY_Y1 - BAY_D + 0.1, SHEET_Z, RIM + 1)
+
+    # squeegee pockets, front left, clear of the gusset
+    x0, y0 = SQ_XY0
+    for w, k in SQ_SIZES:
+        sx = w - 1 + 2 * SQ_CHEEK_T + 2 * PKT
+        sy = SQ_BASE * k + 2 * SQ_CHEEK_REACH + 2 * PKT
+        p -= _pocket(x0, y0, sx, sy, FLOOR_Z)
+        x0 += sx + DIV
+
+    # adapter slots, planks on edge, 3 against each side wall
+    for x0 in AD_XS:
+        p -= _pocket(x0, BAY_Y1 - AD_D, AD_SLOT_W, AD_D, AD_Z)
+    # loose hardware between squeegees and the right gusset
+    p -= _pocket(HW_BIN[0], HW_BIN[1], HW_BIN[2] - HW_BIN[0],
+                 HW_BIN[3] - HW_BIN[1], FLOOR_Z)
+
+    # foot mounts in the bottom face, same shared cutter as the base
+    # (the slab is >=8.4 everywhere here, the stack needs 6)
+    cut = mount_cutter()
+    for x, y, a in BOX_FOOT_POSE:
+        p -= Pos(x, y, -BOX_H) * Rot(0, 0, a) * cut
+
+    p.label = "stenciljig_box"
+    p.color = ORANGE
+    return p
+
+
+def _gusset_rect(s):
+    """Gusset footprint, oversize outboard and forward - the cavity
+    boolean clips it to the walls, so no corner can poke past the
+    outer rounds (square blocks unioned on did exactly that)."""
+    return Pos(s * (GUS[0] + EXT + 2) / 2, (GUS[1] - 1) / 2) * \
+        Rectangle(EXT + 2 - GUS[0], GUS[1] + 1)

--- a/mechanical/stenciljig/clamp_plate.py
+++ b/mechanical/stenciljig/clamp_plate.py
@@ -1,0 +1,26 @@
+"""Stencil clamp plate over the rear deck: M3x16 from above into the
+nuts captive in the deck's bottom-entry pockets, heads flush in 1.7
+pockets. Two screws clamp fine; the rest of the grid is bobstay's
+"overkill clamping". Prints as modeled."""
+from build123d import *
+
+from stenciljig.common import (_plate, BTN_CBORE, BTN_CBORE_D, CLAMP_D,
+                               CLAMP_HOLES, CLAMP_T, CLAMP_Y0, M3_FREE,
+                               BLACK, PCB_TOP, REAR_HW)
+
+PRINT = None
+
+
+def build_clamp_plate() -> Part:
+    p = Pos(0, CLAMP_Y0 + CLAMP_D / 2, PCB_TOP) * _plate(
+        2 * REAR_HW, CLAMP_D, CLAMP_T, CLAMP_D / 8, 0.5)
+    for x, y in CLAMP_HOLES:
+        p -= Pos(x, y, PCB_TOP - 0.1) * Cylinder(
+            M3_FREE / 2, CLAMP_T + 0.2,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+        p -= Pos(x, y, PCB_TOP + CLAMP_T - BTN_CBORE) * Cylinder(
+            BTN_CBORE_D / 2, BTN_CBORE + 0.1,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p.label = "stenciljig_clamp"
+    p.color = BLACK
+    return p

--- a/mechanical/stenciljig/common.py
+++ b/mechanical/stenciljig/common.py
@@ -1,0 +1,240 @@
+"""Shared spec for the stencil jig set (design story in __init__.py):
+printed fits, M3 hardware, the jig frame, and every cross-part
+interface. A dimension lives here only when two parts must agree on
+it; everything else stays in its part's file, and a mating cavity is
+built by offset()-ing the owning part's profile by a fit from here
+rather than re-drawing it.
+
+Frame: x = 0 at the jig centerline, y = 0 at the front edge, z = 0 at
+the base underside. Board slides in from the front (-y).
+
+Printability doctrine (every part exports pre-oriented for slicing,
+see __main__.py): no down-face steeper than 45 deg off the bed, no
+bridge over ~3.6 wide; internal ceilings close as 45 deg cones/tents;
+catch and bearing surfaces are printed edges or 45 deg faces, never
+flat bridges. check_overhangs.py in the session scratchpad audits
+every part's print pose against this.
+"""
+import math
+
+from build123d import *
+
+# --- printed fits (clearance per side, mating part also printed) ---
+FIT_LOOSE = 0.15           # free slide
+FIT_STD = 0.10             # drop-in
+FIT_TIGHT = 0.05           # push-in, holds inverted
+FIT_PRESS = 0.0            # interference from print shrinkage alone
+
+# --- M3 hardware: button heads (ISO 7380) + plain nuts in printed
+# --- pockets (encbench benched: 5.7 drop-out, 5.4 broach) ---
+M3_HOLE = 3.4              # vertical clearance, prints ~3.25
+M3_FREE = 3.6              # pass-throughs, drop-through loose
+M3_NUT_T = 2.4
+NUT_AF = 5.5               # across flats, prints ~true
+NUT_PRESS_AF = NUT_AF + 2 * FIT_PRESS
+                           # every nut SEAT: interference comes from
+                           # print shrinkage, the far-side screw's
+                           # preload drags the nut home
+NUT_SLIDE_AF = NUT_AF + 2 * FIT_LOOSE
+                           # deep-pocket travel shaft: the nut rides
+                           # up free, then hits the press band
+M3_TAP = 2.9               # self-tap pilot: M3 machine screw forms
+                           # its own threads in PETG (knob spine +
+                           # foot mounts)
+BTN_H = 1.65               # ISO 7380 button head, 5.7 across
+BTN_CBORE = BTN_H + FIT_TIGHT      # head pockets: dome sits flush
+BTN_CBORE_D = 6.5          # drop-in room around the 5.7 head
+
+# --- frame (bobstay parameter names kept recognizable) ---
+BORDER = 5.0
+SIDE_W = 20.0              # side plate width
+LEDGE = 1.0                # board rests on this, each side
+PCB_W = 120.0              # max board the plates open to
+PCB_D = 120.0
+PCB_T = 2.0                # thickest supported board (JLC catalog
+                           # top); the base's rear notch is cut for
+                           # it, thinner boards clear
+AD_PAIRS = ((1.6, 1.0), (1.2, 0.8), (0.6, 0.4), (2.0, 1.6))
+                           # adapter planks, one thickness per long
+                           # edge (flip 180 to swap) - the full JLC
+                           # rigid ladder, workhorse 1.6 spared twice
+LEDGE_PROUD = 0.1          # ledge drop = pcb_t - this: the board rides
+                           # proud so the stencil seats on the board,
+                           # not the plates (m007 measures 1.579 ->
+                           # 0.08 proud); slice at 0.10 layers so
+                           # every drop lands on a boundary
+STENCIL_W = 168.0          # max stencil width, drives BASE_W - sized
+                           # so the box below closes its layout
+UNDER = 15.0               # clear space under the board
+BASE_T = 6.0
+REAR_D = 40.0              # rear plate depth
+CLAMP_D = 34.0             # clamp plate depth
+CLAMP_T = 6.0
+SCREW_SP = 4.0             # bobstay's insertHoleDia, kept as spacing unit
+NOTCH_EXTRA = 0.02         # rear ledge cut slightly deep - board never catches
+OUTLINE_R = 10.0           # base / box shared corner round
+
+BASE_W = 2 * BORDER + SIDE_W + 2 * SCREW_SP + STENCIL_W  # 206
+BASE_D = 2 * BORDER + PCB_D + REAR_D                     # 170
+PLATE_H = UNDER + PCB_T                                  # 16.6
+PCB_TOP = BASE_T + PLATE_H                               # 22.6 stencil plane
+REAR_Y = (BORDER + PCB_D, BORDER + PCB_D + REAR_D)       # 125 .. 165
+REAR_HW = BASE_W / 2 - BORDER                            # 98
+PLATE_YC = BORDER + PCB_D / 2                            # 65 plate y center
+CLAMP_Y0 = REAR_Y[1] - CLAMP_D
+
+# --- ejection tongue channel (base <-> tongue) ---
+TONGUE_W = 20.0
+TONGUE_CLEAR = FIT_LOOSE   # groove growth each side
+TONGUE_DROP = 0.1          # tongue 0.1 under board thickness - slides free
+TONGUE_LEN = PCB_D * 0.8
+
+# --- rail slots (base <-> side plate travel; track the ear holes) ---
+# rows centered on the plate depth (bobstay used board thirds) so a
+# plate flipped 180 deg lands on the same slots
+SLOT_Y = (PLATE_YC - PCB_D / 6, PLATE_YC + PCB_D / 6)
+SLOT_W = 4.0               # loose on the M3 shank
+EAR_HOLE = 4.0             # ear hole center, out from the plate face
+SLOT_X0 = (PCB_W / 2 - LEDGE) + SIDE_W + EAR_HOLE  # screw x at max opening
+SLOT_LEN = PCB_W / 2 - LEDGE  # travel band: plate inner faces touch
+                              # at the centerline when fully closed
+
+# --- keel rail (base <-> side plate; profile shared with the adapter
+# --- deck's dovetail) ---
+RAIL_Y = (SLOT_Y[0] + SLOT_Y[1]) / 2
+RAIL_W = 8.0               # dovetail top (wide) width
+RAIL_ROOT = 5.0            # root width: 1.5 overhang each side keeps
+                           # the mating part from lifting off
+RAIL_H = 3.0               # under-board clearance drops 15 -> 12 here
+RAIL_X = PCB_W / 2 - LEDGE + SIDE_W     # half-length, plate outer face
+RAIL_SLIDE = 2 * FIT_LOOSE # groove width over rail - tight slide
+RAIL_DROP = 0.3            # groove deeper than rail: mating part seats
+                           # on the face, the rail only guides
+GROOVE_ROOT = RAIL_ROOT + RAIL_SLIDE
+GROOVE_TOP = RAIL_W + RAIL_SLIDE + RAIL_DROP * (RAIL_W - RAIL_ROOT) / RAIL_H
+GROOVE_H = RAIL_H + RAIL_DROP  # groove keeps the rail's flank slope
+
+# --- adapter interface (side plate <-> adapter) ---
+CAP_T = 3.0                # adapter plank thickness over the plate
+                           # body; fully backed by the plate top, so
+                           # only the head cbore web and the 1.9 max
+                           # ledge drop size it
+AD_SCREW_Y = (PLATE_YC - PCB_D / 3, PLATE_YC + PCB_D / 3)
+                           # plank screw rows, symmetric about the
+                           # plate center so a 180 flip lands on the
+                           # same holes; clear of the keel gable attic
+                           # at RAIL_Y (M3x10 reach audit in adapter.py)
+
+# --- clamp screw grid (base <-> clamp plate; bobstay's 9 positions
+# --- less the rear corner pair - two is enough, 2+ used) ---
+COL_X = STENCIL_W / 2 + SCREW_SP
+COL_Y = (CLAMP_Y0 + CLAMP_D / 4, CLAMP_Y0 + CLAMP_D / 2)
+MID_X = 2 * REAR_HW / 6
+MID_Y = CLAMP_Y0 + CLAMP_D - 1.5 * SCREW_SP
+CLAMP_HOLES = tuple((s * COL_X, y) for s in (1, -1) for y in COL_Y) \
+    + tuple((x, MID_Y) for x in (-MID_X, 0.0, MID_X))
+
+# --- stacking interface (base <-> foot <-> box <-> knob: the jig
+# --- stands beside the open box on screw-on feet and stacks onto it
+# --- as the lid; rear-foot hooks + front cam knobs lock the seam) ---
+FOOT_INSET = 10.0          # box floor pad centers, in from each corner
+FOOT_H = 6.4               # puck height, stance 8.4 with the pad:
+                           # clears the nut bars (6) on the bench;
+                           # taller would put the stacked pads into
+                           # the boxed squeegee's crown
+FOOT_SCREW_OFF = 12.0      # screw station, inboard of the pad center
+FOOT_PIN_OFF = 18.5        # anti-rotation pin, further inboard
+FOOT_PIN_D = 4.0
+FOOT_PIN_H = 2.2
+# pad-center anchor, long-axis angle (screw side = local -y), hook.
+# Rear feet point their noses at the box wall, anchored inboard so
+# their screw + pin cuts clear the clamp pockets' full-depth broach
+# shafts at (+/-COL_X, COL_Y); front feet turn sideways so screw +
+# pin stay clear of the rail slot rows
+FOOT_POSE = ((60.0, 14.0, -90.0, False), (-60.0, 14.0, 90.0, False),
+             (78.0, 156.0, 0.0, True), (-78.0, 156.0, 0.0, True))
+
+
+def foot_pt(x, y, a, d):
+    """Point d along a foot's screw side (local -y) in jig frame."""
+    r = math.radians(a)
+    return x + d * math.sin(r), y - d * math.cos(r)
+
+
+CAM_XY = (88.5, 16.6)      # cam axes (+/-x): head circle 0.5 clear of
+                           # a side plate at max opening, ears 1.4
+                           # away, T swing inside the box wall
+CAM_LID = 3.0              # box gusset ceiling band the wings ride under
+CAM_CLEAR = 0.65           # roof-edge drop below that ceiling at entry
+CAM_RISE = 0.8             # total descent of the box's sector tents
+                           # over the quarter turn; bites RISE - CLEAR
+CAM_TENT = 2.2             # shared 45 deg tent height: the knob's wing
+                           # roof and the box's ceiling tents use the
+                           # same taper so they seat face on face
+CAM_KEY_FIT = 2 * FIT_LOOSE        # base keyhole over the T profile
+CAM_ENTRY_FIT = 0.5        # box entry slot over the T profile
+
+# print palette (ELEGOO PETG): BLACK = the whole jig (base, plates,
+# clamp, tongue, bars), ORANGE = box, GREY = feet + pads, GREEN =
+# hand tools (knob, squeegees) - the touch points. Planks are silk
+# PLA, one color per design (adapter.AD_COLORS)
+GREEN = Color(0.10, 0.48, 0.15)
+BLACK = Color(0.04, 0.04, 0.045)
+ORANGE = Color(0.85, 0.33, 0.05)
+WHITE = Color(0.88, 0.88, 0.86)
+GREY = Color(0.42, 0.43, 0.45)
+
+
+def _box(x0, x1, y0, y1, z0, z1):
+    return Pos((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2) * Box(
+        abs(x1 - x0), abs(y1 - y0), abs(z1 - z0))
+
+
+def _hex(af):
+    return RegularPolygon(af / math.sqrt(3), 6)
+
+
+def _nut_broach(seat):
+    """Bottom-entry captive-nut cutter, mouth at z=0 opening down, nut
+    top face at z=seat: loose hex shaft rides the nut up, a 45 lead
+    into the press band, and the far-side screw's preload drags it the
+    last 0.5 onto the 45 tapered-hex hopper that carries the tension.
+    Caller adds the screw hole above the seat."""
+    band0 = seat - M3_NUT_T - 0.5
+    c = Pos(0, 0, -0.1) * extrude(_hex(NUT_SLIDE_AF), band0 + 0.1)
+    c += Pos(0, 0, band0) * extrude(_hex(NUT_SLIDE_AF),
+                                    FIT_LOOSE - FIT_PRESS, taper=45)
+    c += Pos(0, 0, band0) * extrude(_hex(NUT_PRESS_AF), seat - band0)
+    c += Pos(0, 0, seat - 0.01) * extrude(_hex(NUT_PRESS_AF), 1.0,
+                                          taper=45)
+    return c
+
+
+def _plate(w, d, h, r, bevel_):
+    """Rounded-corner plate with top/bottom edge bevels, centered in
+    xy, z 0..h (bobstay's RoundedBevelCube)."""
+    p = extrude(RectangleRounded(w, d, r), h)
+    edges = p.edges().group_by(Axis.Z)
+    return chamfer(edges[0] + edges[-1], bevel_)
+
+
+def _dovetail_rail(root, top, h, half_len, lead=0.0, gable=False):
+    """Dovetail bar along x, root (narrow) plane at z=0 flaring to top
+    width at z=h - the overhang blocks lift-off, so mating parts only
+    slide in from the ends. lead chamfers the end faces' upper edges
+    for entry. gable replaces the flat top with a 45 deg roof ridge:
+    use it for GROOVE cuts whose ceiling would otherwise print as a
+    bridge and droop into the rail path (a printed keel groove jammed
+    on the base rail exactly that way); the mating rail never reaches
+    the ceiling, so the attic costs nothing."""
+    pts = [(-root / 2, 0), (root / 2, 0), (top / 2, h)]
+    if gable:
+        pts.append((0, h + top / 2))
+    pts.append((-top / 2, h))
+    prof = Polygon(*pts, align=None)
+    bar = extrude(Plane.YZ * prof, half_len, both=True)
+    if lead:
+        ends = [e for i in (0, -1) for e in bar.edges().group_by(Axis.X)[i]
+                if e.center().Z > 0.01]
+        bar = chamfer(ends, lead)
+    return bar

--- a/mechanical/stenciljig/foot.py
+++ b/mechanical/stenciljig/foot.py
@@ -1,0 +1,98 @@
+"""Screw-on bench foot, ONE design for jig and box: an oblong puck
+with two stations. The pad station carries the TPU pad in a THROUGH
+bore (hourglass throat at the bottom, 45 deg stop ring, open to the
+mounting face - no ceiling to print); the screw station takes an
+M3x10 driven from BELOW - head recessed in the foot's underside, a
+45 deg cone ring closing up to the free hole - thread-forming into
+the host's M3_TAP pilot (mount_cutter below; seat the foot, drive -
+no nut anywhere). An anti-rotation pin beyond the screw keys
+the long axis. hook=True adds the rear nose that latches into the
+box's rear-wall slot - the jig's rear feet are bench stance,
+stacking registration AND the rear lock in one part.
+
+Screw audit: head seat at -4.7, M3x10 tip at +5.3 into the host's
+pilot ending 5.6 - 5.3 of formed thread (knob-spine precedent).
+
+Modeled z=0 at the base underside, pad center at the origin, screw
+side local -y (common.FOOT_POSE turns each foot on the jig,
+box.BOX_FOOT_POSE on the box). Prints as modeled, bottom down: the
+only internal down-faces are the 45 deg cones and the hourglass
+flare. Print 6 plain + 2 hooked (4 plain go under the box)."""
+from build123d import *
+
+from stenciljig.common import (_box, BTN_CBORE, BTN_CBORE_D,
+                               FIT_STD, FOOT_H, FOOT_PIN_D, FOOT_PIN_H,
+                               FOOT_PIN_OFF, FOOT_SCREW_OFF, M3_FREE,
+                               M3_TAP, GREY)
+from stenciljig.pad import (recess_cutter, stop_ring, PAD_BORE_R,
+                            PAD_RECESS, PAD_STOP)
+
+FOOT_W = 20.0              # pad recess + 3 of rim
+FOOT_L = FOOT_SCREW_OFF + FOOT_W        # oblong plan, end circles at
+                                        # the pad and screw stations
+HOOK_W = 12.0              # rear nose: width, reach past the pad-end
+HOOK_REACH = 2.2           # rim, band height - locks into the box's
+HOOK_H = 3.0               # rear-wall slots
+
+PRINT = None               # bottom down, as modeled
+
+
+def mount_cutter():
+    """Underside cuts a host takes to mount a foot, in the foot's
+    frame (z=0 mounting face, pad center at origin, screw side local
+    -y): a blind M3_TAP pilot the screw thread-forms (clamp stack =
+    head -> foot -> host threads, so BOTH parts are clamped; a nut
+    pocketed here reacted against the foot's own roof and left the
+    host floating 0.2 - caught on the printed base), 45 entry cone,
+    end 5.6 up (M3x10 tip 5.3), and a coned pin socket. Both the jig
+    base and the box consume this."""
+    c = Pos(0, -FOOT_SCREW_OFF, -0.1) * Cylinder(
+        M3_TAP / 2, 5.7,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    c += Pos(0, -FOOT_SCREW_OFF, -0.1) * Cone(
+        M3_FREE / 2, M3_TAP / 2, (M3_FREE - M3_TAP) / 2 + 0.1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    r = FOOT_PIN_D / 2 + FIT_STD
+    c += Pos(0, -FOOT_PIN_OFF, -0.1) * Cylinder(
+        r, FOOT_PIN_H + 0.3,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    c += Pos(0, -FOOT_PIN_OFF, FOOT_PIN_H + 0.2) * Cone(
+        r, 0, r, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    return c
+
+
+def build_foot(hook=False) -> Part:
+    p = Pos(0, -FOOT_SCREW_OFF / 2, -FOOT_H) * extrude(
+        SlotOverall(FOOT_L, FOOT_W, rotation=90), FOOT_H)
+    p = chamfer(p.edges().group_by(Axis.Z)[0], 1.0)
+    if hook:
+        n = _box(-HOOK_W / 2, HOOK_W / 2, FOOT_W / 2 - 2.5,
+                 FOOT_W / 2 + HOOK_REACH, -FOOT_H, -FOOT_H + HOOK_H)
+        top_rear = n.edges().group_by(Axis.Y)[-1].group_by(Axis.Z)[-1]
+        p += chamfer(top_rear, 1.2)
+    pin = Pos(0, -FOOT_PIN_OFF) * Cylinder(
+        FOOT_PIN_D / 2, FOOT_PIN_H,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p += chamfer(pin.edges().group_by(Axis.Z)[-1], 0.5)
+
+    # pad station: through bore, the stop ring seats the pad's flare
+    p -= Pos(0, 0, -FOOT_H) * (recess_cutter() + stop_ring())
+    p -= Pos(0, 0, -FOOT_H + PAD_RECESS + PAD_STOP - 0.05) * Cylinder(
+        PAD_BORE_R, FOOT_H + 0.1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    # screw station: head well from below, cone ring up to the free
+    # hole - every internal face 45 deg or vertical
+    ring = (BTN_CBORE_D - M3_FREE) / 2
+    p -= Pos(0, -FOOT_SCREW_OFF, -FOOT_H - 0.1) * Cylinder(
+        BTN_CBORE_D / 2, BTN_CBORE + 0.1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p -= Pos(0, -FOOT_SCREW_OFF, -FOOT_H + BTN_CBORE - 0.05) * Cone(
+        BTN_CBORE_D / 2 + 0.05, M3_FREE / 2, ring + 0.05,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p -= Pos(0, -FOOT_SCREW_OFF, -FOOT_H + BTN_CBORE + ring - 0.1) * \
+        Cylinder(M3_FREE / 2, FOOT_H + 0.2,
+                 align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+    p.label = "stenciljig_hookfoot" if hook else "stenciljig_foot"
+    p.color = GREY
+    return p

--- a/mechanical/stenciljig/knob.py
+++ b/mechanical/stenciljig/knob.py
@@ -1,0 +1,120 @@
+"""Cam bolt for the stack lock, two printed parts on an M3x16 spine:
+drop the T through the base keyhole and the box's entry slot, quarter
+turn clockwise to the stop. The cam ramp lives in the BOX (descending
+ceiling tents, box.py); the rod carries the follower: a 45 deg
+tapered roof on the wing whose faces seat flat on those tents,
+drawing the handle down onto the keyhole's side strips.
+
+Split so each part prints in its strong pose (a one-piece knob either
+lies down and loses the full-circle head, or stands head-down with
+every weld across the tension path):
+- rod prints standing as modeled: wing root bending and the cam
+  faces stay in-plane, the roof prints as a clean 45 tent
+- handle prints flat: a full scallop circle bearing on the keyhole
+  strips across its layers, top unbroken but for the steel head and
+  the T groove
+- the spine self-taps TAP_ENGAGE into the wing root (M3_TAP pilot)
+  and carries all cam tension in steel; plastic only sees
+  compression, bearing and torque. The two-flat boss keys the
+  torque, and being 2-fold like the T, the top groove always marks
+  the T direction. No nut anywhere in the knob.
+
+Modeled installed, z=0 at the handle underside = base top. One knob
+serves both sides - the box cuts both cavities at the same absolute
+angles. Between stackings it lives in the hardware bin."""
+import math
+
+from build123d import *
+
+from stenciljig.common import (_box, BASE_T, BTN_CBORE, BTN_CBORE_D,
+                               CAM_CLEAR, CAM_LID, CAM_TENT, FIT_LOOSE,
+                               M3_FREE, M3_HOLE, M3_TAP, GREEN)
+
+CAM_T = (16.0, 7.0)        # T-bar plan slot
+CAM_T_ROOT = 6.0           # wing slab under the roof
+CAM_SHAFT = 7.0
+CAM_LEAD = -(BASE_T + CAM_LID + CAM_CLEAR)
+                           # wing roof-edge plane when the handle
+                           # sits on the base top
+
+HANDLE_D = 18.0            # bears on the keyhole's side strips
+HANDLE_T = 4.5
+BOSS_W = 5.0               # torque key flats; the boss is the shaft
+                           # circle with two flats so its arcs continue
+                           # the shaft surface (a slot merely tangent
+                           # at +/-x welds a degenerate seam - the
+                           # mesher drops faces, open neck)
+BOSS_H = 2.1
+SOCKET_FIT = FIT_LOOSE     # socket offset; the socket is also 0.1
+                           # deeper so the spine clamps handle to
+                           # shaft shoulder, never boss top to web
+SPINE_L = 16.0             # the house M3x16
+SEAT_Z = HANDLE_T - BTN_CBORE      # head seat in the handle
+TIP_Z = SEAT_Z - SPINE_L           # 1.95 shy of the wing underside
+TAP_ENGAGE = 6.0           # threads formed across shaft + wing root
+
+PRINT = None               # both parts model in their print pose
+
+
+def t_slot():
+    """T-bar plan profile: base keyhole and box entry slot are offsets
+    of this."""
+    return SlotOverall(*CAM_T)
+
+
+def boss_profile():
+    """Double-D torque key, 2-fold like the T; the handle socket is an
+    offset of this."""
+    return Circle(CAM_SHAFT / 2) & Rectangle(CAM_SHAFT + 1, BOSS_W)
+
+
+def build_rod() -> Part:
+    p = Cylinder(CAM_SHAFT / 2, -CAM_LEAD,
+                 align=(Align.CENTER, Align.CENTER, Align.MAX))
+    p += Pos(0, 0, CAM_LEAD - CAM_T_ROOT) * extrude(t_slot(), CAM_T_ROOT)
+    # follower roof: same tent as the box ceiling, faces seat flat
+    p += Pos(0, 0, CAM_LEAD) * extrude(t_slot(), CAM_TENT, taper=45)
+    # keyhole entry lead on the wing's leading face
+    p = chamfer(p.edges().group_by(Axis.Z)[0], 0.8)
+    p += extrude(boss_profile(), BOSS_H)
+    p = chamfer(p.edges().group_by(Axis.Z)[-1], 0.5)
+    p -= Pos(0, 0, BOSS_H) * Cylinder(
+        M3_HOLE / 2, BOSS_H - (TIP_Z + TAP_ENGAGE),
+        align=(Align.CENTER, Align.CENTER, Align.MAX))
+    p -= Pos(0, 0, TIP_Z + TAP_ENGAGE) * Cylinder(
+        M3_TAP / 2, TAP_ENGAGE + 0.5,
+        align=(Align.CENTER, Align.CENTER, Align.MAX))
+    p.label = "stenciljig_knob_rod"
+    p.color = GREEN
+    return p
+
+
+def build_handle() -> Part:
+    p = Cylinder(HANDLE_D / 2, HANDLE_T,
+                 align=(Align.CENTER, Align.CENTER, Align.MIN))
+    for i in range(8):
+        a = math.radians(i * 45 + 22.5)
+        p -= Pos(9.0 * math.cos(a), 9.0 * math.sin(a), -0.1) * \
+            Cylinder(1.3, HANDLE_T + 0.2,
+                     align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p = chamfer(p.edges().group_by(Axis.Z)[-1], 0.5)
+    p = chamfer(p.edges().group_by(Axis.Z)[0], 0.3)
+    # T-direction groove, interrupted by the spine head
+    p -= _box(-7.5, 7.5, -0.6, 0.6, HANDLE_T - 0.6, HANDLE_T + 0.1)
+    p -= extrude(offset(boss_profile(), SOCKET_FIT), BOSS_H + 0.1)
+    p -= Cylinder(M3_FREE / 2, 2 * HANDLE_T)
+    p -= Pos(0, 0, SEAT_Z) * Cylinder(
+        BTN_CBORE_D / 2, BTN_CBORE + 0.1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p.label = "stenciljig_knob_handle"
+    p.color = GREEN
+    return p
+
+
+def build_knob() -> Part:
+    """Assembled rod + handle (they fuse at the z=0 shoulder) for
+    scenes and interference checks - not a print."""
+    p = build_rod() + build_handle()
+    p.label = "stenciljig_knob"
+    p.color = GREEN
+    return p

--- a/mechanical/stenciljig/nutbar.py
+++ b/mechanical/stenciljig/nutbar.py
@@ -1,0 +1,39 @@
+"""T-nut bar: slides flat against the base underside carrying the
+two side-plate nuts, one per rail row. Hex pockets open DOWN in the
+working pose - press the nuts up in from below, the screws retain
+them after that. Clamp tension pulls each nut up into the 2 mm web,
+the web presses the base, the plate presses down from above: base
+sandwiched, nothing to spin or rip out.
+
+Exports flipped: printed web-down the pockets open upward, so the
+part has no down-faces at all. Print 2, same part both sides;
+modeled under the right plate at max opening."""
+from build123d import *
+
+from stenciljig.common import (_hex, _plate, M3_FREE, NUT_PRESS_AF,
+                               SLOT_X0, SLOT_Y, BLACK)
+
+BAR_W = 12.0               # cross-section under the base
+BAR_L = 60.0               # spans both rail rows (nuts at SLOT_Y)
+                           # with a solid block past each pocket -
+                           # 48 left 2 perimeters at the ends
+BAR_T = 6.0                # 2 web + 2.4 nut + tip room; sweeps 7
+                           # over the stacked box's deck
+BAR_WEB = 2.0              # roof between nut and base underside
+
+PRINT = Rotation(180, 0, 0)  # web down, pockets opening up
+
+
+def build_nutbar() -> Part:
+    xc = SLOT_X0                            # under the ear holes at
+    yc = (SLOT_Y[0] + SLOT_Y[1]) / 2        # max opening
+    p = Pos(xc, yc, -BAR_T) * _plate(BAR_W, BAR_L, BAR_T, 3.0, 0.5)
+    for y in SLOT_Y:
+        p -= Pos(xc, y, -BAR_T - 0.1) * extrude(
+            _hex(NUT_PRESS_AF), BAR_T - BAR_WEB + 0.1)
+        p -= Pos(xc, y, -BAR_T - 0.1) * Cylinder(
+            M3_FREE / 2, BAR_T + 0.2,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p.label = "stenciljig_nutbar"
+    p.color = BLACK
+    return p

--- a/mechanical/stenciljig/pad.py
+++ b/mechanical/stenciljig/pad.py
@@ -1,0 +1,68 @@
+"""TPU desk pad + the recess profiles every host part reuses. The pad
+snaps stem-first through an hourglass throat - captive by geometry,
+peels out with a fingernail. One model serves the jig's feet and the
+box floor: print 8 in TPU, exported FLIPPED - the retention flare's
+full 14 disc lands on the bed (best TPU adhesion, and its 45 cone
+turns into a shrinking dome instead of an overhang); the desk face
+prints as the top skin."""
+from build123d import *
+
+from stenciljig.common import GREY
+
+PAD_D = 14.0               # pad rim / recess interior
+PAD_LIP = 0.6              # throat squeeze per side; also the 45 deg
+                           # flare heights either side of the throat
+PAD_H = 4.0
+PAD_PROUD = 2.0            # rubber, not PETG, meets the desk
+PAD_RECESS = PAD_H - PAD_PROUD
+PAD_STOP = 1.0             # 45 deg shoulder ring above the recess: in
+                           # the foot the pad bore runs through (no
+                           # ceiling to print), the ring is what the
+                           # pad's flare seats against
+PAD_BORE_R = PAD_D / 2 - PAD_STOP
+
+PRINT = Rotation(180, 0, 0)  # flare down, desk face up
+
+
+def recess_cutter():
+    """Hourglass recess: entry funnel, PAD_LIP throat, retention
+    flare, all 45 deg. z=0 at the opening face, material above. The
+    ceiling at PAD_RECESS is OPEN - close it with stop_ring() (foot:
+    through-bore above) or stop_cone() (box: blind, cones shut)."""
+    r = Pos(0, 0, -0.1) * Cone(
+        PAD_D / 2 + 0.1, PAD_D / 2 - PAD_LIP, PAD_LIP + 0.1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    r += Pos(0, 0, PAD_LIP) * Cone(
+        PAD_D / 2 - PAD_LIP, PAD_D / 2, PAD_LIP,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    r += Pos(0, 0, 2 * PAD_LIP - 0.05) * Cylinder(
+        PAD_D / 2, PAD_RECESS - 2 * PAD_LIP + 0.05,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    return r
+
+
+def stop_ring():
+    """45 deg ring closing the recess down to the through-bore (base
+    radius 0.05 proud so no flat sliver survives the union)."""
+    return Pos(0, 0, PAD_RECESS - 0.05) * Cone(
+        PAD_D / 2 + 0.05, PAD_BORE_R, PAD_STOP + 0.05,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+
+def stop_cone():
+    """45 deg cone closing a blind recess to a point (box floor)."""
+    return Pos(0, 0, PAD_RECESS - 0.05) * Cone(
+        PAD_D / 2 + 0.05, 0, PAD_D / 2 + 0.05,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+
+def build_pad() -> Part:
+    p = Cylinder(PAD_D / 2 - PAD_LIP, PAD_H - PAD_LIP,
+                 align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p += Pos(0, 0, PAD_H - PAD_LIP) * Cone(
+        PAD_D / 2 - PAD_LIP, PAD_D / 2, PAD_LIP,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    p = chamfer(p.edges().group_by(Axis.Z)[0], 0.3)
+    p.label = "stenciljig_pad"
+    p.color = GREY
+    return p

--- a/mechanical/stenciljig/qa/assembly_scene.py
+++ b/mechanical/stenciljig/qa/assembly_scene.py
@@ -1,0 +1,204 @@
+"""Export assembly glbs for the two-part stack:
+- assembly_stacked.glb: full jig locked onto the stocked box (knobs
+  turned, hooks latched), box keyed blue for transparency
+- assembly_apart.glb: working layout - jig standing on its feet
+  beside the open box
+Colors are keys for render_assembly.py: box (0.45,0.58,0.75) renders
+see-through, side plates (0.35,0.37,0.40) half-transparent (ghost
+scenes only - "real" keeps every plastic its true print color)."""
+import pathlib
+
+from bd_warehouse.fastener import ButtonHeadScrew, HexNut
+from build123d import *
+
+from stenciljig.adapter import build_adapter, AD_CBORE
+from stenciljig.base import build_base
+from stenciljig.box import (build_box, AD_D, AD_XS, AD_Z, BAY_D,
+                            BAY_Y1, BOX_FOOT_POSE, BOX_H, EXT,
+                            FLOOR_Z, PKT, SHEET, SHEET_Z, SQ_XY0)
+from stenciljig.clamp_plate import build_clamp_plate
+from stenciljig.common import (foot_pt, AD_SCREW_Y, BASE_T, CAM_XY,
+                               CAP_T, CLAMP_T, COL_X, COL_Y, FOOT_H,
+                               FOOT_INSET, FOOT_POSE, FOOT_SCREW_OFF,
+                               LEDGE, PCB_TOP, PCB_W, PLATE_H,
+                               PLATE_YC, SIDE_W, SLOT_X0,
+                               SLOT_Y, BASE_D)
+from stenciljig.foot import build_foot
+from stenciljig.knob import build_knob, HANDLE_T, SEAT_Z
+from stenciljig.nutbar import build_nutbar
+from stenciljig.pad import build_pad, PAD_PROUD
+from stenciljig.side_plate import build_side_plate, EAR_T
+from stenciljig.squeegee import build_squeegee, SQ_SIZES
+from stenciljig.tray import build_tray
+
+OUT = pathlib.Path("stenciljig/build")
+BOX_C = Color(0.45, 0.58, 0.75)
+PLATE_C = Color(0.35, 0.37, 0.40)
+STEEL = Color(0.75, 0.76, 0.78)
+
+box = build_box()
+box.color = BOX_C
+knob = build_knob()
+pad = build_pad()
+
+_SCREWS = {}
+
+
+def screw(x, y, z_seat, length, up=False):
+    """ISO 7380 M3 button head (bd_warehouse, threaded): seat plane
+    lands at z_seat, shank down (up=True flips it shank-up for the
+    from-below foot screws)."""
+    if length not in _SCREWS:
+        _SCREWS[length] = ButtonHeadScrew(
+            size="M3-0.5", length=length,
+            fastener_type="iso7380_1", simple=False)
+    q = Pos(x, y, z_seat) * (Rot(180, 0, 0) if up else Rot(0, 0, 0)) \
+        * _SCREWS[length]
+    q.color = STEEL
+    return q
+
+
+NUT = HexNut(size="M3-0.5", fastener_type="iso4032")
+
+
+def nut(pose):
+    q = pose * NUT
+    q.color = STEEL
+    return q
+
+
+def jig_parts(locked, real=False):
+    """Base + feet + plates + bars + clamp + knobs + screws + foot
+    pads, in the standard frame (base underside z=0). Ghost scenes
+    key the side plates half-transparent so the captive nuts read."""
+    parts = [build_base()]
+    for b in (build_side_plate, build_nutbar):
+        q = b()
+        if b is build_side_plate and not real:
+            q.color = PLATE_C
+        m = mirror(q, Plane.YZ)
+        m.color = q.color
+        parts += [q, m]
+    # planks rotate (not mirror) to the left hand - same edge inboard,
+    # labels stay right-reading
+    q = build_adapter(1.6, 1.0)
+    m = Pos(0, 2 * PLATE_YC, 0) * Rot(0, 0, 180) * q
+    m.color = q.color
+    parts += [q, m]
+    parts.append(build_clamp_plate())
+    if locked:
+        for s in (1, -1):
+            at = Pos(s * CAM_XY[0], CAM_XY[1], BASE_T)
+            k = at * Rot(0, 0, -90) * knob
+            k.color = knob.color
+            parts.append(k)
+            parts.append(screw(s * CAM_XY[0], CAM_XY[1],
+                               BASE_T + SEAT_Z, 16))
+    foot, hookfoot = build_foot(), build_foot(True)
+    for x, y, a, hook in FOOT_POSE:
+        f = Pos(x, y, 0) * Rot(0, 0, a) * (hookfoot if hook else foot)
+        f.color = foot.color
+        parts.append(f)
+        q = Pos(x, y, -FOOT_H - PAD_PROUD) * pad
+        q.color = pad.color
+        parts.append(q)
+        sx, sy = foot_pt(x, y, a, FOOT_SCREW_OFF)
+        parts.append(screw(sx, sy, -4.7, 10, up=True))
+    xc = PCB_W / 2 - LEDGE + SIDE_W / 2
+    for s in (1, -1):
+        for y in SLOT_Y:
+            parts.append(screw(s * SLOT_X0, y, BASE_T + EAR_T, 16))
+            # nut-bar nut, pressed up under the 2 web
+            parts.append(nut(Pos(s * SLOT_X0, y, -4.4)))
+        for y in COL_Y:
+            parts.append(screw(s * COL_X, y,
+                               PCB_TOP + CLAMP_T - 1.7, 16))
+            # clamp nut seated in its bottom-entry press band
+            parts.append(nut(Pos(s * COL_X, y, PCB_TOP - 5.0)))
+        # plank screws down into the broached-up pocket nuts
+        for y in AD_SCREW_Y:
+            parts.append(screw(s * xc, y, PCB_TOP - AD_CBORE, 10))
+            parts.append(nut(Pos(s * xc, y, 14.3 - 2.4)))
+    return parts
+
+
+def contents(with_knobs=False):
+    parts = []
+    if with_knobs:
+        # between stackings the knobs live head-down in the bin
+        for x in (32.0, 55.0):
+            at = Pos(x, 16.0, FLOOR_Z + HANDLE_T) * Rot(180, 0, 0)
+            k = at * knob
+            k.color = knob.color
+            parts.append(k)
+            q = at * Pos(0, 0, SEAT_Z) * screw(0, 0, 0, 16)
+            q.color = STEEL
+            parts.append(q)
+    # the 6 unmounted planks on edge, 3 in each wall-side crate (the
+    # 1.6/1.0 pair rides the jig); pairs kept together per side
+    for x0, (ta, tb) in zip(AD_XS, ((1.2, 0.8), (1.2, 0.8),
+                                    (0.6, 0.4), (0.6, 0.4),
+                                    (2.0, 1.6), (2.0, 1.6))):
+        ad = Rot(0, 90, 0) * build_adapter(ta, tb)
+        bb = ad.bounding_box()
+        q = Pos(x0 + PKT - bb.min.X,
+                BAY_Y1 - AD_D + PKT - bb.min.Y, AD_Z - bb.min.Z) * ad
+        q.color = ad.color
+        parts.append(q)
+    x0, y0 = SQ_XY0
+    for w, k in SQ_SIZES:
+        sq = build_squeegee(w, k)
+        bb = sq.bounding_box()
+        q = Pos(x0 + PKT - bb.min.X, y0 + PKT - bb.min.Y,
+                FLOOR_Z - bb.min.Z) * sq
+        q.color = sq.color
+        parts.append(q)
+        x0 += (w - 1 + 2 * 2.5 + 2 * PKT) + 2.4
+    for i in range(4):
+        sh = Pos(-BAY_D / 2 + PKT, BAY_Y1 - SHEET - PKT,
+                 SHEET_Z + i * 0.15) * Box(
+            SHEET, SHEET, 0.12, align=(Align.MIN, Align.MIN, Align.MIN))
+        sh.color = Color(0.75, 0.76, 0.78)
+        parts.append(sh)
+    tr = build_tray()
+    q = Pos(0, BAY_Y1 - BAY_D / 2, FLOOR_Z) * tr
+    q.color = tr.color
+    parts.append(q)
+    # the box stands on the same screw-on feet as the jig
+    foot = build_foot()
+    for x, y, a in BOX_FOOT_POSE:
+        f = Pos(x, y, -BOX_H) * Rot(0, 0, a) * foot
+        f.color = foot.color
+        parts.append(f)
+        q = Pos(x, y, -BOX_H - FOOT_H - PAD_PROUD) * pad
+        q.color = pad.color
+        parts.append(q)
+        sx, sy = foot_pt(x, y, a, FOOT_SCREW_OFF)
+        parts.append(screw(sx, sy, -BOX_H - 4.7, 10, up=True))
+    return parts
+
+
+def export(name, parts):
+    comp = Compound(children=parts)
+    export_gltf(comp, str(OUT / name), binary=True)
+    print(f"{name}: {len(parts)} parts")
+
+
+export("assembly_stacked.glb", [box] + contents() + jig_parts(True))
+
+
+def apart_layout(box_part, real=False):
+    """Working layout: jig on its feet beside the open box. Bench
+    plane = the box feet's pad bottoms; the jig's own stance is
+    identical, so the side-by-side offset is exactly -BOX_H."""
+    parts = [box_part] + contents(with_knobs=True)
+    for q in jig_parts(False, real):
+        m = Pos(2 * EXT + 40.0, 0, -BOX_H) * q
+        m.color = q.color
+        parts.append(m)
+    return parts
+
+
+export("assembly_apart.glb", apart_layout(box))
+# true print colors: orange box, black plates
+export("assembly_real.glb", apart_layout(build_box(), real=True))

--- a/mechanical/stenciljig/qa/check_all.py
+++ b/mechanical/stenciljig/qa/check_all.py
@@ -1,0 +1,312 @@
+"""Full boolean check suite for the refactored stenciljig package:
+jig assembly (plate/adapter/board both edges), plank screw + captive
+nut path, center nut vs tongue, the two-part stack (feet, hooks,
+cam), box tenants. Everything asserts; run from mechanical/ with
+PYTHONPATH=. .venv/bin/python <this>."""
+from build123d import *
+
+from stenciljig.adapter import build_adapter, AD_CBORE
+from stenciljig.box import (build_box, AD_D, AD_XS, AD_SLOT_W,
+                            AD_SLOTS, AD_Z, BAY_D, BAY_Y1, BOX_H,
+                            EXT, FLOOR_Z, HW_BIN, PKT, SHEET,
+                            SHEET_Z, SQ_XY0)
+from stenciljig.base import build_base
+from stenciljig.clamp_plate import build_clamp_plate
+from stenciljig.common import (_hex, foot_pt, AD_SCREW_Y, BASE_D,
+                               BASE_T, BORDER, BTN_H, CAM_XY, CAP_T,
+                               COL_X, COL_Y, FOOT_H, FOOT_INSET,
+                               FOOT_POSE, FOOT_SCREW_OFF, LEDGE,
+                               LEDGE_PROUD, M3_NUT_T, MID_Y, NUT_AF,
+                               PCB_D, PCB_T, PCB_TOP, PCB_W, PLATE_H,
+                               PLATE_YC, RAIL_DROP, SIDE_W,
+                               SLOT_LEN, TONGUE_CLEAR)
+from stenciljig.foot import build_foot
+from stenciljig.knob import (build_handle, build_knob, build_rod,
+                             SEAT_Z, TAP_ENGAGE, TIP_Z)
+from stenciljig.nutbar import build_nutbar
+from stenciljig.pad import build_pad, PAD_PROUD
+from stenciljig.side_plate import EAR_L, EAR_T
+from stenciljig.squeegee import build_squeegee, SQ_SIZES
+from stenciljig.tongue import build_tongue
+from stenciljig.tray import build_tray, TRAY_FLOOR
+
+from stenciljig.side_plate import build_side_plate
+
+base = build_base()
+plate = build_side_plate()
+ad = build_adapter(1.6, 1.0)
+box = build_box()
+knob = build_knob()
+rod, handle = build_rod(), build_handle()
+foot, hookfoot = build_foot(), build_foot(True)
+bar = build_nutbar()
+pad = build_pad()
+tongue = build_tongue()
+clamp = build_clamp_plate()
+tray = build_tray()
+
+
+def vol(a):
+    try:
+        return a.volume if a.solids() else 0.0
+    except Exception:
+        return 0.0
+
+
+for part in (base, plate, ad, box, knob, rod, handle, foot, hookfoot,
+             bar, pad, tongue, clamp, tray):
+    n = len(part.solids())
+    assert n == 1, (part.label, n)
+print("connectivity:           every part is 1 solid")
+
+xc = (PCB_W / 2 - LEDGE) + SIDE_W / 2
+face_x = PCB_W / 2 - LEDGE + SIDE_W
+
+# --- jig assembly (old check_jig) ---
+# self-rotation lands the ears inboard and the nut-channel mouths
+# outboard, so only the BODY is self-symmetric; the working
+# both-hands proof is the left-station pose further down
+q = Pos(2 * xc, 2 * PLATE_YC, 0) * Rot(0, 0, 180) * plate
+d = vol(plate - q) + vol(q - plate)
+assert d < 3200.0, d
+adflip = Pos(2 * xc, 2 * PLATE_YC, 0) * Rot(0, 0, 180) * ad
+for name, a, b in (("plate^base", plate, base),
+                   ("adapter^plate", ad, plate),
+                   ("adapter^base", ad, base),
+                   ("adflip^plate", adflip, plate),
+                   ("plate^base mid", Pos(-25, 0, 0) * plate, base),
+                   ("plate^base closed", Pos(-SLOT_LEN, 0, 0) * plate,
+                    base),
+                   ("plate^base out", Pos(30, 0, 0) * plate, base)):
+    v = vol(a & b)
+    assert v == 0.0, (name, v)
+v = vol(Pos(0, 0, 1) * plate & base)
+assert v > 0.0, v
+lift = Pos(0, 0, RAIL_DROP + 0.2) * plate
+assert vol(lift & base) > 0.0
+left = Pos(0, PLATE_YC, 0) * Rot(0, 0, 180) * Pos(0, -PLATE_YC, 0) * plate
+assert vol(left & base) == 0.0
+assert vol(Pos(0, 0, RAIL_DROP + 0.2) * left & base) > 0.0
+probe = Pos(face_x + EAR_L / 2, PLATE_YC, BASE_T + 1.0) * Box(
+    4, 4, EAR_T - 1.2, align=(Align.CENTER, Align.CENTER, Align.MIN))
+assert vol(probe & plate) == 0.0
+# fully closed: both plates ride to the centerline, faces kiss
+rc = Pos(-SLOT_LEN, 0, 0) * plate
+lc = Pos(SLOT_LEN, 0, 0) * Pos(0, 2 * PLATE_YC, 0) * Rot(0, 0, 180) \
+    * plate
+v = vol(rc & lc)
+assert v < 0.05, v
+for t, meas, a in ((1.6, 1.579, ad), (1.0, 0.98, adflip)):
+    board = Pos(0, BORDER + PCB_D / 2, PCB_TOP - (t - LEDGE_PROUD)) * Box(
+        100, 100, meas, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    assert vol(board & a) == 0.0 and vol(board & plate) == 0.0
+    assert vol(Pos(0, -30, 0) * board & a) == 0.0
+print("jig assembly:           flip/slide/lift-block/board both edges ok")
+
+# --- plank screws: shank + head path, nut seats press, hopper holds ---
+floor_z = 14.3 - M3_NUT_T          # nut seated under the hopper
+for y in AD_SCREW_Y:
+    shank = Pos(xc, y, PCB_TOP - AD_CBORE - 10.0) * Cylinder(
+        1.5, 10.0, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    head = Pos(xc, y, PCB_TOP - AD_CBORE) * Cylinder(
+        2.85, BTN_H, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    nut = Pos(xc, y, floor_z) * extrude(_hex(NUT_AF), M3_NUT_T)
+    v = vol(shank & ad) + vol(shank & plate) + vol(head & ad) \
+        + vol(nut & ad)
+    assert v == 0.0, (y, v)
+    bite = vol(nut & plate)            # press band: exact at nominal
+    assert bite < 0.05, (y, bite)
+    drop = vol(Pos(0, 0, -4.0) * nut & plate)  # loose shaft passes it
+    assert drop < 0.05, (y, drop)
+    roof = vol(Pos(0, 0, 1.2) * nut & plate)   # hopper blocks pull-up
+    assert roof > 2.0, (y, roof)
+    tap = vol(shank & nut)
+    assert tap > 15.0, (y, tap)
+print("plank screws:           M3x10 path clear, nut seats press, "
+      "hopper retains")
+
+# --- clamp nuts: bottom-entry seats, hoppers hold, screws + tongue ---
+gfloor = PCB_TOP - PCB_T - TONGUE_CLEAR
+for (x, y), top in (((0.0, MID_Y), gfloor),
+                    ((COL_X, COL_Y[0]), PCB_TOP),
+                    ((-COL_X, COL_Y[1]), PCB_TOP)):
+    seat = top - 2.6
+    nut = Pos(x, y, seat - M3_NUT_T) * extrude(_hex(NUT_AF), M3_NUT_T)
+    v = vol(nut & base)
+    assert v < 0.05, (x, y, v)         # press band: exact at nominal
+    drop = vol(Pos(0, 0, -6.0) * nut & base)   # loose shaft passes it
+    assert drop < 0.05, (x, y, drop)
+    roof = vol(Pos(0, 0, 1.2) * nut & base)    # hopper blocks pull-up
+    assert roof > 2.0, (x, y, roof)
+    # M3x16 from the clamp seat: shank clear down to 0.5 past the nut
+    shank = Pos(x, y, seat - M3_NUT_T - 0.5) * Cylinder(
+        1.5, PCB_TOP + 6.0 - (seat - M3_NUT_T - 0.5),
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    vs = vol(shank & base) + vol(shank & clamp)
+    assert vs == 0.0, (x, y, vs)
+assert vol(tongue & base) == 0.0 and vol(clamp & base) == 0.0
+cnut = Pos(0, MID_Y, gfloor - 2.6 - M3_NUT_T) * extrude(_hex(NUT_AF),
+                                                        M3_NUT_T)
+assert vol(tongue & cnut) == 0.0       # centre nut under groove floor
+print("clamp nuts + tongue:    seat press, hoppers hold, screws "
+      "clear, tongue passes over")
+
+# --- feet mounted: pin seats, screw core clear, thread zone bites ---
+worst = 0.0
+posed_feet = []
+for x, y, a, hook in FOOT_POSE:
+    f = Pos(x, y, 0) * Rot(0, 0, a) * (hookfoot if hook else foot)
+    posed_feet.append(f)
+    worst = max(worst, vol(f & base))
+    sx, sy = foot_pt(x, y, a, FOOT_SCREW_OFF)
+    # M3x10 from below: head seat -4.7, tip 5.3 - core (minor dia)
+    # passes free, thread envelope bites the host pilot
+    shank = Pos(sx, sy, -4.6) * Cylinder(
+        1.2, 9.9, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    head = Pos(sx, sy, -4.7 - BTN_H) * Cylinder(
+        2.85, BTN_H, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    vp = vol(shank & base) + vol(shank & f) + vol(head & f)
+    assert vp == 0.0, (x, y, vp)
+    bite = vol(Pos(sx, sy, 0.4) * Cylinder(
+        1.6, 4.9, align=(Align.CENTER, Align.CENTER, Align.MIN)) & base)
+    assert bite > 4.0, (x, y, bite)
+assert worst < 0.05, worst
+print(f"4 feet mounted:         kiss max {worst:.4f}, taps bite, "
+      f"M3x10 path clear")
+
+# --- the stack: rig seated / tilted / hooked on the box ---
+rig = base + posed_feet
+v = vol(rig & box)
+assert v == 0.0, v
+print(f"rig seated on box:      {v:.4f} (want 0)")
+tilt = Pos(0, 169.5, 0) * Rot(-1.5, 0, 0) * Pos(0, -169.5, 0) * rig
+v = vol(tilt & box)
+assert v == 0.0, v
+print(f"rig tilted 1.5 deg:     {v:.4f} (want 0)")
+grab = vol(Pos(0, 0, 1.0) * rig & box)
+assert grab > 0.0, grab
+print(f"hooks catch lift +1:    overlap {grab:.2f} > 0")
+
+# --- cam knobs: entry drops free, locked seats under the tents ---
+for s in (1, -1):
+    at = Pos(s * CAM_XY[0], CAM_XY[1], BASE_T)
+    ke, kl = at * knob, at * Rot(0, 0, -90) * knob
+    khalf = at * Rot(0, 0, -45) * knob
+    ve = vol(ke & base) + vol(ke & box)
+    assert ve == 0.0, (s, ve)
+    vl_ba, vl_bo = vol(kl & base), vol(kl & box)
+    assert vl_ba == 0.0, (s, vl_ba)
+    assert 0.02 < vl_bo < 5.0, (s, vl_bo)
+    print(f"knob {s:+d}: entry free, mid {vol(khalf & box):.3f}, "
+          f"locked bite {vl_bo:.3f} (want 0.02..5)")
+at = Pos(CAM_XY[0], CAM_XY[1], BASE_T)
+for k in (at * knob, at * Rot(0, 0, -90) * knob):
+    v = vol(k & plate)
+    assert v == 0.0, v
+print("knob^plate max opening: 0 both poses")
+
+# --- knob spine: boss fits, pilot clear, tap zone bites, head sinks ---
+v = vol(rod & handle)
+assert v == 0.0, v
+pilot = Pos(0, 0, SEAT_Z) * Cylinder(
+    1.4, SEAT_Z - TIP_Z + 0.1, align=(Align.CENTER, Align.CENTER, Align.MAX))
+vp = vol(pilot & handle) + vol(pilot & rod)
+assert vp == 0.0, vp
+bite = Pos(0, 0, TIP_Z + TAP_ENGAGE) * Cylinder(
+    1.6, TAP_ENGAGE, align=(Align.CENTER, Align.CENTER, Align.MAX))
+vb = vol(bite & rod)
+assert vb > 5.0, vb
+headp = Pos(0, 0, SEAT_Z) * Cylinder(
+    2.9, BTN_H, align=(Align.CENTER, Align.CENTER, Align.MIN))
+vh = vol(headp & handle)
+assert vh == 0.0, vh
+print(f"knob spine:             boss free, pilot clear, "
+      f"tap bite {vb:.1f} mm^3, head sinks")
+
+# --- nut-bar sweep over the stacked box ---
+for s in (1, -1):
+    for dx in (0.0, -SLOT_LEN):
+        b = Pos(dx, 0, 0) * bar
+        if s < 0:
+            b = mirror(b, Plane.YZ)
+        v = vol(b & box)
+        assert v == 0.0, (s, dx, v)
+print("nut bars ^box:          0 at both extremes, both sides")
+
+# --- box tenants + stacked pads ---
+pads = [Pos(x, y, -FOOT_H - PAD_PROUD) * pad for x, y, a, h in FOOT_POSE]
+tenants = []
+adl = Rot(0, 90, 0) * ad
+bb = adl.bounding_box()
+worst = 0.0
+for x0 in AD_XS:
+    q = Pos(x0 + PKT - bb.min.X,
+            BAY_Y1 - AD_D + PKT - bb.min.Y, AD_Z - bb.min.Z) * adl
+    worst = max(worst, vol(q & box))
+    ptop = q.bounding_box().max.Z
+    assert abs(ptop - (AD_Z + SIDE_W)) < 0.01, ptop
+    tenants.append(q)
+assert worst == 0.0, worst
+print(f"{AD_SLOTS} planks in slots:      ^box 0, "
+      f"tops at {AD_Z + SIDE_W:.1f}")
+# tray on the bay's side ledges, flush with the rim
+tp = Pos(0, BAY_Y1 - BAY_D / 2, FLOOR_Z) * tray
+v = vol(tp & box)
+assert v == 0.0, v
+assert abs(tp.bounding_box().max.Z - (-13.0)) < 0.01
+tenants.append(tp)
+# a stack of 50x50 boards in the tray - tops must clear the
+# stacked jig's base underside (z=0) with margin
+stack = Pos(-25.0, BAY_Y1 - BAY_D / 2 - 25.0, FLOOR_Z + TRAY_FLOOR) * Box(
+    50, 50, 16.0, align=(Align.MIN, Align.MIN, Align.MIN))
+v = vol(stack & box) + vol(stack & tp)
+assert v == 0.0, v
+assert stack.bounding_box().max.Z <= -1.0
+tenants.append(stack)
+print("tray on ledges + 50x50 board stack inside: ^box 0, "
+      "under the stacked base")
+x0, y0 = SQ_XY0
+for w, k in SQ_SIZES:
+    sq = build_squeegee(w, k)
+    bb = sq.bounding_box()
+    q = Pos(x0 + PKT - bb.min.X, y0 + PKT - bb.min.Y,
+            FLOOR_Z - bb.min.Z) * sq
+    v = vol(q & box)
+    assert v == 0.0, (w, v)
+    tenants.append(q)
+    x0 += (w - 1 + 2 * 2.5 + 2 * PKT) + 2.4
+sheet = Pos(-BAY_D / 2 + PKT, BAY_Y1 - SHEET - PKT, SHEET_Z) * Box(
+    SHEET, SHEET, 0.12, align=(Align.MIN, Align.MIN, Align.MIN))
+assert vol(sheet & box) == 0.0 and vol(sheet & tp) == 0.0
+tenants.append(sheet)
+worst = 0.0
+for q in pads:
+    worst = max(worst, vol(q & box), *(vol(q & t) for t in tenants))
+assert worst == 0.0, worst
+print("squeegees+sheet stored; stacked pads clear box + tenants")
+
+# --- box feet: same mount interface, mounted at the bottom face ---
+from stenciljig.box import BOX_FOOT_POSE
+worst = 0.0
+for x, y, a in BOX_FOOT_POSE:
+    f = Pos(x, y, -BOX_H) * Rot(0, 0, a) * foot
+    worst = max(worst, vol(f & box))
+    sx, sy = foot_pt(x, y, a, FOOT_SCREW_OFF)
+    shank = Pos(sx, sy, -BOX_H - 4.6) * Cylinder(
+        1.2, 9.9, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    vp = vol(shank & box) + vol(shank & f)
+    assert vp == 0.0, (x, y, vp)
+    bite = vol(Pos(sx, sy, -BOX_H + 0.4) * Cylinder(
+        1.6, 4.9, align=(Align.CENTER, Align.CENTER, Align.MIN)) & box)
+    assert bite > 4.0, (x, y, bite)
+assert worst < 0.05, worst
+print(f"4 box feet mounted:     kiss max {worst:.4f}, taps bite")
+
+# --- pads seated in the feet, near-zero kiss ---
+for f in (foot, hookfoot):
+    q = Pos(0, 0, -FOOT_H - PAD_PROUD) * pad
+    v = vol(q & f)
+    assert v < 0.05, (f.label, v)
+print("pads seated in feet:    kiss < 0.05 (snap fit)")
+
+print("ALL GREEN")

--- a/mechanical/stenciljig/qa/check_joints.py
+++ b/mechanical/stenciljig/qa/check_joints.py
@@ -1,0 +1,139 @@
+"""Fastener clamp-stack audit for stenciljig: between screw head and
+nut (or formed threads), EVERY part the joint joins must sit inside
+the clamp stack, and the nut must react against a part OTHER than
+the one the head bears on - a nut that reacts against the head's own
+part clamps nothing else. Two ~20h bases were printed with exactly
+that bug (clamp nuts roofed by the clamp plate; foot nuts roofed by
+the foot itself), so this runs alongside check_all before any host
+reprint.
+
+Per joint:
+1. completeness: a head-diameter column between the bearing planes
+   intersects every joined part
+2. reaction: the nut displaced 0.4 along the screw-tension direction
+   bears the intended reaction part and NOT the head-bearing part;
+   tap joints instead require thread-envelope bite in the reaction
+   part and zero bite in the head part
+Run from mechanical/: PYTHONPATH=. .venv/bin/python check_joints.py"""
+from build123d import *
+
+from stenciljig.adapter import build_adapter, AD_CBORE
+from stenciljig.base import build_base
+from stenciljig.box import build_box, BOX_FOOT_POSE, BOX_H
+from stenciljig.clamp_plate import build_clamp_plate
+from stenciljig.common import (_hex, foot_pt, AD_SCREW_Y, BASE_T,
+                               BTN_CBORE, CLAMP_HOLES, CLAMP_T,
+                               FOOT_POSE, FOOT_SCREW_OFF, LEDGE,
+                               M3_NUT_T, NUT_AF, PCB_T, PCB_TOP,
+                               PCB_W, SIDE_W, SLOT_X0, SLOT_Y,
+                               TONGUE_CLEAR)
+from stenciljig.foot import build_foot
+from stenciljig.knob import (build_handle, build_rod, SEAT_Z,
+                             TAP_ENGAGE, TIP_Z)
+from stenciljig.nutbar import build_nutbar
+from stenciljig.side_plate import build_side_plate, EAR_T
+
+base = build_base()
+plate = build_side_plate()
+ad = build_adapter(1.6, 1.0)
+box = build_box()
+clamp = build_clamp_plate()
+bar = build_nutbar()
+foot, hookfoot = build_foot(), build_foot(True)
+rod, handle = build_rod(), build_handle()
+
+HEAD_R = 2.85              # button head bearing radius
+THREAD_R = 1.6             # M3 thread envelope
+
+
+def vol(a):
+    try:
+        return a.volume if a.solids() else 0.0
+    except Exception:
+        return 0.0
+
+
+def column(x, y, z0, z1):
+    return Pos(x, y, min(z0, z1)) * Cylinder(
+        HEAD_R, abs(z1 - z0),
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+
+def check_stack(name, col, stack):
+    for label, part in stack:
+        v = vol(col & part)
+        assert v > 0.01, (name, label, "NOT in the clamp stack")
+
+
+def nut_joint(name, x, y, seat, head_z, stack, head, reaction):
+    """seat = nut top face z; head_z = head bearing plane z."""
+    check_stack(name, column(x, y, seat, head_z), stack)
+    nut = Pos(x, y, seat - M3_NUT_T) * extrude(_hex(NUT_AF), M3_NUT_T)
+    d = 0.4 if head_z > seat else -0.4     # tension pulls nut headward
+    shifted = Pos(0, 0, d) * nut
+    vr, vh = vol(shifted & reaction[1]), vol(shifted & head[1])
+    assert vr > 0.1, (name, "nut does not bear on", reaction[0])
+    assert vh == 0.0, (name, "nut reacts against the head's own part",
+                       head[0])
+    print(f"{name:24s} stack {'+'.join(l for l, _ in stack)}, "
+          f"nut reacts on {reaction[0]}")
+
+
+def tap_joint(name, x, y, z0, z1, head_z, stack, head, reaction):
+    """z0..z1 = thread engagement band in the reaction part."""
+    check_stack(name, column(x, y, head_z, z1), stack)
+    bite_cyl = Pos(x, y, z0) * Cylinder(
+        THREAD_R, z1 - z0,
+        align=(Align.CENTER, Align.CENTER, Align.MIN))
+    vr, vh = vol(bite_cyl & reaction[1]), vol(bite_cyl & head[1])
+    assert vr > 4.0, (name, "threads do not bite", reaction[0], vr)
+    assert vh == 0.0, (name, "threads bite the head's own part",
+                       head[0])
+    print(f"{name:24s} stack {'+'.join(l for l, _ in stack)}, "
+          f"taps {reaction[0]} ({vr:.1f} mm^3)")
+
+
+# side-plate ear screws -> nut bars (bar nut pressed up under its web)
+for y in SLOT_Y:
+    nut_joint(f"ear y={y:g}", SLOT_X0, y, -2.0, BASE_T + EAR_T,
+              (("plate", plate), ("base", base), ("bar", bar)),
+              ("plate", plate), ("bar", bar))
+
+# plank screws -> captive plate nuts
+xc = PCB_W / 2 - LEDGE + SIDE_W / 2
+for y in AD_SCREW_Y:
+    nut_joint(f"plank y={y:g}", xc, y, 14.3, PCB_TOP - AD_CBORE,
+              (("plank", ad), ("plate", plate)),
+              ("plank", ad), ("plate", plate))
+
+# clamp screws -> bottom-entry base nuts (centre hangs from the
+# tongue groove floor)
+gfloor = PCB_TOP - PCB_T - TONGUE_CLEAR
+for x, y in CLAMP_HOLES:
+    top = gfloor if x == 0.0 else PCB_TOP
+    nut_joint(f"clamp ({x:g},{y:g})", x, y, top - 2.6,
+              PCB_TOP + CLAMP_T - BTN_CBORE,
+              (("clamp", clamp), ("base", base)),
+              ("clamp", clamp), ("base", base))
+
+# foot screws thread-form the host pilots, jig then box
+for x, y, a, hook in FOOT_POSE:
+    f = Pos(x, y, 0) * Rot(0, 0, a) * (hookfoot if hook else foot)
+    sx, sy = foot_pt(x, y, a, FOOT_SCREW_OFF)
+    tap_joint(f"foot ({x:g},{y:g})", sx, sy, 0.4, 5.3, -4.7,
+              (("foot", f), ("base", base)),
+              ("foot", f), ("base", base))
+for x, y, a in BOX_FOOT_POSE:
+    f = Pos(x, y, -BOX_H) * Rot(0, 0, a) * foot
+    sx, sy = foot_pt(x, y, a, FOOT_SCREW_OFF)
+    tap_joint(f"boxfoot ({x:g},{y:g})", sx, sy, -BOX_H + 0.4,
+              -BOX_H + 5.3, -BOX_H - 4.7,
+              (("foot", f), ("box", box)),
+              ("foot", f), ("box", box))
+
+# knob spine self-taps the rod's wing root
+tap_joint("knob spine", 0, 0, TIP_Z, TIP_Z + TAP_ENGAGE, SEAT_Z,
+          (("handle", handle), ("rod", rod)),
+          ("handle", handle), ("rod", rod))
+
+print("ALL JOINTS SOUND")

--- a/mechanical/stenciljig/qa/check_overhangs.py
+++ b/mechanical/stenciljig/qa/check_overhangs.py
@@ -1,0 +1,49 @@
+"""Print-pose overhang audit: every part must be support-free in its
+export pose - no down-face steeper than 45 deg unless it sits on the
+bed or spans <=3.7 as a bridge. Narrow-span = min(bbox edges,
+2*area/perimeter) so annular rings measure their true width, not
+their diameter. Curved faces grounded on the bed (lying-rod belly
+bands) are exempt - the bed squash supports them.
+Run from mechanical/: PYTHONPATH=. .venv/bin/python stenciljig/qa/check_overhangs.py"""
+import math
+
+from build123d import GeomType
+
+from stenciljig.__main__ import BUILDERS, print_pose
+
+DOWN = math.cos(math.radians(45)) + 0.01   # normal.Z < -DOWN = steeper
+BRIDGE = 3.7
+BED = 0.15
+
+fails = 0
+for name, (build, rot) in BUILDERS.items():
+    part = build()
+    posed = print_pose(part, rot)
+    bad = []
+    for f in posed.faces():
+        uv = ((0.5, 0.5),) if f.geom_type == GeomType.PLANE else \
+            tuple((u / 2, v / 2) for u in range(3) for v in range(3))
+        down = False
+        for u, v in uv:
+            try:
+                if f.normal_at(f.position_at(u, v)).Z < -DOWN:
+                    down = True
+                    break
+            except Exception:
+                continue
+        if not down:
+            continue
+        bb = f.bounding_box()
+        if bb.max.Z < BED:
+            continue                       # sits on the bed
+        if f.geom_type != GeomType.PLANE and bb.min.Z < BED:
+            continue                       # lying-rod belly band
+        per = sum(e.length for e in f.edges())
+        span = min(bb.size.X, bb.size.Y, bb.size.Z,
+                   2 * f.area / per if per > 0 else 1e9)
+        if span > BRIDGE:
+            bad.append((round(span, 2), round(bb.min.Z, 2)))
+    fails += bool(bad)
+    print(f"{part.label:28s} {'ok' if not bad else f'OVERHANGS {bad}'}")
+print("ALL PRINTABLE" if not fails else f"{fails} PARTS FAIL")
+raise SystemExit(1 if fails else 0)

--- a/mechanical/stenciljig/qa/check_watertight.py
+++ b/mechanical/stenciljig/qa/check_watertight.py
@@ -1,0 +1,45 @@
+"""Exact-vertex edge-manifold audit on the exported STLs: every edge
+shared by exactly 2 triangles = watertight. OCC T-junction seams
+report as open edges - slicers stitch those, so nonzero counts only
+matter for parts that must be strictly watertight (reported holes).
+Run from mechanical/ after `python -m stenciljig`:
+.venv/bin/python stenciljig/qa/check_watertight.py"""
+import pathlib
+import struct
+
+BUILD = pathlib.Path(__file__).parent.parent / "build"
+
+
+def read_stl(path):
+    data = path.read_bytes()
+    if data[:5] == b"solid" and b"facet" in data[:300]:
+        tris, vs = [], []
+        for line in data.decode(errors="ignore").splitlines():
+            line = line.strip()
+            if line.startswith("vertex"):
+                vs.append(tuple(float(x) for x in line.split()[1:4]))
+                if len(vs) == 3:
+                    tris.append(tuple(vs))
+                    vs = []
+        return tris
+    n = struct.unpack_from("<I", data, 80)[0]
+    tris = []
+    off = 84
+    for _ in range(n):
+        v = struct.unpack_from("<12f", data, off)
+        tris.append(((v[3], v[4], v[5]), (v[6], v[7], v[8]),
+                     (v[9], v[10], v[11])))
+        off += 50
+    return tris
+
+
+for path in sorted(BUILD.glob("*.stl")):
+    tris = read_stl(path)
+    edges = {}
+    for a, b, c in tris:
+        for e in ((a, b), (b, c), (c, a)):
+            k = tuple(sorted(e))
+            edges[k] = edges.get(k, 0) + 1
+    open_e = sum(1 for n in edges.values() if n != 2)
+    tag = "watertight" if open_e == 0 else f"{open_e} OPEN EDGES"
+    print(f"{path.stem:28s} {len(tris):6d} tris  {tag}")

--- a/mechanical/stenciljig/qa/render_assembly.py
+++ b/mechanical/stenciljig/qa/render_assembly.py
@@ -1,0 +1,155 @@
+"""Blender headless renders of the chassis assembly glbs with a
+see-through sleeve (and half-transparent drawer) so the wheel /
+ledge / snap mechanism reads. Two shots per pose: front-right and
+rear-right. Run:
+blender -b -P render_assembly.py -- <outdir> <glb> [<glb> ...]"""
+import math
+import sys
+
+import bpy
+from mathutils import Vector
+
+args = sys.argv[sys.argv.index("--") + 1:]
+outdir, glbs = args[0], args[1:]
+
+# (rgb to match, alpha, metallic, roughness)
+KEYS = (
+    ((0.45, 0.58, 0.75), 0.28, 0.0, 0.35),   # box key - see-through
+    ((0.35, 0.37, 0.40), 0.55, 0.0, 0.5),    # plates smoke key - half
+    ((0.75, 0.76, 0.78), 1.0, 1.0, 0.2),     # fastener steel
+)
+
+for glb in glbs:
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.ops.import_scene.gltf(filepath=glb)
+
+    lo = Vector((1e9,) * 3)
+    hi = Vector((-1e9,) * 3)
+    for ob in bpy.data.objects:
+        if ob.type != "MESH":
+            continue
+        for c in ob.bound_box:
+            w = ob.matrix_world @ Vector(c)
+            lo = Vector(map(min, lo, w))
+            hi = Vector(map(max, hi, w))
+    center = (lo + hi) / 2
+    size = max(hi - lo)
+
+    # the exporter stores linear values - compare keys through ^2.2.
+    # "real" scenes keep every plastic opaque (true print colors);
+    # only the steel key still applies
+    ghost = "real" not in glb
+    for m in bpy.data.materials:
+        b = m.node_tree.nodes.get("Principled BSDF")
+        if not b:
+            continue
+        c = b.inputs["Base Color"].default_value
+        # unkeyed = printed plastic: matte, low specular - big soft
+        # lamps otherwise wash dark colors into sheen-grey
+        alpha, metal, rough = 1.0, 0.0, 0.75
+        for (kr, kg, kb), ka, km, krf in KEYS:
+            if (abs(c[0] - kr ** 2.2) + abs(c[1] - kg ** 2.2)
+                    + abs(c[2] - kb ** 2.2)) < 0.05:
+                if ka < 1.0 and not ghost:
+                    continue
+                alpha, metal, rough = ka, km, krf
+        b.inputs["Metallic"].default_value = metal
+        b.inputs["Roughness"].default_value = rough
+        b.inputs["Alpha"].default_value = alpha
+        if metal == 0.0:
+            for spec in ("Specular IOR Level", "Specular"):
+                if spec in b.inputs:
+                    b.inputs[spec].default_value = 0.25
+                    break
+        try:
+            m.blend_method = "BLEND"
+        except Exception:
+            pass
+
+    bpy.ops.mesh.primitive_plane_add(
+        size=size * 30, location=(center.x, center.y, lo.z - 0.0002))
+    floor = bpy.context.object
+    fm = bpy.data.materials.new("floor")
+    fm.use_nodes = True
+    fb = fm.node_tree.nodes["Principled BSDF"]
+    fb.inputs["Base Color"].default_value = (0.55, 0.55, 0.56, 1)
+    fb.inputs["Roughness"].default_value = 0.9
+    floor.data.materials.append(fm)
+
+    # AgX (the default) lifts blacks and pastels saturated plastics;
+    # bare Standard clips - white parts blow to paper cutouts. PBR
+    # Neutral keeps filament colors true with highlight rolloff
+    for vt in ("Khronos PBR Neutral", "Standard"):
+        try:
+            bpy.context.scene.view_settings.view_transform = vt
+            break
+        except Exception:
+            pass
+    bpy.context.scene.view_settings.exposure = -0.3
+
+    world = bpy.data.worlds.new("w")
+    bpy.context.scene.world = world
+    world.use_nodes = True
+    world.node_tree.nodes["Background"].inputs[0].default_value = (
+        0.55, 0.58, 0.63, 1)
+    world.node_tree.nodes["Background"].inputs[1].default_value = 0.3
+
+    def lamp(name, dx, dy, dz, power, sz):
+        bpy.ops.object.light_add(
+            type="AREA",
+            location=(center.x + dx * size, center.y + dy * size,
+                      lo.z + dz * size))
+        li = bpy.context.object
+        li.name = name
+        li.data.energy = power * size * size * 12
+        li.data.size = sz * size
+        li.rotation_mode = "QUATERNION"
+        li.rotation_quaternion = (
+            Vector((center.x, center.y, lo.z + 0.1 * size)) -
+            li.location).to_track_quat("-Z", "Y")
+        return li
+
+    lamp("key", -0.9, -0.9, 1.6, 13, 1.2)
+    lamp("fill", 1.2, -0.6, 1.0, 5, 1.6)
+    lamp("rim", 0.3, 1.4, 1.2, 7, 1.0)
+
+    target = bpy.data.objects.new("target", None)
+    bpy.context.collection.objects.link(target)
+    cam_data = bpy.data.cameras.new("cam")
+    cam = bpy.data.objects.new("cam", cam_data)
+    bpy.context.collection.objects.link(cam)
+    tr = cam.constraints.new("TRACK_TO")
+    tr.target = target
+
+    sc = bpy.context.scene
+    sc.camera = cam
+    sc.render.engine = "CYCLES"
+    # Metal GPU + denoiser-carried low samples: CPU Cycles at 200
+    # samples pegged every core for minutes per frame
+    prefs = bpy.context.preferences.addons["cycles"].preferences
+    prefs.compute_device_type = "METAL"
+    prefs.get_devices()
+    for d in prefs.devices:
+        d.use = True
+    sc.cycles.device = "GPU"
+    sc.cycles.samples = 64
+    sc.cycles.use_adaptive_sampling = True
+    sc.cycles.use_denoising = True
+    sc.render.resolution_x = 1920
+    sc.render.resolution_y = 1280
+
+    stem = glb.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    SHOTS = {
+        f"{stem}_front": ((0, 0, -0.02), 36, 18, 1.9, 55),
+        f"{stem}_rear": ((0, 0.05, -0.04), 152, 14, 1.8, 55),
+    }
+    for name, (toff, az, el, dist, lens) in SHOTS.items():
+        target.location = center + Vector(toff) * size
+        a, e = math.radians(az), math.radians(el)
+        cam.location = target.location + Vector((
+            math.sin(a) * math.cos(e), -math.cos(a) * math.cos(e),
+            math.sin(e))) * dist * size
+        cam_data.lens = lens
+        sc.render.filepath = f"{outdir}/{name}.png"
+        bpy.ops.render.render(write_still=True)
+        print("wrote", sc.render.filepath)

--- a/mechanical/stenciljig/side_plate.py
+++ b/mechanical/stenciljig/side_plate.py
@@ -1,0 +1,77 @@
+"""Thickness-agnostic side plate, one model for both hands: flipped
+180 deg about vertical the ear lands outboard and the holes land on
+the recentered slot rows (front<->rear swap is the whole trick -
+print two). The board ledge lives on the adapter plank (adapter.py)
+screwed flat onto the top: two M3x10 drop through the plank into
+nuts ridden up bottom-entry hex pockets, and the screw preload
+drags each nut into its press band and tapered-hex hopper.
+The plank roofs the two top holes; the base roofs the pocket
+mouths. Modeled in the right-hand station at max opening.
+
+Prints upright as modeled: the keel groove's gable, the nut
+hoppers' 45 tapers and the horizontal M3 holes all carry their own
+angles."""
+from build123d import *
+
+from stenciljig.common import (_box, _nut_broach, _plate,
+                               _dovetail_rail, AD_SCREW_Y, BASE_T,
+                               BORDER, CAP_T, EAR_HOLE, BLACK,
+                               GROOVE_H, GROOVE_ROOT, GROOVE_TOP,
+                               LEDGE, M3_FREE, PCB_D, PCB_W, PLATE_H,
+                               RAIL_Y, SIDE_W, SLOT_Y)
+
+EAR_L = 9.0                # sticks out from the plate's outer face;
+                           # 3.2 of rim outboard of the hole = 5
+                           # perimeters of a 0.6 nozzle
+EAR_T = 4.0                # head bears straight down onto the base
+EAR_W = 16.0               # per-row tab span, hole centered
+
+PRINT = None               # upright, as modeled
+
+
+def build_side_plate() -> Part:
+    x0 = PCB_W / 2 - LEDGE                  # inner face at max opening
+    xc = x0 + SIDE_W / 2
+    # body corners rounded to the plank's radius so the stack shares
+    # one outline
+    p = _box(x0, x0 + SIDE_W, BORDER, BORDER + PCB_D,
+             BASE_T, BASE_T + PLATE_H - CAP_T)
+    p = fillet(p.edges().filter_by(Axis.Z), 3.0)
+    e = p.edges().group_by(Axis.Z)
+    p = chamfer(e[0] + e[-1], 0.5)
+
+    face_x = x0 + SIDE_W
+    # ears: one rounded low tab per rail row, screw hole centered;
+    # the heads bear straight down through them onto the base, ~10
+    # below the stencil plane in open air. Buried 2 into the plate
+    # face so the rounds only show outboard
+    for y in SLOT_Y:
+        p += Pos(face_x + (EAR_L - 2) / 2, y, BASE_T) * _plate(
+            EAR_L + 2, EAR_W, EAR_T, 3.0, 0.5)
+        p -= Pos(face_x + EAR_HOLE, y, BASE_T - 0.1) * Cylinder(
+            M3_FREE / 2, EAR_T + 0.2,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+    # keel groove across the plate body underside (the ear tabs sit
+    # clear of the rail band); dovetail over the base rail, deeper by
+    # RAIL_DROP so the plate seats on the base face. Gabled roof:
+    # printed upright the channel needs no bridge
+    p -= Pos((x0 + face_x) / 2, RAIL_Y, BASE_T - 0.1) * \
+        _dovetail_rail(GROOVE_ROOT, GROOVE_TOP, GROOVE_H + 0.1,
+                       SIDE_W / 2 + 1, gable=True)
+
+    # plank screw rows: bottom-entry captive nuts (common._nut_broach:
+    # loose ride up, press band, 45 hopper - the screw's preload from
+    # above seats the nut); the M3x10 tip rides 0.85 proud into the
+    # loose shaft, and the base roofs the mouth once mounted
+    top = BASE_T + PLATE_H - CAP_T
+    seat = 14.3                # nut top face; M3x10 tip lands at 11.05
+    for y in AD_SCREW_Y:
+        p -= Pos(xc, y, BASE_T) * _nut_broach(seat - BASE_T)
+        p -= Pos(xc, y, seat) * Cylinder(
+            M3_FREE / 2, top - seat + 0.1,
+            align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+    p.label = "stenciljig_side"
+    p.color = BLACK
+    return p

--- a/mechanical/stenciljig/squeegee.py
+++ b/mechanical/stenciljig/squeegee.py
@@ -1,0 +1,64 @@
+"""Standing-wedge paste squeegee: both faces at SQ_ANGLE, so it sits
+flat on the stencil - attack angle from geometry, not the hand - and
+fore-aft symmetric, either face leads. Only a RAIL strip behind each
+edge touches (base hollowed between). Cheek dams at the ends ride
+the sheet, pen the bead in, and seal the hollow. Low blade profile:
+wedge, short fin, T-grip bar - the whole tool is SQ_H tall so it
+lies in the box like an adapter; fingers hook the grip flanks for
+push or pull. w is the edge width (board + margin), k scales the
+profile for small stencils, one size per stencil via SQ_SIZES.
+
+Prints as modeled, base down: the working edges are bed corners
+(zero elephant-foot compensation); the hollow is a single 45 deg
+gable, rail to ridge, so no layer bridges it; the grip flare is
+27 deg."""
+import math
+
+from build123d import *
+
+from stenciljig.common import GREEN, PCB_TOP, PLATE_YC
+
+SQ_ANGLE = 60.0            # face-to-stencil attack, both faces
+SQ_BASE = 18.0             # stance depth - short enough that the
+                           # wedge closes below the grip bar
+SQ_H = 16.0                # overall height = an adapter lying flat
+SQ_RAIL = 1.5              # contact strip behind each working edge
+SQ_RELIEF = 0.8            # base hollowed between the strips
+SQ_FIN_T = 6.0             # fin between wedge and grip
+SQ_GRIP_H = 4.0            # T-grip bar atop the fin
+SQ_GRIP_W = 10.0           # flares 2 per side over the 4 rise
+SQ_CHEEK_T = 2.5           # end dams: bead stays between them
+SQ_CHEEK_REACH = 5.0       # dam ahead of each edge; a max-depth board
+                           # sweep still clears the clamp plate by 1
+SQ_CHEEK_H = 12.0
+SQ_SIZES = ((60.0, 1.0), (20.0, 0.6))  # (edge width, profile scale)
+
+PRINT = None
+
+
+def build_squeegee(w=60.0, k=1.0) -> Part:
+    base, ft = SQ_BASE * k, SQ_FIN_T * k
+    h1 = (base - ft) / 2 * math.tan(math.radians(SQ_ANGLE))
+    ht, gh, gw = SQ_H * k, SQ_GRIP_H * k, SQ_GRIP_W * k
+    prof = Polygon((-base / 2, 0), (base / 2, 0), (ft / 2, h1),
+                   (ft / 2, ht - gh), (gw / 2, ht), (-gw / 2, ht),
+                   (-ft / 2, ht - gh), (-ft / 2, h1), align=None)
+    p = extrude(Plane.YZ * prof, w / 2, both=True)
+    p = chamfer(p.faces().sort_by(Axis.Z)[-1].edges(), ft / 4)
+    ch = SQ_CHEEK_H * k
+    prof = Pos(0, ch / 2) * RectangleRounded(
+        base + 2 * SQ_CHEEK_REACH, ch, ch / 4)
+    for s in (1, -1):
+        p += Pos(s * (w / 2 - 0.5 + SQ_CHEEK_T / 2), 0, 0) * extrude(
+            Plane.YZ * prof, SQ_CHEEK_T / 2, both=True)
+    # hollow, cut 0.1 into the cheeks so they close its ends; gabled
+    # roof, no flat span (ridge clears the 60 deg faces by >= 1.8)
+    hw = base / 2 - SQ_RAIL
+    p -= extrude(Plane.YZ * Polygon(
+        (-hw, -0.1), (hw, -0.1), (hw, SQ_RELIEF),
+        (0, SQ_RELIEF + hw), (-hw, SQ_RELIEF), align=None),
+        w / 2 - 0.4, both=True)
+    p = Pos(0, PLATE_YC, PCB_TOP) * p
+    p.label = f"stenciljig_squeegee{round(w):02d}"
+    p.color = GREEN
+    return p

--- a/mechanical/stenciljig/tongue.py
+++ b/mechanical/stenciljig/tongue.py
@@ -1,0 +1,26 @@
+"""Ejection tongue: slides in the rear-plate groove, under the
+stencil, flush-ish with the board top; the handle hangs off the
+back. Push to walk the pasted board forward instead of fingering it
+out (don't smear). Works for all board thicknesses: the front face
+spans the groove floor up to 0.3 under the stencil plane, so it
+still catches a 0.6 board's edge. Lives in its groove, not the box.
+Prints as modeled."""
+from build123d import *
+
+from stenciljig.common import (_plate, BLACK, PCB_T, PCB_TOP, REAR_Y,
+                               SLOT_W, TONGUE_DROP, TONGUE_LEN,
+                               TONGUE_W)
+
+PRINT = None
+
+
+def build_tongue() -> Part:
+    t = PCB_T - TONGUE_DROP
+    p = Pos(0, REAR_Y[0] + TONGUE_LEN / 2, PCB_TOP - t) * _plate(
+        TONGUE_W, TONGUE_LEN, t, TONGUE_W / 4, 0.2)
+    p -= Pos(0, REAR_Y[0] + TONGUE_LEN / 2, PCB_TOP - t - 0.1) * extrude(
+        Rot(0, 0, 90) * SlotOverall(TONGUE_LEN - TONGUE_W + SLOT_W, SLOT_W),
+        t + 0.2)
+    p.label = "stenciljig_tongue"
+    p.color = BLACK
+    return p

--- a/mechanical/stenciljig/tray.py
+++ b/mechanical/stenciljig/tray.py
@@ -1,0 +1,32 @@
+"""Lift-out tray splitting the box bay by height: stencil sheets
+lie flat in the well below (a dozen barely fill it), the tray rides
+the bay's side ledges at the tool floor and carries boards + bench
+sundries (paste syringe, wipes) up at hand height, flush with the
+deck rim so the stacked jig sweeps clear. Lift it by pinching the
+front wall through the bay's finger alcove.
+
+Prints as modeled, floor on the bed."""
+from build123d import *
+
+from stenciljig.box import BAY_D, BAY_W, FLOOR_Z, PKT, RIM
+from stenciljig.common import ORANGE
+
+TRAY_WALL = 2.4            # 4 perimeters of a 0.6 nozzle
+TRAY_FLOOR = 2.4
+TRAY_H = RIM - FLOOR_Z     # flush with the deck rim
+TRAY_W = BAY_W - 2 * PKT
+TRAY_D = BAY_D - 2 * PKT
+
+PRINT = None               # floor on the bed, as modeled
+
+
+def build_tray() -> Part:
+    p = extrude(RectangleRounded(TRAY_W, TRAY_D, 2.0), TRAY_H)
+    p -= Pos(0, 0, TRAY_FLOOR) * extrude(
+        RectangleRounded(TRAY_W - 2 * TRAY_WALL,
+                         TRAY_D - 2 * TRAY_WALL, 2.0), TRAY_H)
+    e = p.edges().group_by(Axis.Z)
+    p = chamfer(e[0] + e[-1], 0.5)
+    p.label = "stenciljig_tray"
+    p.color = ORANGE
+    return p


### PR DESCRIPTION
Checks in the accumulated mechanical work:

- shared CAD tooling: third-angle blueprint SVGs, live OCP-viewer preview with file watch, headless Blender renders; sg90 build scripts export blueprints
- sg90 donor facts: M10 motor rename, pot ear pockets, gear2 bore warning
- stenciljig: solder-paste stencil jig package (one part per file, stacking box/feet/knobs, qa suite for watertightness, overhangs and joints)
- carrier: tier-2 encoder carrier scaffold (stator body + magnet cup), dims pending the donor measurement session
- encbench first-light rework: press guide + neck clip, leaf-spring board detents, measured PT/LED window map, two-color discs, L-shims with fence corrals

Also ignores generated board bom outputs (hardware/boards/*/bom/). Build outputs and editor junk are excluded by existing ignore rules.