### PR TITLE
fw: cascaded control kernel, estimators, count-domain table re-org

### DIFF
--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -88,146 +88,282 @@
       "kind": "int"
     },
     {
-      "name": "stall_response",
+      "name": "i_kp_q88",
       "addr": 48,
-      "width": 1,
-      "access": "rw",
-      "kind": "enum",
-      "variants": [
-        {
-          "name": "Disable",
-          "value": 0
-        },
-        {
-          "name": "Comply",
-          "value": 1
-        }
-      ]
-    },
-    {
-      "name": "stall_effort_threshold",
-      "addr": 50,
       "width": 2,
-      "access": "rw",
-      "kind": "int"
-    },
-    {
-      "name": "stall_motion_threshold_urad",
-      "addr": 52,
-      "width": 4,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "stall_time_threshold_ms",
+      "name": "i_ki_q412",
+      "addr": 50,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "i_kaw_q412",
+      "addr": 52,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "duty_max_q15",
+      "addr": 54,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint",
+      "max": 32767
+    },
+    {
+      "name": "v_kp_q88",
       "addr": 56,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "comply_release_window_ms",
+      "name": "v_ki_q412",
       "addr": 58,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "motor_thermal_k_q88",
+      "name": "v_kaw_q412",
       "addr": 60,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "motor_thermal_tau_ms",
+      "name": "j_ff_q88",
       "addr": 62,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "winding_cutoff_cc",
+      "name": "p_kp_q88",
       "addr": 64,
       "width": 2,
       "access": "rw",
-      "kind": "int"
+      "kind": "uint"
     },
     {
-      "name": "winding_recover_cc",
+      "name": "pos_deadband_counts",
       "addr": 66,
       "width": 2,
       "access": "rw",
-      "kind": "int"
+      "kind": "uint"
     },
     {
-      "name": "v_undervolt_mv",
+      "name": "hold_omega_cps",
       "addr": 68,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "pid_kp_q88",
+      "name": "velocity_limit_cps",
+      "addr": 70,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "accel_limit_q88",
       "addr": 72,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "pid_ki_q88",
+      "name": "current_limit_counts",
       "addr": 74,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "pid_kd_q88",
+      "name": "stall_response",
       "addr": 76,
-      "width": 2,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
-      "name": "pid_i_limit",
-      "addr": 80,
-      "width": 4,
-      "access": "rw",
-      "kind": "int"
-    },
-    {
-      "name": "pos_deadband_urad",
-      "addr": 84,
-      "width": 4,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
-      "name": "pwm_deadband_pct",
-      "addr": 88,
       "width": 1,
       "access": "rw",
-      "kind": "uint",
-      "max": 50
+      "kind": "enum",
+      "variants": [
+        {
+          "name": "Fault",
+          "value": 0
+        },
+        {
+          "name": "Yield",
+          "value": 1
+        }
+      ]
     },
     {
-      "name": "v_comp_enable",
-      "addr": 89,
+      "name": "drive_polarity",
+      "addr": 77,
       "width": 1,
       "access": "rw",
       "kind": "bool"
     },
     {
-      "name": "max_effort",
+      "name": "stall_omega_max_cps",
+      "addr": 78,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "stall_time_ms",
+      "addr": 80,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "stall_yield_counts",
+      "addr": 82,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "stall_release_counts",
+      "addr": 84,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "oc_trip_counts",
+      "addr": 86,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "oc_trip_ticks",
+      "addr": 88,
+      "width": 1,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "openloop_decay",
+      "addr": 89,
+      "width": 1,
+      "access": "rw",
+      "kind": "enum",
+      "variants": [
+        {
+          "name": "Slow",
+          "value": 0
+        },
+        {
+          "name": "Fast",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "name": "derate_start_cc",
       "addr": 90,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "v_nominal_mv",
+      "name": "cutoff_cc",
       "addr": 92,
       "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "recover_cc",
+      "addr": 94,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "v_undervolt_counts",
+      "addr": 96,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "rtherm_i_min_counts",
+      "addr": 98,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "rtherm_omega_max_cps",
+      "addr": 100,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "l1_q016",
+      "addr": 102,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "l2_q88",
+      "addr": 104,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "l3_q88",
+      "addr": 106,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "l_bemf_q016",
+      "addr": 108,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pos_error_counts",
+      "addr": 110,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pos_error_time_ms",
+      "addr": 112,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "sensor_delta_max",
+      "addr": 114,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "sensor_bad_count",
+      "addr": 116,
+      "width": 1,
       "access": "rw",
       "kind": "uint"
     },

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -382,88 +382,144 @@
       "kind": "uint"
     },
     {
-      "name": "lut",
+      "name": "lut_corr",
       "addr": 132,
-      "width": 220,
+      "width": 110,
       "access": "rw",
       "kind": "bytes"
     },
     {
-      "name": "ke_uvs_per_rad",
-      "addr": 352,
-      "width": 2,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
-      "name": "r_motor_mohm",
-      "addr": 354,
-      "width": 2,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
-      "name": "calib_v_bus_mv",
-      "addr": 356,
-      "width": 2,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
-      "name": "calib_i_ma",
-      "addr": 358,
-      "width": 2,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
       "name": "shunt_r_mohm",
-      "addr": 360,
+      "addr": 242,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "gain_milli",
-      "addr": 362,
+      "addr": 244,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "vmotor_div_top",
-      "addr": 364,
+      "addr": 246,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "vmotor_div_bot",
-      "addr": 366,
+      "addr": 248,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "vdd_mv",
-      "addr": 368,
+      "addr": 250,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "r0_mohm",
-      "addr": 370,
+      "name": "tick_hz",
+      "addr": 252,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "i_window_min_ticks",
+      "addr": 254,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "v_window_min_ticks",
+      "addr": 256,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "r0_q12",
+      "addr": 258,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "t0_cc",
-      "addr": 372,
+      "addr": 260,
       "width": 2,
       "access": "rw",
       "kind": "int"
+    },
+    {
+      "name": "k_r2t_q88",
+      "addr": 262,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "mu_q016",
+      "addr": 264,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "ke_uvs_per_rad",
+      "addr": 266,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "r_q12",
+      "addr": 268,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "recip_ke_q",
+      "addr": 270,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "b_i_q016",
+      "addr": 272,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "fric_fc_counts",
+      "addr": 274,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "fric_fv_q016",
+      "addr": 276,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "fric_breakaway_counts",
+      "addr": 278,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
     },
     {
       "name": "torque_enable",

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -522,6 +522,13 @@
       "kind": "uint"
     },
     {
+      "name": "ke_vpc_q",
+      "addr": 280,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
       "name": "torque_enable",
       "addr": 384,
       "width": 1,

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -239,22 +239,29 @@
       "kind": "uint"
     },
     {
-      "name": "oc_trip_counts",
+      "name": "stall_tau_trip_counts",
       "addr": 86,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "oc_trip_ticks",
+      "name": "oc_trip_counts",
       "addr": 88,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "oc_trip_ticks",
+      "addr": 90,
       "width": 1,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "openloop_decay",
-      "addr": 89,
+      "addr": 91,
       "width": 1,
       "access": "rw",
       "kind": "enum",
@@ -271,98 +278,98 @@
     },
     {
       "name": "derate_start_cc",
-      "addr": 90,
-      "width": 2,
-      "access": "rw",
-      "kind": "int"
-    },
-    {
-      "name": "cutoff_cc",
       "addr": 92,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "recover_cc",
+      "name": "cutoff_cc",
       "addr": 94,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "v_undervolt_counts",
+      "name": "recover_cc",
       "addr": 96,
       "width": 2,
       "access": "rw",
-      "kind": "uint"
+      "kind": "int"
     },
     {
-      "name": "rtherm_i_min_counts",
+      "name": "v_undervolt_counts",
       "addr": 98,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "rtherm_omega_max_cps",
+      "name": "rtherm_i_min_counts",
       "addr": 100,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l1_q016",
+      "name": "rtherm_omega_max_cps",
       "addr": 102,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l2_q88",
+      "name": "l1_q016",
       "addr": 104,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l3_q88",
+      "name": "l2_q88",
       "addr": 106,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l_bemf_q016",
+      "name": "l3_q88",
       "addr": 108,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "pos_error_counts",
+      "name": "l_bemf_q016",
       "addr": 110,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "pos_error_time_ms",
+      "name": "pos_error_counts",
       "addr": 112,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "sensor_delta_max",
+      "name": "pos_error_time_ms",
       "addr": 114,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "sensor_bad_count",
+      "name": "sensor_delta_max",
       "addr": 116,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "sensor_bad_count",
+      "addr": 118,
       "width": 1,
       "access": "rw",
       "kind": "uint"

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -806,21 +806,21 @@
       "addr": 596,
       "width": 2,
       "access": "ro",
-      "kind": "uint"
+      "kind": "int"
     },
     {
       "name": "i_min_counts",
       "addr": 598,
       "width": 2,
       "access": "ro",
-      "kind": "uint"
+      "kind": "int"
     },
     {
       "name": "i_max_counts",
       "addr": 600,
       "width": 2,
       "access": "ro",
-      "kind": "uint"
+      "kind": "int"
     },
     {
       "name": "vdiff_mean",

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -648,106 +648,190 @@
       "kind": "uint"
     },
     {
-      "name": "current_bias_counts",
-      "addr": 564,
+      "name": "theta_hat_q16",
+      "addr": 548,
+      "width": 4,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "omega_hat_cps",
+      "addr": 552,
+      "width": 4,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "tau_d_counts",
+      "addr": 556,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "i_lim_counts",
+      "addr": 558,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
-      "name": "t_winding_dc",
+      "name": "t_winding_cc",
+      "addr": 560,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "vbus_counts",
+      "addr": 562,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "duty_applied_q15",
+      "addr": 564,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "omega_bemf_cps",
       "addr": 566,
       "width": 2,
       "access": "ro",
       "kind": "int"
     },
     {
-      "name": "pwm_duty_actual",
+      "name": "r_hat_q12",
       "addr": 568,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "i_hat_counts",
+      "addr": 570,
       "width": 2,
       "access": "ro",
       "kind": "int"
     },
     {
-      "name": "pid_error_last",
-      "addr": 572,
-      "width": 4,
-      "access": "ro",
-      "kind": "int"
-    },
-    {
-      "name": "pid_output_last",
-      "addr": 576,
-      "width": 4,
-      "access": "ro",
-      "kind": "int"
-    },
-    {
-      "name": "internal_goal",
-      "addr": 580,
-      "width": 4,
-      "access": "ro",
-      "kind": "int"
-    },
-    {
       "name": "sample_tick",
-      "addr": 584,
+      "addr": 572,
       "width": 4,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "pos",
-      "addr": 588,
+      "addr": 576,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "current",
-      "addr": 590,
+      "addr": 578,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "vcal",
-      "addr": 592,
+      "addr": 580,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "vcal_lpf",
-      "addr": 594,
+      "addr": 582,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "vmotor_a",
-      "addr": 596,
+      "addr": 584,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "vmotor_b",
-      "addr": 598,
+      "addr": 586,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "enc_a",
-      "addr": 600,
+      "addr": 588,
       "width": 2,
       "access": "ro",
       "kind": "uint"
     },
     {
       "name": "enc_b",
+      "addr": 590,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "current_trough",
+      "addr": 592,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "current_bias_counts",
+      "addr": 594,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "i_mean_counts",
+      "addr": 596,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "i_min_counts",
+      "addr": 598,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "i_max_counts",
+      "addr": 600,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "vdiff_mean",
       "addr": 602,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "duty_mean_q15",
+      "addr": 604,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "agg_seq",
+      "addr": 606,
       "width": 2,
       "access": "ro",
       "kind": "uint"

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -375,44 +375,8 @@
       "kind": "int"
     },
     {
-      "name": "stream_enable",
-      "addr": 400,
-      "width": 1,
-      "access": "rw",
-      "kind": "bool"
-    },
-    {
-      "name": "stream_decimation",
-      "addr": 401,
-      "width": 1,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
-      "name": "stream_duration_ms",
-      "addr": 402,
-      "width": 2,
-      "access": "rw",
-      "kind": "uint",
-      "min": 1
-    },
-    {
-      "name": "stream_field_mask",
-      "addr": 404,
-      "width": 4,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
-      "name": "stream_dropped",
-      "addr": 408,
-      "width": 4,
-      "access": "ro",
-      "kind": "uint"
-    },
-    {
       "name": "boot_mode",
-      "addr": 412,
+      "addr": 400,
       "width": 1,
       "access": "rw",
       "kind": "enum",

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -348,10 +348,25 @@
           "value": 0
         },
         {
-          "name": "PositionPid",
+          "name": "Current",
           "value": 1
+        },
+        {
+          "name": "Velocity",
+          "value": 2
+        },
+        {
+          "name": "Position",
+          "value": 3
         }
       ]
+    },
+    {
+      "name": "goal_duty",
+      "addr": 386,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
     },
     {
       "name": "goal_position",
@@ -368,7 +383,7 @@
       "kind": "int"
     },
     {
-      "name": "goal_effort",
+      "name": "goal_current",
       "addr": 396,
       "width": 2,
       "access": "rw",

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -60,28 +60,28 @@
       "kind": "uint"
     },
     {
-      "name": "pos_min_phys_urad",
+      "name": "pos_min_phys_counts",
       "addr": 32,
       "width": 4,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "pos_max_phys_urad",
+      "name": "pos_max_phys_counts",
       "addr": 36,
       "width": 4,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "pos_min_soft_urad",
+      "name": "pos_min_soft_counts",
       "addr": 40,
       "width": 4,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "pos_max_soft_urad",
+      "name": "pos_max_soft_counts",
       "addr": 44,
       "width": 4,
       "access": "rw",

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -52,8 +52,8 @@ fn main() -> ! {
             vdd_mv: 3300,
         },
         defaults: ConfigDefaults {
-            pos_min_phys_urad: -1_570_796,
-            pos_max_phys_urad: 1_570_796,
+            pos_min_phys_counts: 0,
+            pos_max_phys_counts: 4095,
             id: 1,
             baud: BaudRate::B1000000,
             response_deadline_us: DEFAULT_RESPONSE_DEADLINE_US,

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -50,9 +50,13 @@ fn main() -> ! {
                 bot_ohm: 10_000,
             },
             vdd_mv: 3300,
-            // bench-measured floor pending
             i_window_min_ticks: 240,
-            v_window_min_ticks: 220,
+            // one floor for BOTH terminals: the scan converts vmotor_b one
+            // slot after vmotor_a, so B's edge sits ~50 ticks later (bench:
+            // B garbage at 238, clean at 274; A clean at 222). A floor
+            // below B's edge let a position-mode launch seed the vbus EWMA
+            // from off-phase samples and latch a false undervolt.
+            v_window_min_ticks: 300,
         },
         defaults: ConfigDefaults {
             pos_min_phys_counts: 0,

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -50,6 +50,9 @@ fn main() -> ! {
                 bot_ohm: 10_000,
             },
             vdd_mv: 3300,
+            // bench-measured floor pending
+            i_window_min_ticks: 240,
+            v_window_min_ticks: 220,
         },
         defaults: ConfigDefaults {
             pos_min_phys_counts: 0,

--- a/firmware/lib/control-table/tests/derive_enum.rs
+++ b/firmware/lib/control-table/tests/derive_enum.rs
@@ -6,7 +6,7 @@ use control_table::descriptor::EnumVariant;
 #[repr(u8)]
 enum Mode {
     OpenLoop = 0,
-    PositionPid = 1,
+    Current = 1,
 }
 
 #[derive(Copy, Clone, Enum)]
@@ -48,7 +48,7 @@ fn variants_pair_name_with_value() {
                 value: 0
             },
             EnumVariant {
-                name: "PositionPid",
+                name: "Current",
                 value: 1
             },
         ]

--- a/firmware/lib/core/src/estimator/bemf.rs
+++ b/firmware/lib/core/src/estimator/bemf.rs
@@ -1,0 +1,176 @@
+//! Back-EMF velocity observer, telemetry-only in v1 (nothing consumes it
+//! yet). Slow decay shorts the terminals off-window (v_diff ~ 0), so the
+//! period-average applied differential voltage is just the duty fraction
+//! times the drive-window differential - bridge drops included, which is the
+//! point. Subtract the resistive drop and scale by 1/Ke and the motor is its
+//! own tachometer: omega = (v_mean - R*i) / Ke, divide-free via caller-side
+//! reciprocals (control-theory "Back-EMF, a Velocity Sensor for Free").
+
+use crate::math::q_mul;
+
+/// `recip_arr` Q: chip const-evals `(1 << RECIP_ARR_SHIFT) / pwm_arr`. Q24
+/// keeps reciprocal quantization under arr/2^24 relative (arr=1200 -> 0.007%
+/// vs 1.2% at Q16). `drive_ticks * vdiff` <= 65535 * 4095 fits i32 and
+/// `q_mul` widens to i64, so the extra shift is free.
+pub const RECIP_ARR_SHIFT: u32 = 24;
+
+/// `recip_ke_q` (CALIB motor block) Q: c/s per vcount at Q6.10. SG90-scale
+/// motors land ~3.6 c/s per vcount (~3700 stored, 0.03% quantization); the
+/// u16 caps at 64 c/s per vcount, 16x headroom over the rig motor.
+pub const RECIP_KE_SHIFT: u32 = 10;
+
+const GUARD: u32 = 2;
+const ALPHA_SHIFT: u32 = 2;
+
+/// The EWMA lives here, not downstream: per-period vdiff/shunt sampling
+/// noise is this observer's own artifact and telemetry reads the output
+/// directly. Alpha 1/4 with 2 guard bits; first valid sample seeds the state.
+#[derive(Default)]
+pub struct BemfObs {
+    state_qg: i32,
+    initialized: bool,
+}
+
+impl BemfObs {
+    pub const fn new() -> Self {
+        Self {
+            state_qg: 0,
+            initialized: false,
+        }
+    }
+
+    /// One MEDIUM-tick update. `vdiff_drive` from `vdrive_from_frame`,
+    /// `i_meas` from `i_from_frame`; either `None` (window too narrow) holds
+    /// the last output. `recip_arr` and `recip_ke_q` per the shift consts
+    /// above, `r_q12` vcounts/ccount Q4.12. Returns the telemetry value.
+    pub fn step(
+        &mut self,
+        vdiff_drive: Option<i32>,
+        i_meas: Option<i32>,
+        drive_ticks: u32,
+        recip_arr: u32,
+        r_q12: u16,
+        recip_ke_q: u16,
+    ) -> i16 {
+        if let (Some(vdiff), Some(i)) = (vdiff_drive, i_meas) {
+            let v_mean = q_mul(
+                drive_ticks as i32 * vdiff,
+                recip_arr as i32,
+                RECIP_ARR_SHIFT,
+            );
+            let r_drop = q_mul(r_q12 as i32, i, 12);
+            let omega = q_mul(v_mean - r_drop, recip_ke_q as i32, RECIP_KE_SHIFT);
+            let x = omega << GUARD;
+            if self.initialized {
+                self.state_qg += (x - self.state_qg) >> ALPHA_SHIFT;
+            } else {
+                self.state_qg = x;
+                self.initialized = true;
+            }
+        }
+        self.omega_cps_i16()
+    }
+
+    /// Filtered estimate, whole c/s, full width.
+    pub fn omega_cps(&self) -> i32 {
+        self.state_qg >> GUARD
+    }
+
+    /// Saturating cast matching telemetry `est.omega_bemf_cps`.
+    pub fn omega_cps_i16(&self) -> i16 {
+        self.omega_cps().clamp(i16::MIN as i32, i16::MAX as i32) as i16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ARR: u32 = 1200;
+    const RECIP_ARR: u32 = (1 << RECIP_ARR_SHIFT) / ARR;
+    // unity Ke: 1.0 c/s per vcount
+    const KE_UNITY: u16 = 1 << RECIP_KE_SHIFT;
+
+    #[test]
+    fn zero_current_scaling() {
+        // 50% duty of vdiff=3000 -> v_mean ideal 1500, floor 1499
+        let mut obs = BemfObs::new();
+        let out = obs.step(Some(3000), Some(0), 600, RECIP_ARR, 4096, KE_UNITY);
+        assert_eq!(out, 1499);
+        // rig-scale recip_ke ~3.61 c/s per vcount: 1499 * 3700 >> 10
+        let mut obs = BemfObs::new();
+        let out = obs.step(Some(3000), Some(0), 600, RECIP_ARR, 4096, 3700);
+        assert_eq!(out, 5416);
+    }
+
+    #[test]
+    fn r_drop_reduces_omega_toward_zero() {
+        // v_mean 1499; r=0.5 Q4.12, i=2048 -> r_drop 1024 -> omega 475
+        let mut obs = BemfObs::new();
+        let out = obs.step(Some(3000), Some(2048), 600, RECIP_ARR, 2048, KE_UNITY);
+        assert_eq!(out, 475);
+        assert!(out < 1499);
+        assert!(out > 0);
+    }
+
+    #[test]
+    fn sign_symmetry() {
+        // exact-power-of-two drive: arr=1024, ticks=512, vdiff +-2048 -> +-1024
+        let recip = (1u32 << RECIP_ARR_SHIFT) / 1024;
+        let mut fwd = BemfObs::new();
+        let mut rev = BemfObs::new();
+        let f = fwd.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY);
+        let r = rev.step(Some(-2048), Some(0), 512, recip, 4096, KE_UNITY);
+        assert_eq!(f, 1024);
+        assert_eq!(r, -1024);
+    }
+
+    #[test]
+    fn invalid_window_holds_last_output() {
+        let recip = (1u32 << RECIP_ARR_SHIFT) / 1024;
+        let mut obs = BemfObs::new();
+        assert_eq!(
+            obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY),
+            1024
+        );
+        assert_eq!(obs.step(None, Some(0), 512, recip, 4096, KE_UNITY), 1024);
+        assert_eq!(obs.step(Some(2048), None, 512, recip, 4096, KE_UNITY), 1024);
+        assert_eq!(obs.step(None, None, 0, recip, 4096, KE_UNITY), 1024);
+        // valid sample moves it again
+        assert!(obs.step(Some(0), Some(0), 512, recip, 4096, KE_UNITY) < 1024);
+    }
+
+    #[test]
+    fn saturates_at_i16_bounds() {
+        // full duty, full vdiff, max recip_ke: omega 262012 >> i16::MAX
+        let mut obs = BemfObs::new();
+        let out = obs.step(Some(4095), Some(0), ARR, RECIP_ARR, 0, u16::MAX);
+        assert_eq!(out, i16::MAX);
+        assert_eq!(obs.omega_cps(), 262_012);
+        let mut obs = BemfObs::new();
+        let out = obs.step(Some(-4095), Some(0), ARR, RECIP_ARR, 0, u16::MAX);
+        assert_eq!(out, i16::MIN);
+        assert_eq!(obs.omega_cps(), -262_077);
+    }
+
+    #[test]
+    fn ewma_seeds_then_converges() {
+        let recip = (1u32 << RECIP_ARR_SHIFT) / 1024;
+        let mut obs = BemfObs::new();
+        // seed at 0, then step toward 1024: alpha 1/4 from the seed
+        assert_eq!(obs.step(Some(0), Some(0), 512, recip, 4096, KE_UNITY), 0);
+        assert_eq!(
+            obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY),
+            256
+        );
+        assert_eq!(
+            obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY),
+            448
+        );
+        let mut last = 0i16;
+        for _ in 0..40 {
+            last = obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY);
+        }
+        assert!((last as i32 - 1024).abs() <= 1, "last={last}");
+    }
+}

--- a/firmware/lib/core/src/estimator/bemf.rs
+++ b/firmware/lib/core/src/estimator/bemf.rs
@@ -11,7 +11,9 @@ use crate::math::q_mul;
 /// `recip_arr` Q: chip const-evals `(1 << RECIP_ARR_SHIFT) / pwm_arr`. Q24
 /// keeps reciprocal quantization under arr/2^24 relative (arr=1200 -> 0.007%
 /// vs 1.2% at Q16). `drive_ticks * vdiff` <= 65535 * 4095 fits i32 and
-/// `q_mul` widens to i64, so the extra shift is free.
+/// `q_mul` widens to i64, so the extra shift is free. The kernel computes
+/// `v_mean = q_mul(drive_ticks * vdiff, recip_arr, RECIP_ARR_SHIFT)` once
+/// per medium tick and feeds it here AND to the winding thermometer.
 pub const RECIP_ARR_SHIFT: u32 = 24;
 
 /// `recip_ke_q` (CALIB motor block) Q: c/s per vcount at Q6.10. SG90-scale
@@ -39,25 +41,19 @@ impl BemfObs {
         }
     }
 
-    /// One MEDIUM-tick update. `vdiff_drive` from `vdrive_from_frame`,
-    /// `i_meas` from `i_from_frame`; either `None` (window too narrow) holds
-    /// the last output. `recip_arr` and `recip_ke_q` per the shift consts
-    /// above, `r_q12` vcounts/ccount Q4.12. Returns the telemetry value.
+    /// One MEDIUM-tick update. `v_mean` is the kernel-hoisted period-average
+    /// applied differential (see `RECIP_ARR_SHIFT`), `i_meas` from
+    /// `i_from_frame`; either `None` (window too narrow) holds the last
+    /// output. `recip_ke_q` per the shift const above, `r_q12`
+    /// vcounts/ccount Q4.12. Returns the telemetry value.
     pub fn step(
         &mut self,
-        vdiff_drive: Option<i32>,
+        v_mean: Option<i32>,
         i_meas: Option<i32>,
-        drive_ticks: u32,
-        recip_arr: u32,
         r_q12: u16,
         recip_ke_q: u16,
     ) -> i16 {
-        if let (Some(vdiff), Some(i)) = (vdiff_drive, i_meas) {
-            let v_mean = q_mul(
-                drive_ticks as i32 * vdiff,
-                recip_arr as i32,
-                RECIP_ARR_SHIFT,
-            );
+        if let (Some(v_mean), Some(i)) = (v_mean, i_meas) {
             let r_drop = q_mul(r_q12 as i32, i, 12);
             let omega = q_mul(v_mean - r_drop, recip_ke_q as i32, RECIP_KE_SHIFT);
             let x = omega << GUARD;
@@ -87,27 +83,33 @@ mod tests {
     use super::*;
 
     const ARR: u32 = 1200;
-    const RECIP_ARR: u32 = (1 << RECIP_ARR_SHIFT) / ARR;
     // unity Ke: 1.0 c/s per vcount
     const KE_UNITY: u16 = 1 << RECIP_KE_SHIFT;
+
+    /// The kernel-side hoisted computation, per `RECIP_ARR_SHIFT`.
+    fn v_mean(vdiff: i32, ticks: u32, arr: u32) -> i32 {
+        let recip = (1u32 << RECIP_ARR_SHIFT) / arr;
+        q_mul(ticks as i32 * vdiff, recip as i32, RECIP_ARR_SHIFT)
+    }
 
     #[test]
     fn zero_current_scaling() {
         // 50% duty of vdiff=3000 -> v_mean ideal 1500, floor 1499
+        let vm = v_mean(3000, 600, ARR);
+        assert_eq!(vm, 1499);
         let mut obs = BemfObs::new();
-        let out = obs.step(Some(3000), Some(0), 600, RECIP_ARR, 4096, KE_UNITY);
-        assert_eq!(out, 1499);
+        assert_eq!(obs.step(Some(vm), Some(0), 4096, KE_UNITY), 1499);
         // rig-scale recip_ke ~3.61 c/s per vcount: 1499 * 3700 >> 10
         let mut obs = BemfObs::new();
-        let out = obs.step(Some(3000), Some(0), 600, RECIP_ARR, 4096, 3700);
-        assert_eq!(out, 5416);
+        assert_eq!(obs.step(Some(vm), Some(0), 4096, 3700), 5416);
     }
 
     #[test]
     fn r_drop_reduces_omega_toward_zero() {
         // v_mean 1499; r=0.5 Q4.12, i=2048 -> r_drop 1024 -> omega 475
+        let vm = v_mean(3000, 600, ARR);
         let mut obs = BemfObs::new();
-        let out = obs.step(Some(3000), Some(2048), 600, RECIP_ARR, 2048, KE_UNITY);
+        let out = obs.step(Some(vm), Some(2048), 2048, KE_UNITY);
         assert_eq!(out, 475);
         assert!(out < 1499);
         assert!(out > 0);
@@ -116,60 +118,50 @@ mod tests {
     #[test]
     fn sign_symmetry() {
         // exact-power-of-two drive: arr=1024, ticks=512, vdiff +-2048 -> +-1024
-        let recip = (1u32 << RECIP_ARR_SHIFT) / 1024;
         let mut fwd = BemfObs::new();
         let mut rev = BemfObs::new();
-        let f = fwd.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY);
-        let r = rev.step(Some(-2048), Some(0), 512, recip, 4096, KE_UNITY);
+        let f = fwd.step(Some(v_mean(2048, 512, 1024)), Some(0), 4096, KE_UNITY);
+        let r = rev.step(Some(v_mean(-2048, 512, 1024)), Some(0), 4096, KE_UNITY);
         assert_eq!(f, 1024);
         assert_eq!(r, -1024);
     }
 
     #[test]
     fn invalid_window_holds_last_output() {
-        let recip = (1u32 << RECIP_ARR_SHIFT) / 1024;
+        let vm = v_mean(2048, 512, 1024);
         let mut obs = BemfObs::new();
-        assert_eq!(
-            obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY),
-            1024
-        );
-        assert_eq!(obs.step(None, Some(0), 512, recip, 4096, KE_UNITY), 1024);
-        assert_eq!(obs.step(Some(2048), None, 512, recip, 4096, KE_UNITY), 1024);
-        assert_eq!(obs.step(None, None, 0, recip, 4096, KE_UNITY), 1024);
+        assert_eq!(obs.step(Some(vm), Some(0), 4096, KE_UNITY), 1024);
+        assert_eq!(obs.step(None, Some(0), 4096, KE_UNITY), 1024);
+        assert_eq!(obs.step(Some(vm), None, 4096, KE_UNITY), 1024);
+        assert_eq!(obs.step(None, None, 4096, KE_UNITY), 1024);
         // valid sample moves it again
-        assert!(obs.step(Some(0), Some(0), 512, recip, 4096, KE_UNITY) < 1024);
+        assert!(obs.step(Some(0), Some(0), 4096, KE_UNITY) < 1024);
     }
 
     #[test]
     fn saturates_at_i16_bounds() {
         // full duty, full vdiff, max recip_ke: omega 262012 >> i16::MAX
         let mut obs = BemfObs::new();
-        let out = obs.step(Some(4095), Some(0), ARR, RECIP_ARR, 0, u16::MAX);
+        let out = obs.step(Some(v_mean(4095, ARR, ARR)), Some(0), 0, u16::MAX);
         assert_eq!(out, i16::MAX);
         assert_eq!(obs.omega_cps(), 262_012);
         let mut obs = BemfObs::new();
-        let out = obs.step(Some(-4095), Some(0), ARR, RECIP_ARR, 0, u16::MAX);
+        let out = obs.step(Some(v_mean(-4095, ARR, ARR)), Some(0), 0, u16::MAX);
         assert_eq!(out, i16::MIN);
         assert_eq!(obs.omega_cps(), -262_077);
     }
 
     #[test]
     fn ewma_seeds_then_converges() {
-        let recip = (1u32 << RECIP_ARR_SHIFT) / 1024;
+        let vm = v_mean(2048, 512, 1024);
         let mut obs = BemfObs::new();
         // seed at 0, then step toward 1024: alpha 1/4 from the seed
-        assert_eq!(obs.step(Some(0), Some(0), 512, recip, 4096, KE_UNITY), 0);
-        assert_eq!(
-            obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY),
-            256
-        );
-        assert_eq!(
-            obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY),
-            448
-        );
+        assert_eq!(obs.step(Some(0), Some(0), 4096, KE_UNITY), 0);
+        assert_eq!(obs.step(Some(vm), Some(0), 4096, KE_UNITY), 256);
+        assert_eq!(obs.step(Some(vm), Some(0), 4096, KE_UNITY), 448);
         let mut last = 0i16;
         for _ in 0..40 {
-            last = obs.step(Some(2048), Some(0), 512, recip, 4096, KE_UNITY);
+            last = obs.step(Some(vm), Some(0), 4096, KE_UNITY);
         }
         assert!((last as i32 - 1024).abs() <= 1, "last={last}");
     }

--- a/firmware/lib/core/src/estimator/fusion.rs
+++ b/firmware/lib/core/src/estimator/fusion.rs
@@ -1,0 +1,300 @@
+//! Fixed-gain 3-state fusion observer (control-theory "The Fusion Filter").
+//! Predict pushes theta/omega through the mechanical model - b_i bakes
+//! Kt*Ts/J so current counts map straight to csQ16 - and correct nudges all
+//! three states against the measured pot position. The third state is the
+//! disturbance torque the model cannot explain, in current counts; it feeds
+//! stall/collision detection and telemetry. Gains are host-synthesized
+//! constants (no runtime matrix math on this chip).
+
+use crate::math::q_mul;
+
+/// Predict skips the Coulomb term below 1 c/s: at rest omega dithers around
+/// zero by sub-count amounts, and a sign-chattering sgn(omega)*fric_fc would
+/// inject phantom +-fric_fc drive into every predict.
+const FRIC_OMEGA_EPS_CSQ16: i32 = 1 << 16;
+
+/// theta is NOT clamped to the pot span - it must track the measurement
+/// freely so e stays honest past the ends. The bound only guards i32: pot
+/// tops at 4095<<16 < 2^28, so |pos<<16 - theta| <= 2^28 + 2^29 fits i32.
+const THETA_LIM_CQ16: i32 = 1 << 29;
+
+/// Innovation clamp, 128 counts. The worst correct-step product is a Q8.8
+/// gain at u16::MAX: 65535 * 2^23 >> 8 = 65535 << 15 < i32::MAX, so no
+/// q_mul result wraps for any gain encoding; also bounds glitch response.
+const E_LIM_CQ16: i32 = 1 << 23;
+
+/// i16 c/s full scale in csQ16 (SG90 tops ~9000 c/s, 3.6x headroom).
+const OMEGA_LIM_CSQ16: i32 = 32767 << 16;
+
+/// Full shunt scale in ccQ16 - a disturbance beyond +-4095 current counts
+/// is not resolvable by the model anyway.
+const TAU_D_LIM_CCQ16: i32 = 4095 << 16;
+
+/// CALIB motor (b_i, fric_fc) + CONFIG fusion correction gains, loaded fresh
+/// each step by the kernel.
+#[derive(Copy, Clone)]
+pub struct FusionGains {
+    pub b_i_q016: u16,
+    pub l1_q016: u16,
+    pub l2_q88: u16,
+    pub l3_q88: u16,
+    pub l_bemf_q016: u16,
+    pub fric_fc_counts: u16,
+}
+
+fn fric_c(omega_q16: i32, fric_fc_counts: u16) -> i32 {
+    if omega_q16 > FRIC_OMEGA_EPS_CSQ16 {
+        fric_fc_counts as i32
+    } else if omega_q16 < -FRIC_OMEGA_EPS_CSQ16 {
+        -(fric_fc_counts as i32)
+    } else {
+        0
+    }
+}
+
+/// States: theta cQ16 (pot counts), omega csQ16, tau_d ccQ16.
+#[derive(Default)]
+pub struct FusionObs {
+    theta_q16: i32,
+    omega_q16: i32,
+    tau_d_q16: i32,
+}
+
+impl FusionObs {
+    pub const fn new() -> Self {
+        Self {
+            theta_q16: 0,
+            omega_q16: 0,
+            tau_d_q16: 0,
+        }
+    }
+
+    /// Reset to the measurement. Kernel calls at install and on the
+    /// torque-enable edge so stale states never kick a fresh enable.
+    pub fn seed(&mut self, pos_meas: u16) {
+        self.theta_q16 = (pos_meas as i32) << 16;
+        self.omega_q16 = 0;
+        self.tau_d_q16 = 0;
+    }
+
+    /// One MEDIUM-tick predict+correct. `i_counts` is i_use, already
+    /// resolved by the caller: i_meas when the shunt window is valid, else
+    /// i_ref - the observer never sees the validity flag. `dt_med_q32` =
+    /// 2^32 / MED_HZ (MED_HZ >= 2 keeps it under 2^31, so the i32 cast is
+    /// value-preserving).
+    pub fn step(
+        &mut self,
+        i_counts: i32,
+        pos_meas: u16,
+        omega_bemf_cps_q16: Option<i32>,
+        dt_med_q32: u32,
+        gains: &FusionGains,
+    ) {
+        // Predict. b_i Q0.16 < 1.0 so |delta| <= |accel|; saturating subs
+        // guard a hostile i_counts, everything downstream is clamp-bounded.
+        let fric = fric_c(self.omega_q16, gains.fric_fc_counts);
+        let accel = i_counts
+            .saturating_sub(fric)
+            .saturating_sub(self.tau_d_q16 >> 16);
+        self.omega_q16 = self
+            .omega_q16
+            .saturating_add(q_mul(gains.b_i_q016 as i32, accel, 16))
+            .clamp(-OMEGA_LIM_CSQ16, OMEGA_LIM_CSQ16);
+        // |omega| <= 2^31, dt < 2^31 -> |delta| < 2^30
+        self.theta_q16 = self
+            .theta_q16
+            .saturating_add(q_mul(self.omega_q16, dt_med_q32 as i32, 32))
+            .clamp(-THETA_LIM_CQ16, THETA_LIM_CQ16);
+
+        // Correct. Plain sub is safe: 2^28 + 2^29 < 2^31 (theta clamp).
+        let e = (((pos_meas as i32) << 16) - self.theta_q16).clamp(-E_LIM_CQ16, E_LIM_CQ16);
+        self.theta_q16 = self
+            .theta_q16
+            .saturating_add(q_mul(gains.l1_q016 as i32, e, 16))
+            .clamp(-THETA_LIM_CQ16, THETA_LIM_CQ16);
+        self.omega_q16 = self
+            .omega_q16
+            .saturating_add(q_mul(gains.l2_q88 as i32, e, 8))
+            .clamp(-OMEGA_LIM_CSQ16, OMEGA_LIM_CSQ16);
+        self.tau_d_q16 = self
+            .tau_d_q16
+            .saturating_sub(q_mul(gains.l3_q88 as i32, e, 8))
+            .clamp(-TAU_D_LIM_CCQ16, TAU_D_LIM_CCQ16);
+
+        // bemf blend; config defaults l_bemf 0 = off until bench-validated.
+        if gains.l_bemf_q016 > 0
+            && let Some(w) = omega_bemf_cps_q16
+        {
+            let e_w = w.saturating_sub(self.omega_q16);
+            self.omega_q16 = self
+                .omega_q16
+                .saturating_add(q_mul(gains.l_bemf_q016 as i32, e_w, 16))
+                .clamp(-OMEGA_LIM_CSQ16, OMEGA_LIM_CSQ16);
+        }
+    }
+
+    pub fn theta_q16(&self) -> i32 {
+        self.theta_q16
+    }
+
+    pub fn omega_q16(&self) -> i32 {
+        self.omega_q16
+    }
+
+    /// Whole current counts. The state clamp already bounds to +-4095; the
+    /// i16 clamp is the saturating ABI cast.
+    pub fn tau_d_counts(&self) -> i16 {
+        (self.tau_d_q16 >> 16).clamp(i16::MIN as i32, i16::MAX as i32) as i16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 2 kHz MEDIUM rate, matching the kernel's DT_MED_Q32 derivation.
+    const DT: u32 = ((1u64 << 32) / 2000) as u32;
+
+    // Hand-picked stable set for the 2 kHz discrete observer: l1 = 0.25,
+    // l2 = 4.0 c/s per count, l3 = 64.0 cc per count, b_i ~ 1.0. The b_i
+    // encoding couples current into omega at <= 1 q16 per ccount per tick,
+    // so tau_d only acts through whole counts (tau_d >> 16) and needs a
+    // large l3 for usable bandwidth; l2 stays small so the position
+    // transient does not rail omega. If a convergence test oscillates the
+    // fix is smaller gains, not more iterations.
+    const G: FusionGains = FusionGains {
+        b_i_q016: 65535,
+        l1_q016: 16384,
+        l2_q88: 1024,
+        l3_q88: 16384,
+        l_bemf_q016: 0,
+        fric_fc_counts: 0,
+    };
+
+    #[test]
+    fn seed_identity() {
+        let mut f = FusionObs::new();
+        f.seed(1234);
+        assert_eq!(f.theta_q16(), 1234 << 16);
+        assert_eq!(f.omega_q16(), 0);
+        assert_eq!(f.tau_d_counts(), 0);
+    }
+
+    #[test]
+    fn static_convergence() {
+        // Seed 10 counts below the measurement, zero current: theta locks
+        // to the measurement, omega and tau_d bleed back to ~0. 40000
+        // ticks (20 s) because the tau_d -> omega bleed path only sees
+        // whole counts of tau_d. Residuals below the quantization floors
+        // (omega under ~2200 q16 moves theta by 0 per tick), pinned exact.
+        let mut f = FusionObs::new();
+        f.seed(1990);
+        for _ in 0..40000 {
+            f.step(0, 2000, None, DT, &G);
+        }
+        assert_eq!(f.theta_q16(), 2000 << 16, "pin");
+        assert_eq!(f.omega_q16(), 1998, "pin");
+        assert_eq!(f.tau_d_counts(), 0, "pin");
+    }
+
+    #[test]
+    fn constant_velocity_tracking() {
+        // pos ramps 1 count/tick = 2000 c/s; omega settles onto the ramp
+        // rate (measured residual ~0.25%, assert 1%).
+        let mut f = FusionObs::new();
+        f.seed(0);
+        for n in 1..=3000u16 {
+            f.step(0, n, None, DT, &G);
+        }
+        let target = 2000i32 << 16;
+        let err = (f.omega_q16() - target).abs();
+        assert!(err <= target / 100, "omega={} err={}", f.omega_q16(), err);
+    }
+
+    #[test]
+    fn disturbance_step() {
+        // Constant drive current with the measurement pinned: predict keeps
+        // pushing theta up, e goes negative, so tau_d -= l3*e rises until
+        // tau_d ~= i (a load exactly absorbing the drive), while the
+        // correct step keeps theta/omega anchored to the measurement.
+        let mut f = FusionObs::new();
+        f.seed(2000);
+        for _ in 0..20000 {
+            f.step(500, 2000, None, DT, &G);
+        }
+        let tau = f.tau_d_counts();
+        assert!((480..=505).contains(&tau), "tau_d={tau}");
+        let theta_err = (f.theta_q16() - (2000 << 16)).abs();
+        assert!(theta_err < 1 << 16, "theta={}", f.theta_q16());
+        assert!(f.omega_q16().abs() < 1 << 16, "omega={}", f.omega_q16());
+    }
+
+    #[test]
+    fn friction_zero_band() {
+        // At rest with a large Coulomb term configured, nothing moves:
+        // fric_c(0) = 0, e = 0, all deltas exactly zero.
+        let g = FusionGains {
+            fric_fc_counts: 1000,
+            ..G
+        };
+        let mut f = FusionObs::new();
+        f.seed(2048);
+        for _ in 0..100 {
+            f.step(0, 2048, None, DT, &g);
+            assert_eq!(f.theta_q16(), 2048 << 16);
+            assert_eq!(f.omega_q16(), 0);
+            assert_eq!(f.tau_d_counts(), 0);
+        }
+    }
+
+    #[test]
+    fn bemf_blend_off_at_zero_gain() {
+        let mut with = FusionObs::new();
+        let mut without = FusionObs::new();
+        with.seed(1000);
+        without.seed(1000);
+        for n in 0..500u16 {
+            with.step(200, 1000 + n, Some(5000 << 16), DT, &G);
+            without.step(200, 1000 + n, None, DT, &G);
+            assert_eq!(with.theta_q16(), without.theta_q16());
+            assert_eq!(with.omega_q16(), without.omega_q16());
+            assert_eq!(with.tau_d_counts(), without.tau_d_counts());
+        }
+    }
+
+    #[test]
+    fn bemf_blend_pulls_omega() {
+        let g = FusionGains {
+            l_bemf_q016: 16384,
+            ..G
+        };
+        let mut f = FusionObs::new();
+        f.seed(2000);
+        f.step(0, 2000, Some(1000 << 16), DT, &g);
+        assert!(f.omega_q16() > 0, "omega={}", f.omega_q16());
+    }
+
+    #[test]
+    fn clamps_under_hostile_gains() {
+        // Max-encoded gains, extreme inputs: debug overflow checks are the
+        // wrap detector; states must stay inside their clamps.
+        let g = FusionGains {
+            b_i_q016: u16::MAX,
+            l1_q016: u16::MAX,
+            l2_q88: u16::MAX,
+            l3_q88: u16::MAX,
+            l_bemf_q016: u16::MAX,
+            fric_fc_counts: u16::MAX,
+        };
+        let mut f = FusionObs::new();
+        for n in 0..2000 {
+            let pos = if n & 1 == 0 { 0 } else { 4095 };
+            let i = if n & 2 == 0 { i32::MAX } else { i32::MIN };
+            let w = Some(if n & 4 == 0 { i32::MAX } else { i32::MIN });
+            f.step(i, pos, w, DT, &g);
+            assert!(f.theta_q16().abs() <= THETA_LIM_CQ16);
+            assert!(f.omega_q16().abs() <= OMEGA_LIM_CSQ16);
+            assert!((f.tau_d_q16).abs() <= TAU_D_LIM_CCQ16);
+        }
+    }
+}

--- a/firmware/lib/core/src/estimator/mod.rs
+++ b/firmware/lib/core/src/estimator/mod.rs
@@ -3,11 +3,13 @@
 pub mod bemf;
 pub mod fusion;
 pub mod thermal;
+pub mod vbus;
 pub mod vcal;
 pub mod window;
 
 pub use bemf::BemfObs;
 pub use fusion::{FusionGains, FusionObs};
 pub use thermal::{ThermAnchor, ThermGates, WindingTherm};
+pub use vbus::VbusEst;
 pub use vcal::VcalLpf;
 pub use window::WindowSel;

--- a/firmware/lib/core/src/estimator/mod.rs
+++ b/firmware/lib/core/src/estimator/mod.rs
@@ -1,11 +1,13 @@
 //! Count-domain estimator blocks the kernel runs on a `SensorFrame`.
 
 pub mod bemf;
+pub mod fusion;
 pub mod thermal;
 pub mod vcal;
 pub mod window;
 
 pub use bemf::BemfObs;
+pub use fusion::{FusionGains, FusionObs};
 pub use thermal::{ThermAnchor, ThermGates, WindingTherm};
 pub use vcal::VcalLpf;
 pub use window::WindowSel;

--- a/firmware/lib/core/src/estimator/mod.rs
+++ b/firmware/lib/core/src/estimator/mod.rs
@@ -1,9 +1,11 @@
 //! Count-domain estimator blocks the kernel runs on a `SensorFrame`.
 
 pub mod bemf;
+pub mod thermal;
 pub mod vcal;
 pub mod window;
 
 pub use bemf::BemfObs;
+pub use thermal::{ThermAnchor, ThermGates, WindingTherm};
 pub use vcal::VcalLpf;
 pub use window::WindowSel;

--- a/firmware/lib/core/src/estimator/mod.rs
+++ b/firmware/lib/core/src/estimator/mod.rs
@@ -1,7 +1,9 @@
 //! Count-domain estimator blocks the kernel runs on a `SensorFrame`.
 
+pub mod bemf;
 pub mod vcal;
 pub mod window;
 
+pub use bemf::BemfObs;
 pub use vcal::VcalLpf;
 pub use window::WindowSel;

--- a/firmware/lib/core/src/estimator/mod.rs
+++ b/firmware/lib/core/src/estimator/mod.rs
@@ -1,0 +1,7 @@
+//! Count-domain estimator blocks the kernel runs on a `SensorFrame`.
+
+pub mod vcal;
+pub mod window;
+
+pub use vcal::VcalLpf;
+pub use window::WindowSel;

--- a/firmware/lib/core/src/estimator/thermal.rs
+++ b/firmware/lib/core/src/estimator/thermal.rs
@@ -1,0 +1,219 @@
+//! Winding-resistance thermometer, SLOW rate, telemetry-only in v1 (nothing
+//! consumes it yet). Copper's tempco turns the winding's DC resistance into a
+//! temperature probe: a gated LMS tracks R from `v_mean` and `i_meas`, then
+//! `t = t0 + k * (R - r0)` maps it through the CALIB anchor. The anchor is
+//! never re-measured at boot - a hot reboot would record a warm winding as
+//! ambient and bias the estimate low (control-theory "The Winding as a
+//! Thermometer").
+
+use crate::math::q_mul;
+
+/// Gate thresholds from CONFIG thermal (`rtherm_*`). The gates live inside
+/// the estimator, not the kernel: R only shows in `v_mean` when real current
+/// flows and the back-EMF term is negligible, so refusing bad samples is part
+/// of the estimate itself.
+#[derive(Copy, Clone)]
+pub struct ThermGates {
+    pub i_min_counts: u16,
+    pub omega_max_cps: u16,
+}
+
+/// CALIB winding anchor: cold resistance `r0_q12` (Q4.12 vcounts/ccount),
+/// its ambient `t0_cc` (centi-degC), R-to-T slope `k_r2t_q88` (centi-degC per
+/// Q4.12 LSB, Q8.8), LMS step `mu_q016` (Q0.16).
+#[derive(Copy, Clone)]
+pub struct ThermAnchor {
+    pub r0_q12: u16,
+    pub t0_cc: i16,
+    pub k_r2t_q88: u16,
+    pub mu_q016: u16,
+}
+
+/// Guard bits under Q4.12 so sub-LSB LMS steps accumulate instead of
+/// truncating to zero (bemf `state_qg` convention, more bits because mu is
+/// small). R full-scale 16.0 << GUARD stays well inside i32.
+const GUARD: u32 = 8;
+const R_MAX_QG: i32 = 16 << (12 + GUARD);
+
+/// `e_v` beyond this is garbage input (realistic magnitude < 2^17); the clamp
+/// bounds `mu << GUARD * e_v` inside the q_mul contract for any caller values.
+const E_MAX: i32 = 1 << 20;
+
+/// R estimate + cached temperature. `seed` installs the CALIB `r0_q12`
+/// (kernel install, and again on a calib rewrite); unseeded `step` is a
+/// no-op reporting the anchor temperature.
+#[derive(Default)]
+pub struct WindingTherm {
+    r_qg: i32,
+    t_cc: i16,
+    seeded: bool,
+}
+
+impl WindingTherm {
+    pub const fn new() -> Self {
+        Self {
+            r_qg: 0,
+            t_cc: 0,
+            seeded: false,
+        }
+    }
+
+    pub fn seed(&mut self, r0_q12: u16) {
+        self.r_qg = (r0_q12 as i32) << GUARD;
+        self.seeded = true;
+    }
+
+    /// One SLOW-tick update. `v_mean` per the bemf RECIP_ARR convention,
+    /// `omega_hat_abs_cps` from the fusion observer. Gate: current present
+    /// and above `i_min_counts`, speed below `omega_max_cps`; a refused
+    /// sample holds R. Signed-LMS (sign-data variant): the update is
+    /// `e_v * sgn(i)`, not `e_v * i`, so the step size stays mu-controlled
+    /// independent of current magnitude. `t_cc` is re-derived from the held
+    /// R every seeded step so an anchor rewrite lands without waiting for a
+    /// gate pass. Returns the cached temperature.
+    pub fn step(
+        &mut self,
+        v_mean: i32,
+        i_meas: Option<i32>,
+        omega_hat_abs_cps: u32,
+        gates: &ThermGates,
+        anchor: &ThermAnchor,
+    ) -> i16 {
+        if !self.seeded {
+            self.t_cc = anchor.t0_cc;
+            return self.t_cc;
+        }
+        if let Some(i) = i_meas
+            && i.unsigned_abs() > gates.i_min_counts as u32
+            && omega_hat_abs_cps < gates.omega_max_cps as u32
+        {
+            let r_drop = q_mul(self.r_qg >> GUARD, i, 12);
+            let e_v = v_mean.saturating_sub(r_drop).clamp(-E_MAX, E_MAX);
+            let e_signed = if i < 0 { -e_v } else { e_v };
+            let step = q_mul((anchor.mu_q016 as i32) << GUARD, e_signed, 16);
+            self.r_qg = (self.r_qg + step).clamp(0, R_MAX_QG);
+        }
+        let dt = q_mul(
+            (self.r_qg >> GUARD) - anchor.r0_q12 as i32,
+            anchor.k_r2t_q88 as i32,
+            8,
+        );
+        let t = anchor.t0_cc as i32 + dt;
+        self.t_cc = t.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+        self.t_cc
+    }
+
+    /// Saturating cast matching telemetry `est.r_hat_q12`.
+    pub fn r_q12(&self) -> u16 {
+        (self.r_qg >> GUARD).clamp(0, u16::MAX as i32) as u16
+    }
+
+    /// Cached output of the last `step`.
+    pub fn t_cc(&self) -> i16 {
+        self.t_cc
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GATES: ThermGates = ThermGates {
+        i_min_counts: 300,
+        omega_max_cps: 400,
+    };
+    // r0 3.0 Q4.12, 25.00C, 2.00 cc per Q12 LSB, mu ~0.1
+    const ANCHOR: ThermAnchor = ThermAnchor {
+        r0_q12: 12288,
+        t0_cc: 2500,
+        k_r2t_q88: 512,
+        mu_q016: 6554,
+    };
+
+    #[test]
+    fn unseeded_step_is_noop() {
+        let mut th = WindingTherm::new();
+        for _ in 0..4 {
+            assert_eq!(th.step(3000, Some(4096), 0, &GATES, &ANCHOR), 2500);
+        }
+        assert_eq!(th.r_q12(), 0);
+        assert_eq!(th.t_cc(), 2500);
+    }
+
+    #[test]
+    fn gate_refuses_bad_samples() {
+        let mut th = WindingTherm::new();
+        th.seed(ANCHOR.r0_q12);
+        // low current, high speed, no current: R held at r0 -> t0
+        assert_eq!(th.step(3000, Some(300), 0, &GATES, &ANCHOR), 2500);
+        assert_eq!(th.step(3000, Some(4096), 400, &GATES, &ANCHOR), 2500);
+        assert_eq!(th.step(3000, None, 0, &GATES, &ANCHOR), 2500);
+        assert_eq!(th.r_q12(), ANCHOR.r0_q12);
+    }
+
+    #[test]
+    fn converges_to_warm_r() {
+        // R_true = r0 + 400; i = 4096 makes v_mean = R_true exactly, so the
+        // LMS equilibrium is exact. t = 2500 + (12688 - 12288) * 512 >> 8
+        //   = 2500 + 400 * 2 = 3300 (33.00C).
+        let r_true = 12688i32;
+        let v_mean = q_mul(r_true, 4096, 12);
+        assert_eq!(v_mean, r_true);
+        let mut th = WindingTherm::new();
+        th.seed(ANCHOR.r0_q12);
+        let mut t = 0i16;
+        for _ in 0..2000 {
+            t = th.step(v_mean, Some(4096), 0, &GATES, &ANCHOR);
+        }
+        assert_eq!(th.r_q12(), r_true as u16);
+        assert_eq!(t, 3300);
+        assert_eq!(th.t_cc(), 3300);
+    }
+
+    #[test]
+    fn negative_current_converges_identically() {
+        let r_true = 12688i32;
+        let v_mean = q_mul(r_true, -4096, 12);
+        assert_eq!(v_mean, -r_true);
+        let mut th = WindingTherm::new();
+        th.seed(ANCHOR.r0_q12);
+        for _ in 0..2000 {
+            th.step(v_mean, Some(-4096), 0, &GATES, &ANCHOR);
+        }
+        assert_eq!(th.r_q12(), r_true as u16);
+        assert_eq!(th.t_cc(), 3300);
+    }
+
+    #[test]
+    fn hostile_mu_saturates_no_wrap() {
+        let hot = ThermAnchor {
+            mu_q016: u16::MAX,
+            ..ANCHOR
+        };
+        let mut th = WindingTherm::new();
+        th.seed(hot.r0_q12);
+        for _ in 0..100 {
+            th.step(i32::MAX, Some(301), 0, &GATES, &hot);
+        }
+        assert_eq!(th.r_q12(), u16::MAX);
+        assert_eq!(th.t_cc(), i16::MAX);
+        for _ in 0..100 {
+            th.step(i32::MIN, Some(301), 0, &GATES, &hot);
+        }
+        assert_eq!(th.r_q12(), 0);
+        // R clamped at 0: t = t0 - r0 * k >> 8 = 2500 - 24576
+        assert_eq!(th.t_cc(), -22076);
+    }
+
+    #[test]
+    fn cold_anchor_identity() {
+        // R == r0 with a consistent v_mean: e_v = 0, t == t0 exactly
+        let mut th = WindingTherm::new();
+        th.seed(ANCHOR.r0_q12);
+        let v_mean = q_mul(ANCHOR.r0_q12 as i32, 4096, 12);
+        for _ in 0..8 {
+            assert_eq!(th.step(v_mean, Some(4096), 0, &GATES, &ANCHOR), 2500);
+        }
+        assert_eq!(th.r_q12(), ANCHOR.r0_q12);
+    }
+}

--- a/firmware/lib/core/src/estimator/vbus.rs
+++ b/firmware/lib/core/src/estimator/vbus.rs
@@ -18,6 +18,7 @@ pub struct VbusEst {
     state_qg: i32,
     initialized: bool,
     recip_q15: u32,
+    fresh: bool,
 }
 
 impl VbusEst {
@@ -26,7 +27,17 @@ impl VbusEst {
             state_qg: 0,
             initialized: false,
             recip_q15: 0,
+            fresh: false,
         }
+    }
+
+    /// True iff a valid drive-window sample landed since the last call;
+    /// clears on read. Undervolt verdicts gate on this: a held (stale)
+    /// estimate is not evidence - a sagged reading frozen by the fault's
+    /// own bridge-off otherwise re-latches forever (fault -> no drive ->
+    /// no fresh sample -> fault).
+    pub fn take_fresh(&mut self) -> bool {
+        core::mem::take(&mut self.fresh)
     }
 
     /// Install-time seed from the first frame or a nominal, so boot does not
@@ -49,6 +60,7 @@ impl VbusEst {
                 self.state_qg = x;
                 self.initialized = true;
             }
+            self.fresh = true;
         }
         self.update_recip(undervolt_floor_counts);
     }

--- a/firmware/lib/core/src/estimator/vbus.rs
+++ b/firmware/lib/core/src/estimator/vbus.rs
@@ -1,0 +1,155 @@
+//! Supply-voltage estimator. EWMA of the driven-terminal sample (fwd ->
+//! vmotor_a, rev -> vmotor_b; the kernel window-selects) plus the cached Q15
+//! supply reciprocal the current loop compensates with. The spec sketches an
+//! incremental one-Newton-step-per-tick reciprocal; this runs the shared
+//! full-accuracy `math::recip_div` every step instead - ~10 multiplies at
+//! MEDIUM (2 kHz) is noise, and one reciprocal implementation beats two.
+
+use crate::math::recip_div;
+
+const GUARD: u32 = 3;
+const ALPHA_SHIFT: u32 = 3;
+
+/// EWMA alpha 1/8 with 3 guard bits; the first valid sample seeds the state
+/// (`BemfObs` convention). A fresh `new()` carries recip 0 - duty 0 through
+/// the current loop - until the first sample or an install-time `seed`.
+#[derive(Default)]
+pub struct VbusEst {
+    state_qg: i32,
+    initialized: bool,
+    recip_q15: u32,
+}
+
+impl VbusEst {
+    pub const fn new() -> Self {
+        Self {
+            state_qg: 0,
+            initialized: false,
+            recip_q15: 0,
+        }
+    }
+
+    /// Install-time seed from the first frame or a nominal, so boot does not
+    /// ride a zero reciprocal through an EWMA settle.
+    pub fn seed(&mut self, vbus_counts: u16, floor: u16) {
+        self.state_qg = (vbus_counts as i32) << GUARD;
+        self.initialized = true;
+        self.update_recip(floor);
+    }
+
+    /// One MEDIUM-tick update. `vdrive` = the window-selected driven-terminal
+    /// sample; `None` (window under the vmotor validity floor) holds the last
+    /// estimate - vbus moves slowly.
+    pub fn step(&mut self, vdrive: Option<u16>, undervolt_floor_counts: u16) {
+        if let Some(v) = vdrive {
+            let x = (v as i32) << GUARD;
+            if self.initialized {
+                self.state_qg += (x - self.state_qg) >> ALPHA_SHIFT;
+            } else {
+                self.state_qg = x;
+                self.initialized = true;
+            }
+        }
+        self.update_recip(undervolt_floor_counts);
+    }
+
+    /// The floor clamp (>= 1 backstop) bounds the reciprocal: a glitched
+    /// near-zero sample cannot blow it up and drive duty to the rail - the
+    /// worst case the current loop ever sees is the undervolt floor's own
+    /// reciprocal, and undervolt is the fault path's call.
+    fn update_recip(&mut self, floor: u16) {
+        let d = (self.vbus_counts() as u32).max(floor.max(1) as u32);
+        self.recip_q15 = recip_div(32767u32 << 15, d);
+    }
+
+    /// Filtered supply, vcounts.
+    pub fn vbus_counts(&self) -> u16 {
+        (self.state_qg >> GUARD) as u16
+    }
+
+    /// Contract: `q_mul(u_vcounts, recip_q15 as i32, 15)` maps u == vbus to
+    /// ~32767 - the pair `CurrentLoop::step` expects for `recip_vbus_q15`.
+    pub fn recip_q15(&self) -> u32 {
+        self.recip_q15
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::q_mul;
+
+    /// Contract residual: 0 means q_mul(vbus, recip, 15) hit 32767 exactly.
+    fn recip_err(vbus: u16, recip: u32) -> i32 {
+        q_mul(vbus as i32, recip as i32, 15) - 32767
+    }
+
+    #[test]
+    fn seed_sets_state_and_recip() {
+        let mut est = VbusEst::new();
+        assert_eq!(est.recip_q15(), 0);
+        est.seed(3000, 100);
+        assert_eq!(est.vbus_counts(), 3000);
+        assert!(recip_err(3000, est.recip_q15()).abs() <= 1);
+    }
+
+    #[test]
+    fn first_sample_seeds_then_ewma_pins() {
+        let mut est = VbusEst::new();
+        est.step(Some(800), 1);
+        assert_eq!(est.vbus_counts(), 800);
+        // alpha 1/8: 800 + 800/8 = 900, then 900 + 700/8 = 987 in Q3
+        est.step(Some(1600), 1);
+        assert_eq!(est.vbus_counts(), 900);
+        est.step(Some(1600), 1);
+        assert_eq!(est.vbus_counts(), 987);
+    }
+
+    #[test]
+    fn none_holds_value_and_recip() {
+        let mut est = VbusEst::new();
+        est.seed(2500, 1);
+        let r = est.recip_q15();
+        est.step(None, 1);
+        assert_eq!(est.vbus_counts(), 2500);
+        assert_eq!(est.recip_q15(), r);
+    }
+
+    #[test]
+    fn floor_clamps_recip() {
+        // vbus sags to 5: the estimate follows but the reciprocal caps at
+        // the floor's, not 5's (~200x larger)
+        let mut est = VbusEst::new();
+        est.seed(5, 1000);
+        assert_eq!(est.vbus_counts(), 5);
+        assert!(recip_err(1000, est.recip_q15()).abs() <= 1);
+        // never-seeded zero vbus with floor 0: the >= 1 backstop pins the
+        // recip_div d <= 1 path
+        let mut cold = VbusEst::new();
+        cold.step(None, 0);
+        assert_eq!(cold.recip_q15(), 32767 << 15);
+    }
+
+    #[test]
+    fn recip_contract_sweep() {
+        let mut est = VbusEst::new();
+        for vbus in 1000..4000u16 {
+            est.seed(vbus, 1);
+            let err = recip_err(vbus, est.recip_q15());
+            assert!(err.abs() <= 1, "vbus={vbus} err={err}");
+        }
+    }
+
+    #[test]
+    fn recip_tracks_vbus_step_within_ewma_lag() {
+        let mut est = VbusEst::new();
+        est.seed(4000, 100);
+        // tau ~8 steps; 80 steps is >5 tau plus the truncation tail
+        for _ in 0..80 {
+            est.step(Some(3000), 100);
+        }
+        let v = est.vbus_counts();
+        assert!((v as i32 - 3000).abs() <= 1, "v={v}");
+        assert!(recip_err(v, est.recip_q15()).abs() <= 1);
+    }
+}

--- a/firmware/lib/core/src/estimator/vcal.rs
+++ b/firmware/lib/core/src/estimator/vcal.rs
@@ -1,5 +1,4 @@
-//! Count-domain estimator blocks the kernel runs on a `SensorFrame`. `VcalLpf`
-//! is the first.
+//! Vcal reference low-pass filter.
 
 /// Vcal reference low-pass filter. EWMA, alpha = 1/128. `state_q6` keeps 6
 /// sub-LSB bits so the filter resolves drift slower than 1 LSB per step

--- a/firmware/lib/core/src/estimator/window.rs
+++ b/firmware/lib/core/src/estimator/window.rs
@@ -1,0 +1,217 @@
+//! Drive-window selection for the twin per-period ADC scans. Center-aligned
+//! PWMMODE1 with the chip-side CCR mapping (Slow: STATIC_HIGH + arr-ticks,
+//! Fast: ticks + 0) puts the drive window at the counter PEAK under Slow
+//! decay and at the TROUGH under Fast, for either drive direction - decay
+//! alone picks the scan half. The shunt is direction-blind, so the signed
+//! current takes its sign from the commanded duty.
+
+use crate::SensorFrame;
+use crate::traits::DecayMode;
+
+/// Which scan half carries the drive window and whether it is wide enough
+/// for each sense path to have settled.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct WindowSel {
+    pub i_valid: bool,
+    pub v_valid: bool,
+    pub use_trough: bool,
+}
+
+/// `drive_ticks` is the TIM1 compare width the motor write used; the caller
+/// passes 0 for Coast/Brake/Disabled or zero duty, which invalidates both
+/// paths even against a zero floor. Floors are board-data minimum widths
+/// (`i_window_min_ticks` / `v_window_min_ticks`).
+pub fn select(decay: DecayMode, drive_ticks: u32, i_floor: u16, v_floor: u16) -> WindowSel {
+    WindowSel {
+        i_valid: drive_ticks != 0 && drive_ticks >= i_floor as u32,
+        v_valid: drive_ticks != 0 && drive_ticks >= v_floor as u32,
+        use_trough: matches!(decay, DecayMode::Fast),
+    }
+}
+
+/// Signed bias-subtracted shunt current from the drive-window scan, or `None`
+/// when the window is too narrow for a settled sample.
+pub fn i_from_frame(
+    frame: &SensorFrame,
+    sel: WindowSel,
+    duty_sign_positive: bool,
+    bias: u16,
+) -> Option<i32> {
+    if !sel.i_valid {
+        return None;
+    }
+    let sample = if sel.use_trough {
+        frame.current_trough
+    } else {
+        frame.current
+    };
+    let mag = sample as i32 - bias as i32;
+    Some(if duty_sign_positive { mag } else { -mag })
+}
+
+/// Drive-window vmotor pair: (driven-high terminal sample = vbus candidate,
+/// differential `va - vb`). Positive duty drives IN1 (TIM1 CH3, PC6) ->
+/// DRV8212P OUT1 -> MOT_A -> VSNA -> `vmotor_a`, so forward drive reads
+/// `vmotor_a` and `va - vb` is positive under forward drive, negative under
+/// reverse - the sign convention downstream bemf math relies on.
+pub fn vdrive_from_frame(frame: &SensorFrame, sel: WindowSel, forward: bool) -> Option<(u16, i32)> {
+    if !sel.v_valid {
+        return None;
+    }
+    let (va, vb) = if sel.use_trough {
+        (frame.vmotor_a_trough, frame.vmotor_b_trough)
+    } else {
+        (frame.vmotor_a, frame.vmotor_b)
+    };
+    let vdrive = if forward { va } else { vb };
+    Some((vdrive, va as i32 - vb as i32))
+}
+
+/// Mirrors chip-side `effort_to_ticks` (`mag * arr / 32767` approximated as
+/// round(`mag * arr >> 15`)) so validity floors compare against the same
+/// width the motor write programs.
+pub fn drive_ticks(duty: i16, pwm_arr: u16) -> u32 {
+    let mag = duty.unsigned_abs().min(i16::MAX as u16) as u32;
+    (mag * pwm_arr as u32 + (1 << 14)) >> 15
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame() -> SensorFrame {
+        SensorFrame {
+            current: 2500,
+            current_trough: 1500,
+            vmotor_a: 3000,
+            vmotor_a_trough: 2900,
+            vmotor_b: 100,
+            vmotor_b_trough: 90,
+            ..Default::default()
+        }
+    }
+
+    fn valid(use_trough: bool) -> WindowSel {
+        WindowSel {
+            i_valid: true,
+            v_valid: true,
+            use_trough,
+        }
+    }
+
+    #[test]
+    fn slow_decay_selects_peak_fast_selects_trough() {
+        assert!(!select(DecayMode::Slow, 500, 240, 220).use_trough);
+        assert!(select(DecayMode::Fast, 500, 240, 220).use_trough);
+    }
+
+    #[test]
+    fn floor_boundaries() {
+        let s = select(DecayMode::Slow, 239, 240, 220);
+        assert!(!s.i_valid);
+        assert!(s.v_valid);
+        let s = select(DecayMode::Slow, 240, 240, 220);
+        assert!(s.i_valid);
+        assert!(s.v_valid);
+        let s = select(DecayMode::Slow, 219, 240, 220);
+        assert!(!s.i_valid);
+        assert!(!s.v_valid);
+    }
+
+    #[test]
+    fn zero_ticks_invalid_even_with_zero_floors() {
+        let s = select(DecayMode::Slow, 0, 0, 0);
+        assert!(!s.i_valid);
+        assert!(!s.v_valid);
+    }
+
+    #[test]
+    fn current_peak_vs_trough_pick() {
+        let f = frame();
+        assert_eq!(i_from_frame(&f, valid(false), true, 0), Some(2500));
+        assert_eq!(i_from_frame(&f, valid(true), true, 0), Some(1500));
+    }
+
+    #[test]
+    fn current_bias_and_sign() {
+        let f = frame();
+        assert_eq!(i_from_frame(&f, valid(false), true, 2048), Some(452));
+        assert_eq!(i_from_frame(&f, valid(false), false, 2048), Some(-452));
+        // sample below bias with positive duty reads negative
+        assert_eq!(i_from_frame(&f, valid(true), true, 2048), Some(-548));
+    }
+
+    #[test]
+    fn current_invalid_window_is_none() {
+        let f = frame();
+        let sel = WindowSel {
+            i_valid: false,
+            v_valid: true,
+            use_trough: false,
+        };
+        assert_eq!(i_from_frame(&f, sel, true, 0), None);
+    }
+
+    #[test]
+    fn vdrive_geometry_all_four_rows() {
+        let f = frame();
+        // Slow fwd: vmotor_a peak
+        assert_eq!(
+            vdrive_from_frame(&f, valid(false), true),
+            Some((3000, 2900))
+        );
+        // Slow rev: vmotor_b peak
+        assert_eq!(
+            vdrive_from_frame(&f, valid(false), false),
+            Some((100, 2900))
+        );
+        // Fast fwd: vmotor_a trough
+        assert_eq!(vdrive_from_frame(&f, valid(true), true), Some((2900, 2810)));
+        // Fast rev: vmotor_b trough
+        assert_eq!(vdrive_from_frame(&f, valid(true), false), Some((90, 2810)));
+    }
+
+    #[test]
+    fn vdrive_differential_sign_tracks_drive_direction() {
+        let fwd = frame();
+        let (_, d) = vdrive_from_frame(&fwd, valid(false), true).unwrap();
+        assert!(d > 0);
+        let rev = SensorFrame {
+            vmotor_a: 100,
+            vmotor_b: 3000,
+            ..Default::default()
+        };
+        let (v, d) = vdrive_from_frame(&rev, valid(false), false).unwrap();
+        assert_eq!(v, 3000);
+        assert!(d < 0);
+    }
+
+    #[test]
+    fn vdrive_invalid_window_is_none() {
+        let f = frame();
+        let sel = WindowSel {
+            i_valid: true,
+            v_valid: false,
+            use_trough: false,
+        };
+        assert_eq!(vdrive_from_frame(&f, sel, true), None);
+    }
+
+    #[test]
+    fn drive_ticks_pins_chip_mapping() {
+        assert_eq!(drive_ticks(0, 1200), 0);
+        assert_eq!(drive_ticks(i16::MAX, 1200), 1200);
+        assert_eq!(drive_ticks(-i16::MAX, 1200), 1200);
+        assert_eq!(drive_ticks(i16::MIN, 1200), 1200);
+    }
+
+    #[test]
+    fn drive_ticks_monotonic() {
+        let mut last = 0;
+        for duty in (0..=i16::MAX).step_by(317) {
+            let t = drive_ticks(duty, 1200);
+            assert!(t >= last, "non-monotonic at duty={duty}: {last} -> {t}");
+            last = t;
+        }
+    }
+}

--- a/firmware/lib/core/src/kernel.rs
+++ b/firmware/lib/core/src/kernel.rs
@@ -7,8 +7,6 @@ pub struct Kernel<I: ControlIo> {
     pub io: I,
     pub state: KernelState,
     pub vcal_lpf: VcalLpf,
-    pub stream_decimation_counter: u8,
-    pub stream_duration_remaining_ticks: u32,
 }
 
 #[derive(Default)]
@@ -23,8 +21,6 @@ impl<I: ControlIo> Kernel<I> {
             io,
             state: KernelState::default(),
             vcal_lpf: VcalLpf::new(),
-            stream_decimation_counter: 1,
-            stream_duration_remaining_ticks: 0,
         }
     }
 

--- a/firmware/lib/core/src/kernel.rs
+++ b/firmware/lib/core/src/kernel.rs
@@ -38,6 +38,7 @@ impl<I: ControlIo> Kernel<I> {
             (&raw mut (*s).vcal_lpf).write_volatile(vcal_lpf);
             (&raw mut (*s).vmotor_a).write_volatile(frame.vmotor_a);
             (&raw mut (*s).vmotor_b).write_volatile(frame.vmotor_b);
+            (&raw mut (*s).current_trough).write_volatile(frame.current_trough);
         }
         // TODO: PID + mode dispatch + motor.write once the control loop lands.
     }

--- a/firmware/lib/core/src/kernel/current.rs
+++ b/firmware/lib/core/src/kernel/current.rs
@@ -1,0 +1,314 @@
+//! Voltage-domain current PI (control-theory "The Current Loop"): PI plus
+//! back-EMF decoupling feedforward, supply compensation via the vbus
+//! reciprocal, and a voltage-domain clamp at duty_max*vbus whose excess
+//! back-calculates into the one integrator. Clamping in volts means the
+//! anti-windup term needs no domain crossing and duty <= duty_max by
+//! construction, sagging battery included.
+
+use crate::math::q_mul;
+
+/// PI error clamp, ccounts. Physical error is bounded by shunt full scale
+/// plus the current limit (|i_meas| <= 4095, |i_ref| <= i_lim <= 4095), so
+/// 8192 is never hit in operation; the clamp exists so gain products stay
+/// i32-exact: u16 gain * 2^13 <= 2^29.
+const E_LIM_CC: i32 = 8192;
+
+/// Back-calculation excess clamp, vcounts. The excess u_cl - u is unbounded
+/// (u saturates i32 under hostile inputs); 8192 is already 2x a 12-bit vbus,
+/// so clamping only limits the per-tick unwind rate, and the product bound
+/// matches E_LIM_CC: kaw * 2^13 <= 2^29.
+const AW_LIM_VC: i32 = 8192;
+
+/// CONFIG loop_current gains plus the CALIB forward Ke, loaded fresh each
+/// step by the kernel. `ke_q412` is `CalibMotor.ke_vpc_q`: vcounts per c/s,
+/// the decoupling feedforward (NOT `recip_ke_q`, which points the other way).
+#[derive(Copy, Clone)]
+pub struct CurrentGains {
+    pub kp_q88: u16,
+    pub ki_q412: u16,
+    pub kaw_q412: u16,
+    pub ke_q412: u16,
+    pub duty_max_q15: u16,
+}
+
+/// State: one voltage-domain integrator (vcounts Q16.16) and the last duty
+/// written, kept for telemetry `duty_applied_q15`.
+#[derive(Default)]
+pub struct CurrentLoop {
+    integ_vq16: i32,
+    last_duty_q15: i16,
+}
+
+impl CurrentLoop {
+    pub const fn new() -> Self {
+        Self {
+            integ_vq16: 0,
+            last_duty_q15: 0,
+        }
+    }
+
+    /// Zero state; kernel calls on the enable edge so a stale integrator
+    /// never kicks a fresh enable.
+    pub fn reset(&mut self) {
+        self.integ_vq16 = 0;
+        self.last_duty_q15 = 0;
+    }
+
+    pub fn last_duty_q15(&self) -> i16 {
+        self.last_duty_q15
+    }
+
+    /// One FAST-tick update -> duty. `i_meas` None (shunt window invalid)
+    /// freezes the whole integrator update - ki term and back-calc both -
+    /// and the output rides integrator + feedforward until the window
+    /// returns. `omega_hat_q16` csQ16 from fusion; `recip_vbus_q15` is the
+    /// vbus estimator's Newton reciprocal, contract `(recip * vbus) >> 15
+    /// ~= 32767` (math::recip_seed_q15) - the pair must describe the same
+    /// vbus or the duty cap is off by their mismatch.
+    pub fn step(
+        &mut self,
+        i_ref: i32,
+        i_meas: Option<i32>,
+        omega_hat_q16: i32,
+        vbus_counts: u16,
+        recip_vbus_q15: u32,
+        gains: &CurrentGains,
+    ) -> i16 {
+        let e = match i_meas {
+            Some(i) => i_ref.saturating_sub(i).clamp(-E_LIM_CC, E_LIM_CC),
+            None => 0,
+        };
+        // kp * 2^13 <= 2^29, i32-exact before the shift
+        let u_pi = q_mul(gains.kp_q88 as i32, e, 8).saturating_add(self.integ_vq16 >> 16);
+        // csQ16 * Q4.12 >> 28 -> vcounts; i64 product <= 2^31 * 2^16 = 2^47
+        let u_ff = q_mul(omega_hat_q16, gains.ke_q412 as i32, 28);
+        let u = u_pi.saturating_add(u_ff);
+        // duty_max * vbus <= 2^15 * 2^16 = 2^31, exact in the i64 widen
+        let v_max = q_mul(gains.duty_max_q15 as i32, vbus_counts as i32, 15);
+        let u_cl = u.clamp(-v_max, v_max);
+        if i_meas.is_some() {
+            let aw = u_cl.saturating_sub(u).clamp(-AW_LIM_VC, AW_LIM_VC);
+            // Q4.12 * ccounts -> vQ16 needs << (16 - 12); the products are
+            // i32-exact (<= 2^29 per the E/AW clamps) but << 4 can reach
+            // 2^33, so the shift saturates via mul. Integrator clamp:
+            // +-(v_max << 16), never charged past what the output can
+            // deliver (belt on top of back-calc); v_max <= 65535 so the
+            // shift saturates too (12-bit vbus keeps it far below).
+            let ki_term = q_mul(gains.ki_q412 as i32, e, 0).saturating_mul(1 << 4);
+            let aw_term = q_mul(gains.kaw_q412 as i32, aw, 0).saturating_mul(1 << 4);
+            let lim = v_max.saturating_mul(1 << 16);
+            self.integ_vq16 = self
+                .integ_vq16
+                .saturating_add(ki_term)
+                .saturating_add(aw_term)
+                .clamp(-lim, lim);
+        }
+        // min guards the i32 cast: a reciprocal with bit 31 set would flip
+        // the duty sign; the undervolt-floored vbus keeps real reciprocals
+        // far below. |u_cl| * recip <= 2^17 * 2^31 = 2^48, i64-safe.
+        let recip = recip_vbus_q15.min(i32::MAX as u32) as i32;
+        let duty = q_mul(u_cl, recip, 15).clamp(-(i16::MAX as i32), i16::MAX as i32) as i16;
+        self.last_duty_q15 = duty;
+        duty
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VBUS: u16 = 3000;
+    // floor reciprocal per the recip contract: (RECIP * VBUS) >> 15 = 32766
+    const RECIP: u32 = ((32767u64 << 15) / VBUS as u64) as u32;
+    const VBUS_SAG: u16 = 2400;
+    const RECIP_SAG: u32 = ((32767u64 << 15) / VBUS_SAG as u64) as u32;
+
+    fn recip_for(vbus: u16) -> u32 {
+        ((32767u64 << 15) / vbus as u64) as u32
+    }
+
+    const KP_1: u16 = 1 << 8; // 1.0 vcounts/ccount
+
+    fn g(kp: u16, ki: u16, kaw: u16, ke: u16, duty_max: u16) -> CurrentGains {
+        CurrentGains {
+            kp_q88: kp,
+            ki_q412: ki,
+            kaw_q412: kaw,
+            ke_q412: ke,
+            duty_max_q15: duty_max,
+        }
+    }
+
+    /// Static resistive plant, R = 4 vcounts/ccount: applied volts are the
+    /// duty fraction of vbus, current is v/R. 20 kHz is far above the
+    /// electrical pole so the lag is dropped; steady state is what the
+    /// integrator tests need.
+    fn plant_i(duty: i16, vbus: u16) -> i32 {
+        q_mul(duty as i32, vbus as i32, 15) >> 2
+    }
+
+    #[test]
+    fn p_only_step_toward_setpoint() {
+        // e=500 * kp 1.0 -> u=500 vcounts; duty = 500*RECIP>>15 = 5461
+        // (~500/3000 of full scale). Arithmetic shift floors the negative
+        // side to -5462.
+        let gains = g(KP_1, 0, 0, 0, 32767);
+        let mut cur = CurrentLoop::new();
+        assert_eq!(cur.step(500, Some(0), 0, VBUS, RECIP, &gains), 5461);
+        assert_eq!(cur.last_duty_q15(), 5461);
+        let mut cur = CurrentLoop::new();
+        assert_eq!(cur.step(-500, Some(0), 0, VBUS, RECIP, &gains), -5462);
+    }
+
+    #[test]
+    fn integrator_eliminates_steady_state_error() {
+        // R=4 plant wants u=2000 for i=500. P-only settles at
+        // i = kp*e/R -> e*(1/16): huge standing error; PI closes it.
+        let p_only = g(64, 0, 0, 0, 32767);
+        let mut cur = CurrentLoop::new();
+        let mut i = 0i32;
+        for _ in 0..500 {
+            i = plant_i(cur.step(500, Some(i), 0, VBUS, RECIP, &p_only), VBUS);
+        }
+        assert!(i < 100, "p-only i={i}");
+
+        let pi = g(64, 200, 0, 0, 32767);
+        let mut cur = CurrentLoop::new();
+        let mut i = 0i32;
+        for _ in 0..500 {
+            i = plant_i(cur.step(500, Some(i), 0, VBUS, RECIP, &pi), VBUS);
+        }
+        assert!((i - 500).abs() <= 1, "pi i={i}");
+    }
+
+    #[test]
+    fn invalid_window_holds_integrator_outputs_ff() {
+        let gains = g(64, 200, 0, 1 << 12, 32767);
+        let mut cur = CurrentLoop::new();
+        for _ in 0..50 {
+            cur.step(500, Some(0), 0, VBUS, RECIP, &gains);
+        }
+        // None freezes the integrator: repeated steps identical
+        let d1 = cur.step(500, None, 0, VBUS, RECIP, &gains);
+        let d2 = cur.step(500, None, 0, VBUS, RECIP, &gains);
+        assert_eq!(d1, d2);
+        // ff still live: ke 1.0, omega 100 c/s -> +100 vcounts ->
+        // +100*RECIP>>15 = +1092 duty on top of the held integrator
+        let d3 = cur.step(500, None, 100 << 16, VBUS, RECIP, &gains);
+        assert_eq!(d3 - d1, 1092);
+        // valid sample moves it again
+        let d4 = cur.step(500, Some(0), 0, VBUS, RECIP, &gains);
+        assert!(d4 > d1);
+    }
+
+    #[test]
+    fn back_calc_prevents_windup() {
+        // Phase 1: i_ref 4000 unreachable (plant caps at v_max/4 ~ 750);
+        // phase 2: drop to reachable 200 (u ~ 800 < v_max 2999) and count
+        // ticks pinned near the cap. Back-calc holds the integrator at the
+        // saturation equilibrium u = v_max + (ki/kaw)*e, so the release
+        // unsaturates on the first tick; without it the integrator rails at
+        // the v_max<<16 clamp and must grind back down through ki alone
+        // (slow ki here so that grind is visible).
+        let run = |kaw: u16| -> u32 {
+            let gains = g(64, 50, kaw, 0, 32767);
+            let mut cur = CurrentLoop::new();
+            let mut i = 0i32;
+            let mut duty = 0i16;
+            for _ in 0..300 {
+                duty = cur.step(4000, Some(i), 0, VBUS, RECIP, &gains);
+                i = plant_i(duty, VBUS);
+            }
+            // v_max = 32767*3000>>15 = 2999 -> duty 2999*RECIP>>15 = 32756
+            assert_eq!(duty, 32756, "saturated, kaw={kaw}");
+            let mut ticks = 0u32;
+            while ticks < 200 {
+                duty = cur.step(200, Some(i), 0, VBUS, RECIP, &gains);
+                i = plant_i(duty, VBUS);
+                if duty < 30000 {
+                    break;
+                }
+                ticks += 1;
+            }
+            ticks
+        };
+        let with_aw = run(2048);
+        let without_aw = run(0);
+        assert!(with_aw <= 3, "with_aw={with_aw}");
+        assert!(without_aw > 3 * (with_aw + 1), "without_aw={without_aw}");
+    }
+
+    #[test]
+    fn vbus_compensation_and_sagging_cap() {
+        // Unsaturated: fixed u_ff = 1000 vcounts (ke 1.0, omega 1000 c/s,
+        // None so PI stays zero). Sag raises the reciprocal, so the same
+        // voltage command costs more duty: 1000/3000 vs 1000/2400 of scale.
+        let gains = g(0, 0, 0, 1 << 12, 32767);
+        let mut cur = CurrentLoop::new();
+        assert_eq!(cur.step(0, None, 1000 << 16, VBUS, RECIP, &gains), 10922);
+        let mut cur = CurrentLoop::new();
+        assert_eq!(
+            cur.step(0, None, 1000 << 16, VBUS_SAG, RECIP_SAG, &gains),
+            13652
+        );
+
+        // Saturated at duty_max 0.5: available volts scale with vbus, so
+        // the R=4 plant settles at v_max/4 - less current from a sagging
+        // battery even though duty sits at the cap either way.
+        let gains = g(64, 200, 2048, 0, 16384);
+        let settle = |vbus: u16, recip: u32| -> (i16, i32) {
+            let mut cur = CurrentLoop::new();
+            let mut i = 0i32;
+            let mut duty = 0i16;
+            for _ in 0..300 {
+                duty = cur.step(4000, Some(i), 0, vbus, recip, &gains);
+                i = plant_i(duty, vbus);
+            }
+            (duty, i)
+        };
+        let (duty_full, i_full) = settle(VBUS, RECIP);
+        let (duty_sag, i_sag) = settle(VBUS_SAG, RECIP_SAG);
+        assert!(duty_full <= 16384 && duty_sag <= 16384);
+        // v_max: 16384*3000>>15 = 1499 -> i 374; 16384*2400>>15 = 1199 -> 299
+        assert_eq!(i_full, 374);
+        assert_eq!(i_sag, 299);
+    }
+
+    #[test]
+    fn duty_capped_for_any_input() {
+        // Floor reciprocal keeps recip*vbus <= 32767<<15, so the voltage
+        // clamp maps to duty <= duty_max exactly; sweep hostile corners
+        // including i32 extremes and a pre-wound integrator.
+        let gains = g(KP_1, 200, 2048, 1 << 12, 20000);
+        for vbus in [2400u16, 3000, 4095] {
+            let recip = recip_for(vbus);
+            for i_ref in [i32::MIN, -8000, 0, 500, 8000, i32::MAX] {
+                for omega in [i32::MIN, -(9000 << 16), 0, 9000 << 16, i32::MAX] {
+                    for i_meas in [None, Some(-4095), Some(0), Some(4095)] {
+                        let mut cur = CurrentLoop::new();
+                        for _ in 0..20 {
+                            let d = cur.step(i_ref, i_meas, omega, vbus, recip, &gains);
+                            assert!(
+                                d.unsigned_abs() <= 20000,
+                                "d={d} vbus={vbus} i_ref={i_ref} omega={omega}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn reset_zeroes_state() {
+        let gains = g(64, 200, 0, 0, 32767);
+        let mut cur = CurrentLoop::new();
+        for _ in 0..50 {
+            cur.step(500, Some(0), 0, VBUS, RECIP, &gains);
+        }
+        assert_ne!(cur.step(0, Some(0), 0, VBUS, RECIP, &gains), 0);
+        cur.reset();
+        assert_eq!(cur.last_duty_q15(), 0);
+        assert_eq!(cur.step(0, Some(0), 0, VBUS, RECIP, &gains), 0);
+    }
+}

--- a/firmware/lib/core/src/kernel/current.rs
+++ b/firmware/lib/core/src/kernel/current.rs
@@ -62,9 +62,9 @@ impl CurrentLoop {
     /// freezes the whole integrator update - ki term and back-calc both -
     /// and the output rides integrator + feedforward until the window
     /// returns. `omega_hat_q16` csQ16 from fusion; `recip_vbus_q15` is the
-    /// vbus estimator's Newton reciprocal, contract `(recip * vbus) >> 15
-    /// ~= 32767` (math::recip_seed_q15) - the pair must describe the same
-    /// vbus or the duty cap is off by their mismatch.
+    /// vbus estimator's reciprocal, contract `(recip * vbus) >> 15
+    /// ~= 32767` (estimator::vbus::VbusEst) - the pair must describe the
+    /// same vbus or the duty cap is off by their mismatch.
     pub fn step(
         &mut self,
         i_ref: i32,

--- a/firmware/lib/core/src/kernel/faults.rs
+++ b/firmware/lib/core/src/kernel/faults.rs
@@ -1,0 +1,223 @@
+//! Fault latch + detectors (spec "Fault raise points"). Any set bit forces
+//! MotorCmd::Disabled regardless of torque_enable; the torque_enable 0->1
+//! edge is the only ack - it clears the mask and the detector state, and a
+//! still-present condition re-latches through the normal detectors.
+
+pub const BIT_OVER_CURRENT: u8 = 1 << 0;
+pub const BIT_OVER_TEMP: u8 = 1 << 1;
+pub const BIT_STALL: u8 = 1 << 2;
+pub const BIT_POSITION_ERROR: u8 = 1 << 3;
+pub const BIT_SENSOR: u8 = 1 << 4;
+pub const BIT_UNDER_VOLT: u8 = 1 << 5;
+
+/// `fault_code` values: bit index + 1, 0 = no fault since the last ack.
+pub const CODE_NONE: u8 = 0;
+pub const CODE_OVER_CURRENT: u8 = 1;
+pub const CODE_OVER_TEMP: u8 = 2;
+pub const CODE_STALL: u8 = 3;
+pub const CODE_POSITION_ERROR: u8 = 4;
+pub const CODE_SENSOR: u8 = 5;
+pub const CODE_UNDER_VOLT: u8 = 6;
+
+/// Latched mask + the LATEST newly-latched kind (`fault_code`). Re-raising
+/// an already-set bit does not touch the code, so a persisting first fault
+/// cannot mask a later second one.
+pub struct FaultLatch {
+    mask: u8,
+    last_code: u8,
+}
+
+impl FaultLatch {
+    pub const fn new() -> Self {
+        Self {
+            mask: 0,
+            last_code: CODE_NONE,
+        }
+    }
+
+    pub fn raise(&mut self, bit: u8, code: u8) {
+        if self.mask & bit == 0 {
+            self.mask |= bit;
+            self.last_code = code;
+        }
+    }
+
+    /// Ack (torque_enable 0->1): mask and code both clear.
+    pub fn clear(&mut self) {
+        self.mask = 0;
+        self.last_code = CODE_NONE;
+    }
+
+    pub fn mask(&self) -> u8 {
+        self.mask
+    }
+
+    pub fn code(&self) -> u8 {
+        self.last_code
+    }
+}
+
+impl Default for FaultLatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Detector counters, kept together so `kernel/mod.rs` stays orchestration:
+/// OC consecutive-sample count (FAST), position-error persistence timer
+/// (MEDIUM), sensor-delta screen with its last raw sample (MEDIUM).
+pub struct Detectors {
+    oc_ticks: u8,
+    pos_err_ticks: u32,
+    sensor_bad: u8,
+    sensor_last_pos: u16,
+    sensor_seen: bool,
+}
+
+impl Detectors {
+    pub const fn new() -> Self {
+        Self {
+            oc_ticks: 0,
+            pos_err_ticks: 0,
+            sensor_bad: 0,
+            sensor_last_pos: 0,
+            sensor_seen: false,
+        }
+    }
+
+    /// Ack: every counter re-arms; the sensor screen re-primes off the next
+    /// sample instead of comparing across the disabled gap.
+    pub fn reset(&mut self) {
+        self.oc_ticks = 0;
+        self.pos_err_ticks = 0;
+        self.sensor_bad = 0;
+        self.sensor_seen = false;
+    }
+
+    /// FAST: `over` = Some(|i_meas| > oc_trip_counts) for a VALID window,
+    /// None when the window is invalid. Invalid samples hold the count - a
+    /// masked window must not launder a live overcurrent - and a valid
+    /// below-trip sample re-arms. Returns true when the window fills.
+    pub fn oc_sample(&mut self, over: Option<bool>, trip_ticks: u8) -> bool {
+        match over {
+            Some(true) => {
+                self.oc_ticks = self.oc_ticks.saturating_add(1);
+                self.oc_ticks >= trip_ticks
+            }
+            Some(false) => {
+                self.oc_ticks = 0;
+                false
+            }
+            None => false,
+        }
+    }
+
+    /// MEDIUM: raw pot delta screen; `bad_count` consecutive jumps trip.
+    pub fn sensor_sample(&mut self, pos: u16, delta_max: u16, bad_count: u8) -> bool {
+        let delta = (pos as i32 - self.sensor_last_pos as i32).unsigned_abs();
+        let jump = self.sensor_seen && delta > delta_max as u32;
+        self.sensor_last_pos = pos;
+        self.sensor_seen = true;
+        if jump {
+            self.sensor_bad = self.sensor_bad.saturating_add(1);
+            self.sensor_bad >= bad_count
+        } else {
+            self.sensor_bad = 0;
+            false
+        }
+    }
+
+    /// MEDIUM: tracking-error persistence; trips after `trip_ticks`
+    /// consecutive over-threshold medium ticks.
+    pub fn pos_err_sample(&mut self, over: bool, trip_ticks: u32) -> bool {
+        if over {
+            self.pos_err_ticks = self.pos_err_ticks.saturating_add(1);
+            self.pos_err_ticks >= trip_ticks
+        } else {
+            self.pos_err_ticks = 0;
+            false
+        }
+    }
+}
+
+impl Default for Detectors {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latch_latest_code_first_bit_wins_nothing() {
+        let mut l = FaultLatch::new();
+        assert_eq!((l.mask(), l.code()), (0, CODE_NONE));
+        l.raise(BIT_OVER_CURRENT, CODE_OVER_CURRENT);
+        assert_eq!((l.mask(), l.code()), (BIT_OVER_CURRENT, CODE_OVER_CURRENT));
+        // re-raise of a set bit: code untouched
+        l.raise(BIT_OVER_CURRENT, CODE_OVER_CURRENT);
+        l.raise(BIT_STALL, CODE_STALL);
+        assert_eq!(l.mask(), BIT_OVER_CURRENT | BIT_STALL);
+        assert_eq!(l.code(), CODE_STALL);
+        // persisting first fault does not clobber the latest latch
+        l.raise(BIT_OVER_CURRENT, CODE_OVER_CURRENT);
+        assert_eq!(l.code(), CODE_STALL);
+        l.clear();
+        assert_eq!((l.mask(), l.code()), (0, CODE_NONE));
+    }
+
+    #[test]
+    fn oc_consecutive_valid_only() {
+        let mut d = Detectors::new();
+        for _ in 0..3 {
+            assert!(!d.oc_sample(Some(true), 4));
+        }
+        // invalid holds the count, does not reset
+        assert!(!d.oc_sample(None, 4));
+        assert!(d.oc_sample(Some(true), 4));
+        // valid below-trip re-arms
+        let mut d = Detectors::new();
+        for _ in 0..3 {
+            d.oc_sample(Some(true), 4);
+        }
+        assert!(!d.oc_sample(Some(false), 4));
+        for _ in 0..3 {
+            assert!(!d.oc_sample(Some(true), 4));
+        }
+        assert!(d.oc_sample(Some(true), 4));
+    }
+
+    #[test]
+    fn sensor_screen_primes_and_counts() {
+        let mut d = Detectors::new();
+        // first sample only primes, no matter how large
+        assert!(!d.sensor_sample(4000, 10, 2));
+        assert!(!d.sensor_sample(4020, 10, 2));
+        assert!(d.sensor_sample(4000, 10, 2));
+        // clean delta re-arms
+        let mut d = Detectors::new();
+        d.sensor_sample(100, 10, 2);
+        assert!(!d.sensor_sample(200, 10, 2));
+        assert!(!d.sensor_sample(205, 10, 2));
+        assert!(!d.sensor_sample(300, 10, 2));
+        assert!(d.sensor_sample(400, 10, 2));
+        // reset re-primes
+        d.reset();
+        assert!(!d.sensor_sample(0, 10, 2));
+    }
+
+    #[test]
+    fn pos_err_timer() {
+        let mut d = Detectors::new();
+        for _ in 0..9 {
+            assert!(!d.pos_err_sample(true, 10));
+        }
+        assert!(!d.pos_err_sample(false, 10));
+        for _ in 0..9 {
+            assert!(!d.pos_err_sample(true, 10));
+        }
+        assert!(d.pos_err_sample(true, 10));
+    }
+}

--- a/firmware/lib/core/src/kernel/ident.rs
+++ b/firmware/lib/core/src/kernel/ident.rs
@@ -1,0 +1,152 @@
+//! Identification aggregates (spec IDENT row): sum/min/max of per-tick
+//! current, drive-window differential, and commanded duty, folded over an
+//! own /16 fast-tick window - independent of DECIM_MED so the host fitter
+//! gets decimation-free statistics without streaming every tick. The window
+//! is a power of two so the mean is an arithmetic shift, no divide;
+//! truncation is toward -inf for negative sums (sub-LSB, irrelevant to a
+//! fit). The kernel feeds LAST-VALID current/vdiff through invalid windows
+//! rather than zeros: zeros would drag the means toward 0, last-valid keeps
+//! them unbiased at steady state, and identification runs at healthy duties
+//! where the windows are valid anyway.
+
+/// Window length as a shift: 16 fast ticks, mean = sum >> IDENT_SHIFT.
+pub const IDENT_SHIFT: u32 = 4;
+const IDENT_WINDOW: u8 = 1 << IDENT_SHIFT;
+
+/// One published window; `agg_seq` increments per window (wrapping) so the
+/// host pairs a consistent set across the six fields.
+pub struct IdentOut {
+    pub i_mean_counts: i16,
+    pub i_min_counts: i16,
+    pub i_max_counts: i16,
+    pub vdiff_mean: i16,
+    pub duty_mean_q15: i16,
+    pub agg_seq: u16,
+}
+
+pub struct IdentAgg {
+    ctr: u8,
+    i_sum: i32,
+    i_min: i16,
+    i_max: i16,
+    vdiff_sum: i32,
+    duty_sum: i32,
+    seq: u16,
+}
+
+/// A mean of 16 i16 samples always fits i16 (|sum| <= 16 * 32768); the
+/// clamp is a no-panic belt on that invariant.
+fn mean_i16(sum: i32) -> i16 {
+    let m = sum >> IDENT_SHIFT;
+    debug_assert!((i16::MIN as i32..=i16::MAX as i32).contains(&m));
+    m.clamp(i16::MIN as i32, i16::MAX as i32) as i16
+}
+
+impl IdentAgg {
+    pub const fn new() -> Self {
+        Self {
+            ctr: 0,
+            i_sum: 0,
+            i_min: i16::MAX,
+            i_max: i16::MIN,
+            vdiff_sum: 0,
+            duty_sum: 0,
+            seq: 0,
+        }
+    }
+
+    /// Fold one fast tick; returns the finished window every 16th call.
+    /// Sums cannot overflow: 16 x |i16| <= 2^19.
+    pub fn sample(&mut self, i: i16, vdiff: i16, duty: i16) -> Option<IdentOut> {
+        self.i_sum += i as i32;
+        self.i_min = self.i_min.min(i);
+        self.i_max = self.i_max.max(i);
+        self.vdiff_sum += vdiff as i32;
+        self.duty_sum += duty as i32;
+        self.ctr += 1;
+        if self.ctr < IDENT_WINDOW {
+            return None;
+        }
+        self.seq = self.seq.wrapping_add(1);
+        let out = IdentOut {
+            i_mean_counts: mean_i16(self.i_sum),
+            i_min_counts: self.i_min,
+            i_max_counts: self.i_max,
+            vdiff_mean: mean_i16(self.vdiff_sum),
+            duty_mean_q15: mean_i16(self.duty_sum),
+            agg_seq: self.seq,
+        };
+        self.ctr = 0;
+        self.i_sum = 0;
+        self.i_min = i16::MAX;
+        self.i_max = i16::MIN;
+        self.vdiff_sum = 0;
+        self.duty_sum = 0;
+        Some(out)
+    }
+}
+
+impl Default for IdentAgg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_length_and_stats() {
+        let mut agg = IdentAgg::new();
+        for n in 0..15 {
+            assert!(agg.sample(100 + n, 50, 8000).is_none());
+        }
+        let out = agg.sample(-60, 50, 8000).expect("16th sample publishes");
+        // sum = 100+..+114 - 60 = 1545 -> floor mean 96
+        assert_eq!(out.i_mean_counts, 96);
+        assert_eq!(out.i_min_counts, -60);
+        assert_eq!(out.i_max_counts, 114);
+        assert_eq!(out.vdiff_mean, 50);
+        assert_eq!(out.duty_mean_q15, 8000);
+        assert_eq!(out.agg_seq, 1);
+    }
+
+    #[test]
+    fn negative_mean_truncates_toward_neg_inf() {
+        let mut agg = IdentAgg::new();
+        for _ in 0..15 {
+            agg.sample(0, 0, 0);
+        }
+        let out = agg.sample(-5, -5, -5).expect("publish");
+        assert_eq!(out.i_mean_counts, -1);
+        assert_eq!(out.vdiff_mean, -1);
+        assert_eq!(out.duty_mean_q15, -1);
+    }
+
+    #[test]
+    fn extremes_survive_the_full_window() {
+        let mut agg = IdentAgg::new();
+        let mut out = None;
+        for _ in 0..16 {
+            out = agg.sample(i16::MIN, i16::MIN, i16::MIN);
+        }
+        let out = out.expect("publish");
+        assert_eq!(out.i_mean_counts, i16::MIN);
+        assert_eq!(out.i_min_counts, i16::MIN);
+        assert_eq!(out.i_max_counts, i16::MIN);
+    }
+
+    #[test]
+    fn seq_wraps() {
+        let mut agg = IdentAgg::new();
+        let mut last = 0u16;
+        for _ in 0..(u16::MAX as u32 + 1) {
+            for _ in 0..15 {
+                agg.sample(0, 0, 0);
+            }
+            last = agg.sample(0, 0, 0).expect("publish").agg_seq;
+        }
+        assert_eq!(last, 0, "seq wrapped through 65535");
+    }
+}

--- a/firmware/lib/core/src/kernel/limits.rs
+++ b/firmware/lib/core/src/kernel/limits.rs
@@ -128,6 +128,16 @@ impl LimitState {
         lim
     }
 
+    /// Torque-enable ack: drop the pending fault, unfold, re-arm a full
+    /// stall window. The derate cache survives - it is thermal state, not a
+    /// latch, and clearing it would hand a hot winding one SLOW period of
+    /// full current.
+    pub fn ack(&mut self) {
+        self.fault_pending = false;
+        self.stalled = false;
+        self.stall_ticks = 0;
+    }
+
     /// Cached output of the last `fold`.
     pub fn i_lim_counts(&self) -> u16 {
         self.i_lim

--- a/firmware/lib/core/src/kernel/limits.rs
+++ b/firmware/lib/core/src/kernel/limits.rs
@@ -22,6 +22,7 @@ pub struct LimitCfg {
     pub stall_time_ticks: u32,
     pub stall_yield_counts: u16,
     pub stall_release_counts: u16,
+    pub stall_tau_trip_counts: u16,
     pub derate_start_cc: i16,
     pub cutoff_cc: i16,
     pub pos_min_soft_counts: i32,
@@ -97,10 +98,9 @@ impl LimitState {
     /// inward push, and the door never reopens (caught on the bench).
     ///
     /// Stall: pinned and |omega_hat| < stall_omega_max for stall_time_ticks,
-    /// or a tau_d spike (collision). The v1 collision threshold is
-    /// tau_d_abs > current_limit_counts - model-unexplained torque exceeding
-    /// the commanded ceiling class - bench-tunable through the existing
-    /// fields, no new config. Yield folds to stall_yield_counts until
+    /// or a tau_d spike past stall_tau_trip_counts (collision) - its own
+    /// threshold, so a low bench ceiling does not hair-trigger the
+    /// collision path. Yield folds to stall_yield_counts until
     /// |tau_d| relaxes below stall_release_counts; Fault only pends -
     /// latching is kernel fault policy, and the kernel disables on latch, so
     /// folding here too would double-act.
@@ -118,7 +118,7 @@ impl LimitState {
             self.stalled = false;
             self.stall_ticks = 0;
         }
-        let mut trip = tau_d_abs_counts > cfg.current_limit_counts;
+        let mut trip = tau_d_abs_counts > cfg.stall_tau_trip_counts;
         if i_ref_pinned && omega_hat_abs_cps < cfg.stall_omega_max_cps as u32 {
             self.stall_ticks = self.stall_ticks.saturating_add(1);
             trip |= self.stall_ticks >= cfg.stall_time_ticks;
@@ -208,6 +208,7 @@ mod tests {
         stall_time_ticks: 10,
         stall_yield_counts: 300,
         stall_release_counts: 150,
+        stall_tau_trip_counts: 1200,
         derate_start_cc: 8000,
         cutoff_cc: 10000,
         pos_min_soft_counts: -4000,

--- a/firmware/lib/core/src/kernel/limits.rs
+++ b/firmware/lib/core/src/kernel/limits.rs
@@ -1,0 +1,384 @@
+//! i_lim composition (control-theory "Limits"): the current clamp is the one
+//! choke point every command passes through, so all protection lives here.
+//! i_lim = min of four terms - current_limit (gear teeth), thermal derate
+//! foldback (copper), stall fold (the losing fight), directional endstop
+//! (position walls). `fold` runs at MEDIUM and is compare/min only; the
+//! derate ceiling needs a reciprocal, so it is recomputed at SLOW and cached.
+
+use crate::math::q_mul_u;
+use crate::regions::config::StallResponse;
+
+/// CONFIG limits + thermal + pos-limits fields the block consumes, loaded
+/// fresh by the kernel each step (`CurrentGains` convention).
+#[derive(Copy, Clone)]
+pub struct LimitCfg {
+    pub current_limit_counts: u16,
+    pub stall_response: StallResponse,
+    pub drive_polarity: bool,
+    pub stall_omega_max_cps: u16,
+    /// Consecutive pinned-and-slow MEDIUM ticks before the stall trips. The
+    /// table field is `stall_time_ms`; the kernel converts ms -> ticks once
+    /// at config load, so the per-tick path never multiplies.
+    pub stall_time_ticks: u32,
+    pub stall_yield_counts: u16,
+    pub stall_release_counts: u16,
+    pub derate_start_cc: i16,
+    pub cutoff_cc: i16,
+    pub pos_min_soft_counts: i32,
+    pub pos_max_soft_counts: i32,
+}
+
+// Q1.30 linear reciprocal seed r0 = 48/17 - (32/17)x for the normalized
+// x in [0.5, 1): max relative error 1/17, so two Newton steps land at
+// (1/17)^4 ~ 1.2e-5. The power-of-two seed (math::recip_seed_q15) can start
+// a factor of 2 off, where r*(2 - r*d) convergence stalls - the default
+// 2000cc derate span seeds at x = 1.95 and would need ~8 steps - so the
+// one-shot derate uses the linear seed; the seed_q15 path stays for
+// estimators that refine across ticks.
+const SEED_C1_Q30: u32 = 3_031_741_621; // round(48/17 << 30)
+const SEED_C2_Q30: u32 = 2_021_161_080; // round(32/17 << 30)
+
+/// `num / d` without a divide. Normalize d into [2^31, 2^32) (Q0.32), linear
+/// seed + two Newton steps `r' = r*(2 - r*d)` in Q1.30, then one widening
+/// multiply denormalizes straight into the quotient. Error <= 1.2e-5
+/// relative plus truncation (pinned in tests). d == 0 has no quotient;
+/// callers gate the degenerate span, num is the no-panic backstop.
+fn recip_div_u(num: u32, d: u32) -> u32 {
+    if d <= 1 {
+        return num;
+    }
+    let n = d.leading_zeros(); // 1..=30 for d >= 2
+    let dn = d << n;
+    let mut r = SEED_C1_Q30 - q_mul_u(SEED_C2_Q30, dn, 32);
+    r = q_mul_u(r, (2u32 << 30) - q_mul_u(r, dn, 32), 30);
+    r = q_mul_u(r, (2u32 << 30) - q_mul_u(r, dn, 32), 30);
+    // num/d = num*r >> (62-n), split as (>> 32) then (>> 30-n): identical
+    // bits, but the u64 shift stays constant and the variable shift is u32 -
+    // a variable 64-bit shift is soft on rv32ec (check-soft-arith.sh bans it)
+    let p = num as u64 * r as u64;
+    ((p >> 32) as u32) >> (30 - n)
+}
+
+/// Stall timer + fold flag + the SLOW-cached derate ceiling. `derate_cache`
+/// boots non-binding (u16::MAX) so a fresh state is not zero-current for the
+/// first SLOW period; the base min still caps it at current_limit.
+pub struct LimitState {
+    stall_ticks: u32,
+    stalled: bool,
+    fault_pending: bool,
+    derate_cache: u16,
+    i_lim: u16,
+}
+
+impl LimitState {
+    pub const fn new() -> Self {
+        Self {
+            stall_ticks: 0,
+            stalled: false,
+            fault_pending: false,
+            derate_cache: u16::MAX,
+            i_lim: 0,
+        }
+    }
+
+    /// SLOW-rate: recompute the cached thermal ceiling. Foldback: full below
+    /// derate_start_cc, zero at cutoff_cc, linear between - self-regulating
+    /// (less current -> less heating -> equilibrium at "weaker but still
+    /// holding"). A degenerate span (cutoff <= start, no table cross-gate)
+    /// degrades to a step at cutoff. At 62.5 Hz the reciprocal's ~10
+    /// multiplies are noise.
+    pub fn update_derate(&mut self, t_winding_cc: i16, cfg: &LimitCfg) {
+        let span = cfg.cutoff_cc as i32 - cfg.derate_start_cc as i32;
+        self.derate_cache = if t_winding_cc >= cfg.cutoff_cc {
+            0
+        } else if t_winding_cc < cfg.derate_start_cc || span <= 0 {
+            cfg.current_limit_counts
+        } else {
+            // head in [1, span], both <= 65535: num fits u32 exactly
+            let head = (cfg.cutoff_cc as i32 - t_winding_cc as i32) as u32;
+            let num = cfg.current_limit_counts as u32 * head;
+            recip_div_u(num, span as u32).min(cfg.current_limit_counts as u32) as u16
+        };
+    }
+
+    /// One MEDIUM-tick composition -> i_lim ccounts for this tick's push.
+    /// Compare/min only, no multiplies. `i_ref_pinned` = the caller saw
+    /// i_ref sitting at the ceiling (the pin, not a measurement);
+    /// `i_sign_positive` is the sign of the command this limit clamps, and
+    /// with `drive_polarity` resolves which endstop is "inward".
+    ///
+    /// Stall: pinned and |omega_hat| < stall_omega_max for stall_time_ticks,
+    /// or a tau_d spike (collision). The v1 collision threshold is
+    /// tau_d_abs > current_limit_counts - model-unexplained torque exceeding
+    /// the commanded ceiling class - bench-tunable through the existing
+    /// fields, no new config. Yield folds to stall_yield_counts until
+    /// |tau_d| relaxes below stall_release_counts; Fault only pends -
+    /// latching is kernel fault policy, and the kernel disables on latch, so
+    /// folding here too would double-act.
+    pub fn fold(
+        &mut self,
+        i_ref_pinned: bool,
+        omega_hat_abs_cps: u32,
+        tau_d_abs_counts: u16,
+        theta_hat_counts: i32,
+        i_sign_positive: bool,
+        cfg: &LimitCfg,
+    ) -> u16 {
+        // release before the triggers: a relax re-arms a full stall window
+        // instead of instantly re-tripping off the stale timer
+        if self.stalled && tau_d_abs_counts < cfg.stall_release_counts {
+            self.stalled = false;
+            self.stall_ticks = 0;
+        }
+        let mut trip = tau_d_abs_counts > cfg.current_limit_counts;
+        if i_ref_pinned && omega_hat_abs_cps < cfg.stall_omega_max_cps as u32 {
+            self.stall_ticks = self.stall_ticks.saturating_add(1);
+            trip |= self.stall_ticks >= cfg.stall_time_ticks;
+        } else {
+            self.stall_ticks = 0;
+        }
+        if trip {
+            match cfg.stall_response {
+                StallResponse::Yield => self.stalled = true,
+                StallResponse::Fault => self.fault_pending = true,
+            }
+        }
+        let mut lim = cfg.current_limit_counts.min(self.derate_cache);
+        if self.stalled {
+            lim = lim.min(cfg.stall_yield_counts);
+        }
+        // endstop: inward current at/past a soft limit clamps to 0, retreat
+        // stays at the composed limit
+        let pushing_up = i_sign_positive == cfg.drive_polarity;
+        if (pushing_up && theta_hat_counts >= cfg.pos_max_soft_counts)
+            || (!pushing_up && theta_hat_counts <= cfg.pos_min_soft_counts)
+        {
+            lim = 0;
+        }
+        self.i_lim = lim;
+        lim
+    }
+
+    /// Cached output of the last `fold`.
+    pub fn i_lim_counts(&self) -> u16 {
+        self.i_lim
+    }
+
+    pub fn stalled(&self) -> bool {
+        self.stalled
+    }
+
+    pub fn stall_fault_pending(&self) -> bool {
+        self.fault_pending
+    }
+}
+
+impl Default for LimitState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CFG: LimitCfg = LimitCfg {
+        current_limit_counts: 1200,
+        stall_response: StallResponse::Yield,
+        drive_polarity: true,
+        stall_omega_max_cps: 500,
+        stall_time_ticks: 10,
+        stall_yield_counts: 300,
+        stall_release_counts: 150,
+        derate_start_cc: 8000,
+        cutoff_cc: 10000,
+        pos_min_soft_counts: -4000,
+        pos_max_soft_counts: 4000,
+    };
+
+    /// Mid-range, unpinned, no load: nothing but limit/derate can bind.
+    fn free_fold(st: &mut LimitState, cfg: &LimitCfg) -> u16 {
+        st.fold(false, 1000, 0, 0, true, cfg)
+    }
+
+    #[test]
+    fn cold_state_current_limit_binds() {
+        let mut st = LimitState::new();
+        assert_eq!(free_fold(&mut st, &CFG), 1200);
+        assert_eq!(st.i_lim_counts(), 1200);
+        assert!(!st.stalled());
+        assert!(!st.stall_fault_pending());
+    }
+
+    #[test]
+    fn derate_endpoints_and_midpoint() {
+        let mut st = LimitState::new();
+        st.update_derate(7999, &CFG);
+        assert_eq!(free_fold(&mut st, &CFG), 1200);
+        // onset: head == span, quotient = current_limit up to truncation
+        st.update_derate(8000, &CFG);
+        assert!(free_fold(&mut st, &CFG) >= 1199);
+        // midpoint -> half
+        st.update_derate(9000, &CFG);
+        let mid = free_fold(&mut st, &CFG);
+        assert!((599..=600).contains(&mid), "mid={mid}");
+        // cutoff and beyond -> zero
+        st.update_derate(10000, &CFG);
+        assert_eq!(free_fold(&mut st, &CFG), 0);
+        st.update_derate(12000, &CFG);
+        assert_eq!(free_fold(&mut st, &CFG), 0);
+        // recovery is just the next SLOW recompute
+        st.update_derate(2500, &CFG);
+        assert_eq!(free_fold(&mut st, &CFG), 1200);
+    }
+
+    #[test]
+    fn derate_degenerate_span_steps_at_cutoff() {
+        let cfg = LimitCfg {
+            derate_start_cc: 10000,
+            ..CFG
+        };
+        let mut st = LimitState::new();
+        st.update_derate(9999, &cfg);
+        assert_eq!(free_fold(&mut st, &cfg), 1200);
+        st.update_derate(10000, &cfg);
+        assert_eq!(free_fold(&mut st, &cfg), 0);
+    }
+
+    #[test]
+    fn recip_div_accuracy_pinned() {
+        // worst seeds are just under a power of two (x -> 1 from below maps
+        // to r near the interval edge); sweep those plus a dense band and
+        // the u32-extreme numerator. Bound: 1.2e-5 relative + 2 LSB.
+        let spot = [32767u32, 32768, 65534, 65535];
+        for d in (1..=4096u32).chain(spot) {
+            for num in [1u32, 999, 1_200 * 2_000, 4_294_836_225] {
+                let got = recip_div_u(num, d);
+                let exact = (num / d) as i64;
+                let err = (got as i64 - exact).abs();
+                assert!(
+                    err <= exact / 65536 + 2,
+                    "num={num} d={d} got={got} exact={exact}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn stall_timer_folds_under_yield() {
+        let mut st = LimitState::new();
+        for _ in 0..9 {
+            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+            assert!(!st.stalled());
+        }
+        assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 300);
+        assert!(st.stalled());
+        assert!(!st.stall_fault_pending());
+        assert_eq!(st.i_lim_counts(), 300);
+    }
+
+    #[test]
+    fn movement_resets_timer() {
+        let mut st = LimitState::new();
+        for _ in 0..9 {
+            st.fold(true, 0, 200, 0, true, &CFG);
+        }
+        // one fast tick clears the count; so does an unpinned one
+        st.fold(true, 500, 200, 0, true, &CFG);
+        for _ in 0..9 {
+            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+        }
+        st.fold(false, 0, 200, 0, true, &CFG);
+        for _ in 0..9 {
+            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+        }
+        assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 300);
+    }
+
+    #[test]
+    fn release_on_tau_d_relax_restores_and_rearms() {
+        let mut st = LimitState::new();
+        for _ in 0..10 {
+            st.fold(true, 0, 200, 0, true, &CFG);
+        }
+        assert!(st.stalled());
+        // tau_d still above release: stays folded
+        assert_eq!(st.fold(false, 1000, 150, 0, true, &CFG), 300);
+        // relax below release: restored, and a fresh window is required
+        assert_eq!(st.fold(false, 1000, 149, 0, true, &CFG), 1200);
+        assert!(!st.stalled());
+        for _ in 0..9 {
+            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+        }
+        assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 300);
+    }
+
+    #[test]
+    fn collision_folds_immediately() {
+        let mut st = LimitState::new();
+        // unpinned and moving: only the tau_d spike path can trip
+        assert_eq!(st.fold(false, 2000, 1201, 0, true, &CFG), 300);
+        assert!(st.stalled());
+        // at the threshold is not a spike
+        let mut st = LimitState::new();
+        assert_eq!(st.fold(false, 2000, 1200, 0, true, &CFG), 1200);
+        assert!(!st.stalled());
+    }
+
+    #[test]
+    fn fault_mode_pends_without_folding() {
+        let cfg = LimitCfg {
+            stall_response: StallResponse::Fault,
+            ..CFG
+        };
+        let mut st = LimitState::new();
+        for _ in 0..10 {
+            assert_eq!(st.fold(true, 0, 200, 0, true, &cfg), 1200);
+        }
+        assert!(st.stall_fault_pending());
+        assert!(!st.stalled());
+        // collision pends too, still no fold
+        let mut st = LimitState::new();
+        assert_eq!(st.fold(false, 2000, 1201, 0, true, &cfg), 1200);
+        assert!(st.stall_fault_pending());
+        assert!(!st.stalled());
+    }
+
+    #[test]
+    fn endstop_directional_all_combos() {
+        let mut st = LimitState::new();
+        // at max: inward (positive command, polarity true) clamps, retreat full
+        assert_eq!(st.fold(false, 1000, 0, 4000, true, &CFG), 0);
+        assert_eq!(st.fold(false, 1000, 0, 4000, false, &CFG), 1200);
+        // mirrored at min
+        assert_eq!(st.fold(false, 1000, 0, -4000, false, &CFG), 0);
+        assert_eq!(st.fold(false, 1000, 0, -4000, true, &CFG), 1200);
+        // past the wall keeps protecting
+        assert_eq!(st.fold(false, 1000, 0, 5000, true, &CFG), 0);
+        // reversed polarity flips which sign is inward
+        let rev = LimitCfg {
+            drive_polarity: false,
+            ..CFG
+        };
+        assert_eq!(st.fold(false, 1000, 0, 4000, false, &rev), 0);
+        assert_eq!(st.fold(false, 1000, 0, 4000, true, &rev), 1200);
+        assert_eq!(st.fold(false, 1000, 0, -4000, true, &rev), 0);
+        assert_eq!(st.fold(false, 1000, 0, -4000, false, &rev), 1200);
+    }
+
+    #[test]
+    fn min_composition_tightest_term_wins() {
+        // stalled yield 300 vs derate near cutoff: derate binds
+        let mut st = LimitState::new();
+        st.update_derate(9990, &CFG); // head 10/2000 -> ~6, way under yield
+        for _ in 0..10 {
+            st.fold(true, 0, 200, 0, true, &CFG);
+        }
+        assert!(st.stalled());
+        let lim = st.fold(true, 0, 200, 0, true, &CFG);
+        assert!((5..=6).contains(&lim), "lim={lim}");
+        // endstop zero beats everything
+        assert_eq!(st.fold(true, 0, 200, 4000, true, &CFG), 0);
+    }
+}

--- a/firmware/lib/core/src/kernel/limits.rs
+++ b/firmware/lib/core/src/kernel/limits.rs
@@ -28,6 +28,21 @@ pub struct LimitCfg {
     pub pos_max_soft_counts: i32,
 }
 
+/// The signed current band every command clamps into: `lo <= i_ref <= hi`.
+/// Symmetric `+-i_lim` away from the walls; a soft-limit wall collapses its
+/// inward side to 0 while the outward side keeps the composed limit.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct IBand {
+    pub lo: i32,
+    pub hi: i32,
+}
+
+impl IBand {
+    pub fn clamp(&self, i: i32) -> i32 {
+        i.clamp(self.lo, self.hi)
+    }
+}
+
 /// Stall timer + fold flag + the SLOW-cached derate ceiling. `derate_cache`
 /// boots non-binding (u16::MAX) so a fresh state is not zero-current for the
 /// first SLOW period; the base min still caps it at current_limit.
@@ -70,11 +85,16 @@ impl LimitState {
         };
     }
 
-    /// One MEDIUM-tick composition -> i_lim ccounts for this tick's push.
-    /// Compare/min only, no multiplies. `i_ref_pinned` = the caller saw
-    /// i_ref sitting at the ceiling (the pin, not a measurement);
-    /// `i_sign_positive` is the sign of the command this limit clamps, and
-    /// with `drive_polarity` resolves which endstop is "inward".
+    /// One MEDIUM-tick composition -> the signed current band `[lo, hi]`
+    /// every command clamps into. Compare/min only, no multiplies.
+    /// `i_ref_pinned` = the caller saw i_ref sitting at the ceiling (the
+    /// pin, not a measurement).
+    ///
+    /// The endstop is a DIRECTIONAL bound, not a magnitude fold: at a soft
+    /// limit only the inward side collapses to 0 and retreat keeps the
+    /// composed limit. Folding a magnitude gated by the command's sign
+    /// deadlocks at the wall - the clamp zeroes i_ref, zero reads as an
+    /// inward push, and the door never reopens (caught on the bench).
     ///
     /// Stall: pinned and |omega_hat| < stall_omega_max for stall_time_ticks,
     /// or a tau_d spike (collision). The v1 collision threshold is
@@ -90,9 +110,8 @@ impl LimitState {
         omega_hat_abs_cps: u32,
         tau_d_abs_counts: u16,
         theta_hat_counts: i32,
-        i_sign_positive: bool,
         cfg: &LimitCfg,
-    ) -> u16 {
+    ) -> IBand {
         // release before the triggers: a relax re-arms a full stall window
         // instead of instantly re-tripping off the stale timer
         if self.stalled && tau_d_abs_counts < cfg.stall_release_counts {
@@ -116,16 +135,33 @@ impl LimitState {
         if self.stalled {
             lim = lim.min(cfg.stall_yield_counts);
         }
-        // endstop: inward current at/past a soft limit clamps to 0, retreat
-        // stays at the composed limit
-        let pushing_up = i_sign_positive == cfg.drive_polarity;
-        if (pushing_up && theta_hat_counts >= cfg.pos_max_soft_counts)
-            || (!pushing_up && theta_hat_counts <= cfg.pos_min_soft_counts)
-        {
-            lim = 0;
-        }
         self.i_lim = lim;
-        lim
+        // endstop: with drive_polarity true, positive current moves counts
+        // up, so the max wall zeroes hi and the min wall zeroes lo; an
+        // inverted polarity swaps which side each wall owns
+        let mut band = IBand {
+            lo: -(lim as i32),
+            hi: lim as i32,
+        };
+        let (at_max, at_min) = (
+            theta_hat_counts >= cfg.pos_max_soft_counts,
+            theta_hat_counts <= cfg.pos_min_soft_counts,
+        );
+        if at_max {
+            if cfg.drive_polarity {
+                band.hi = 0;
+            } else {
+                band.lo = 0;
+            }
+        }
+        if at_min {
+            if cfg.drive_polarity {
+                band.lo = 0;
+            } else {
+                band.hi = 0;
+            }
+        }
+        band
     }
 
     /// Torque-enable ack: drop the pending fault, unfold, re-arm a full
@@ -138,7 +174,9 @@ impl LimitState {
         self.stall_ticks = 0;
     }
 
-    /// Cached output of the last `fold`.
+    /// Cached symmetric magnitude of the last `fold` (torque limit, derate,
+    /// stall folds - the endstop is positional and lives in the band's
+    /// sides, not here). This is what telemetry publishes.
     pub fn i_lim_counts(&self) -> u16 {
         self.i_lim
     }
@@ -178,7 +216,7 @@ mod tests {
 
     /// Mid-range, unpinned, no load: nothing but limit/derate can bind.
     fn free_fold(st: &mut LimitState, cfg: &LimitCfg) -> u16 {
-        st.fold(false, 1000, 0, 0, true, cfg)
+        st.fold(false, 1000, 0, 0, cfg).hi as u16
     }
 
     #[test]
@@ -229,10 +267,10 @@ mod tests {
     fn stall_timer_folds_under_yield() {
         let mut st = LimitState::new();
         for _ in 0..9 {
-            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+            assert_eq!(st.fold(true, 0, 200, 0, &CFG).hi, 1200);
             assert!(!st.stalled());
         }
-        assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 300);
+        assert_eq!(st.fold(true, 0, 200, 0, &CFG).hi, 300);
         assert!(st.stalled());
         assert!(!st.stall_fault_pending());
         assert_eq!(st.i_lim_counts(), 300);
@@ -242,47 +280,47 @@ mod tests {
     fn movement_resets_timer() {
         let mut st = LimitState::new();
         for _ in 0..9 {
-            st.fold(true, 0, 200, 0, true, &CFG);
+            st.fold(true, 0, 200, 0, &CFG);
         }
         // one fast tick clears the count; so does an unpinned one
-        st.fold(true, 500, 200, 0, true, &CFG);
+        st.fold(true, 500, 200, 0, &CFG);
         for _ in 0..9 {
-            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+            assert_eq!(st.fold(true, 0, 200, 0, &CFG).hi, 1200);
         }
-        st.fold(false, 0, 200, 0, true, &CFG);
+        st.fold(false, 0, 200, 0, &CFG);
         for _ in 0..9 {
-            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+            assert_eq!(st.fold(true, 0, 200, 0, &CFG).hi, 1200);
         }
-        assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 300);
+        assert_eq!(st.fold(true, 0, 200, 0, &CFG).hi, 300);
     }
 
     #[test]
     fn release_on_tau_d_relax_restores_and_rearms() {
         let mut st = LimitState::new();
         for _ in 0..10 {
-            st.fold(true, 0, 200, 0, true, &CFG);
+            st.fold(true, 0, 200, 0, &CFG);
         }
         assert!(st.stalled());
         // tau_d still above release: stays folded
-        assert_eq!(st.fold(false, 1000, 150, 0, true, &CFG), 300);
+        assert_eq!(st.fold(false, 1000, 150, 0, &CFG).hi, 300);
         // relax below release: restored, and a fresh window is required
-        assert_eq!(st.fold(false, 1000, 149, 0, true, &CFG), 1200);
+        assert_eq!(st.fold(false, 1000, 149, 0, &CFG).hi, 1200);
         assert!(!st.stalled());
         for _ in 0..9 {
-            assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 1200);
+            assert_eq!(st.fold(true, 0, 200, 0, &CFG).hi, 1200);
         }
-        assert_eq!(st.fold(true, 0, 200, 0, true, &CFG), 300);
+        assert_eq!(st.fold(true, 0, 200, 0, &CFG).hi, 300);
     }
 
     #[test]
     fn collision_folds_immediately() {
         let mut st = LimitState::new();
         // unpinned and moving: only the tau_d spike path can trip
-        assert_eq!(st.fold(false, 2000, 1201, 0, true, &CFG), 300);
+        assert_eq!(st.fold(false, 2000, 1201, 0, &CFG).hi, 300);
         assert!(st.stalled());
         // at the threshold is not a spike
         let mut st = LimitState::new();
-        assert_eq!(st.fold(false, 2000, 1200, 0, true, &CFG), 1200);
+        assert_eq!(st.fold(false, 2000, 1200, 0, &CFG).hi, 1200);
         assert!(!st.stalled());
     }
 
@@ -294,13 +332,13 @@ mod tests {
         };
         let mut st = LimitState::new();
         for _ in 0..10 {
-            assert_eq!(st.fold(true, 0, 200, 0, true, &cfg), 1200);
+            assert_eq!(st.fold(true, 0, 200, 0, &cfg).hi, 1200);
         }
         assert!(st.stall_fault_pending());
         assert!(!st.stalled());
         // collision pends too, still no fold
         let mut st = LimitState::new();
-        assert_eq!(st.fold(false, 2000, 1201, 0, true, &cfg), 1200);
+        assert_eq!(st.fold(false, 2000, 1201, 0, &cfg).hi, 1200);
         assert!(st.stall_fault_pending());
         assert!(!st.stalled());
     }
@@ -308,23 +346,33 @@ mod tests {
     #[test]
     fn endstop_directional_all_combos() {
         let mut st = LimitState::new();
-        // at max: inward (positive command, polarity true) clamps, retreat full
-        assert_eq!(st.fold(false, 1000, 0, 4000, true, &CFG), 0);
-        assert_eq!(st.fold(false, 1000, 0, 4000, false, &CFG), 1200);
+        // at max: the inward (positive, polarity true) side collapses,
+        // retreat keeps the composed limit - one band carries both verdicts
+        let b = st.fold(false, 1000, 0, 4000, &CFG);
+        assert_eq!((b.lo, b.hi), (-1200, 0));
         // mirrored at min
-        assert_eq!(st.fold(false, 1000, 0, -4000, false, &CFG), 0);
-        assert_eq!(st.fold(false, 1000, 0, -4000, true, &CFG), 1200);
+        let b = st.fold(false, 1000, 0, -4000, &CFG);
+        assert_eq!((b.lo, b.hi), (0, 1200));
         // past the wall keeps protecting
-        assert_eq!(st.fold(false, 1000, 0, 5000, true, &CFG), 0);
-        // reversed polarity flips which sign is inward
+        assert_eq!(st.fold(false, 1000, 0, 5000, &CFG).hi, 0);
+        // mid-range: symmetric
+        let b = st.fold(false, 1000, 0, 0, &CFG);
+        assert_eq!((b.lo, b.hi), (-1200, 1200));
+        // reversed polarity flips which side each wall owns
         let rev = LimitCfg {
             drive_polarity: false,
             ..CFG
         };
-        assert_eq!(st.fold(false, 1000, 0, 4000, false, &rev), 0);
-        assert_eq!(st.fold(false, 1000, 0, 4000, true, &rev), 1200);
-        assert_eq!(st.fold(false, 1000, 0, -4000, true, &rev), 0);
-        assert_eq!(st.fold(false, 1000, 0, -4000, false, &rev), 1200);
+        let b = st.fold(false, 1000, 0, 4000, &rev);
+        assert_eq!((b.lo, b.hi), (0, 1200));
+        let b = st.fold(false, 1000, 0, -4000, &rev);
+        assert_eq!((b.lo, b.hi), (-1200, 0));
+        // the deadlock regression: a zeroed command must not re-read as an
+        // inward push - the band's retreat side stays open regardless
+        let b = st.fold(false, 1000, 0, 4000, &CFG);
+        assert_eq!(b.clamp(0), 0);
+        assert_eq!(b.clamp(-120), -120);
+        assert_eq!(b.clamp(120), 0);
     }
 
     #[test]
@@ -333,12 +381,12 @@ mod tests {
         let mut st = LimitState::new();
         st.update_derate(9990, &CFG); // head 10/2000 -> ~6, way under yield
         for _ in 0..10 {
-            st.fold(true, 0, 200, 0, true, &CFG);
+            st.fold(true, 0, 200, 0, &CFG);
         }
         assert!(st.stalled());
-        let lim = st.fold(true, 0, 200, 0, true, &CFG);
+        let lim = st.fold(true, 0, 200, 0, &CFG).hi;
         assert!((5..=6).contains(&lim), "lim={lim}");
         // endstop zero beats everything
-        assert_eq!(st.fold(true, 0, 200, 4000, true, &CFG), 0);
+        assert_eq!(st.fold(true, 0, 200, 4000, &CFG).hi, 0);
     }
 }

--- a/firmware/lib/core/src/kernel/limits.rs
+++ b/firmware/lib/core/src/kernel/limits.rs
@@ -5,7 +5,7 @@
 //! (position walls). `fold` runs at MEDIUM and is compare/min only; the
 //! derate ceiling needs a reciprocal, so it is recomputed at SLOW and cached.
 
-use crate::math::q_mul_u;
+use crate::math::recip_div;
 use crate::regions::config::StallResponse;
 
 /// CONFIG limits + thermal + pos-limits fields the block consumes, loaded
@@ -26,37 +26,6 @@ pub struct LimitCfg {
     pub cutoff_cc: i16,
     pub pos_min_soft_counts: i32,
     pub pos_max_soft_counts: i32,
-}
-
-// Q1.30 linear reciprocal seed r0 = 48/17 - (32/17)x for the normalized
-// x in [0.5, 1): max relative error 1/17, so two Newton steps land at
-// (1/17)^4 ~ 1.2e-5. The power-of-two seed (math::recip_seed_q15) can start
-// a factor of 2 off, where r*(2 - r*d) convergence stalls - the default
-// 2000cc derate span seeds at x = 1.95 and would need ~8 steps - so the
-// one-shot derate uses the linear seed; the seed_q15 path stays for
-// estimators that refine across ticks.
-const SEED_C1_Q30: u32 = 3_031_741_621; // round(48/17 << 30)
-const SEED_C2_Q30: u32 = 2_021_161_080; // round(32/17 << 30)
-
-/// `num / d` without a divide. Normalize d into [2^31, 2^32) (Q0.32), linear
-/// seed + two Newton steps `r' = r*(2 - r*d)` in Q1.30, then one widening
-/// multiply denormalizes straight into the quotient. Error <= 1.2e-5
-/// relative plus truncation (pinned in tests). d == 0 has no quotient;
-/// callers gate the degenerate span, num is the no-panic backstop.
-fn recip_div_u(num: u32, d: u32) -> u32 {
-    if d <= 1 {
-        return num;
-    }
-    let n = d.leading_zeros(); // 1..=30 for d >= 2
-    let dn = d << n;
-    let mut r = SEED_C1_Q30 - q_mul_u(SEED_C2_Q30, dn, 32);
-    r = q_mul_u(r, (2u32 << 30) - q_mul_u(r, dn, 32), 30);
-    r = q_mul_u(r, (2u32 << 30) - q_mul_u(r, dn, 32), 30);
-    // num/d = num*r >> (62-n), split as (>> 32) then (>> 30-n): identical
-    // bits, but the u64 shift stays constant and the variable shift is u32 -
-    // a variable 64-bit shift is soft on rv32ec (check-soft-arith.sh bans it)
-    let p = num as u64 * r as u64;
-    ((p >> 32) as u32) >> (30 - n)
 }
 
 /// Stall timer + fold flag + the SLOW-cached derate ceiling. `derate_cache`
@@ -97,7 +66,7 @@ impl LimitState {
             // head in [1, span], both <= 65535: num fits u32 exactly
             let head = (cfg.cutoff_cc as i32 - t_winding_cc as i32) as u32;
             let num = cfg.current_limit_counts as u32 * head;
-            recip_div_u(num, span as u32).min(cfg.current_limit_counts as u32) as u16
+            recip_div(num, span as u32).min(cfg.current_limit_counts as u32) as u16
         };
     }
 
@@ -244,25 +213,6 @@ mod tests {
         assert_eq!(free_fold(&mut st, &cfg), 1200);
         st.update_derate(10000, &cfg);
         assert_eq!(free_fold(&mut st, &cfg), 0);
-    }
-
-    #[test]
-    fn recip_div_accuracy_pinned() {
-        // worst seeds are just under a power of two (x -> 1 from below maps
-        // to r near the interval edge); sweep those plus a dense band and
-        // the u32-extreme numerator. Bound: 1.2e-5 relative + 2 LSB.
-        let spot = [32767u32, 32768, 65534, 65535];
-        for d in (1..=4096u32).chain(spot) {
-            for num in [1u32, 999, 1_200 * 2_000, 4_294_836_225] {
-                let got = recip_div_u(num, d);
-                let exact = (num / d) as i64;
-                let err = (got as i64 - exact).abs();
-                assert!(
-                    err <= exact / 65536 + 2,
-                    "num={num} d={d} got={got} exact={exact}"
-                );
-            }
-        }
     }
 
     #[test]

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -1,4 +1,13 @@
+//! The assembled kernel (spec "on_tick skeleton"): one `on_tick` per PWM
+//! period carries all three rates - FAST every tick (sensor publish, window
+//! select, OC trip, current PI, motor write), MEDIUM every DECIM_MED ticks
+//! (fusion, trajectory, position/velocity, limits, vbus/bemf, detectors,
+//! estimates publish), SLOW every DECIM_SLOW medium ticks (thermometer,
+//! derate, undervolt/overtemp). Tick-indexed by design: a missed tick
+//! dilates time, nothing compensates and nothing reads a wall clock.
+
 pub mod current;
+pub mod faults;
 pub mod limits;
 pub mod position;
 pub mod trajectory;
@@ -10,40 +19,159 @@ pub use position::{PosOut, PositionCfg};
 pub use trajectory::{TrajCfg, TrajGen};
 pub use velocity::{VelocityGains, VelocityLoop};
 
-use crate::estimator::VcalLpf;
-use crate::traits::ControlIo;
+use crate::estimator::{
+    BemfObs, FusionGains, FusionObs, ThermAnchor, ThermGates, VbusEst, VcalLpf, WindingTherm, bemf,
+    window,
+};
+use crate::math::{q_mul, q_mul_u};
+use crate::regions::config::DecaySelect;
+use crate::regions::control::Mode;
+use crate::traits::{ControlIo, DecayMode, Motor, MotorCmd};
 use crate::{RegionStorageRaw, SensorFrame, Shared};
+use osc_units::Effort;
 
-/// Runs in the PWM ISR; one `on_tick` per period.
-pub struct Kernel<I: ControlIo> {
-    pub io: I,
-    pub state: KernelState,
-    pub vcal_lpf: VcalLpf,
+/// FAST -> MEDIUM decimation: MED_HZ = tick_hz / DECIM_MED (2 kHz at 20 kHz).
+pub const DECIM_MED: u8 = 10;
+/// MEDIUM -> SLOW decimation: SLOW_HZ = MED_HZ / DECIM_SLOW (62.5 Hz).
+pub const DECIM_SLOW: u8 = 32;
+
+/// Finished timing constants the chip const-evals from `MOTOR_PWM_FREQ_HZ`
+/// and the TIM1 ARR, so core never divides at runtime or install - every
+/// field is a compile-time quotient on the chip side (`Precomputed`).
+#[derive(Copy, Clone)]
+pub struct KernelTiming {
+    /// The TIM1 auto-reload the motor write programs; drive-window widths
+    /// derive from it (`window::drive_ticks`).
+    pub pwm_arr: u16,
+    /// `(1 << bemf::RECIP_ARR_SHIFT) / pwm_arr`: duty-fraction reciprocal
+    /// for the shared `v_mean` computation.
+    pub recip_arr_q24: u32,
+    /// FAST tick rate = `MOTOR_PWM_FREQ_HZ`, the same constant stamped into
+    /// `CalibSense.tick_hz` at install; carried as the derivation anchor for
+    /// the fields below.
+    pub tick_hz: u16,
+    /// `2^32 / MED_HZ` where `MED_HZ = tick_hz / DECIM_MED`: the medium
+    /// integration step, `theta += q_mul(omega, dt_med_q32, 32)`.
+    pub dt_med_q32: u32,
+    /// `(MED_HZ << 16) / 1000`: ms -> medium ticks via `q_mul_u(ms, ., 16)`.
+    pub med_ticks_per_ms_q16: u32,
 }
 
-#[derive(Default)]
-pub struct KernelState {
-    pub pid_integrator: i32,
-    pub pid_prev_error: i32,
+/// Runs in the ADC DMA TC ISR (PFIC LOW); one `on_tick` per PWM period.
+/// Single-writer contracts: the transport (PFIC HIGH) owns every
+/// CONTROL/CONFIG/CALIB write and can preempt this ISR mid-read, so the
+/// kernel only ever reads those regions - volatile via `region_ptr`, never
+/// forming `&T`, cross-field tearing accepted (each field is independently
+/// sane). The kernel is the sole writer of TELEMETRY sensors/estimates/mode
+/// and the `fault_flags` byte.
+pub struct Kernel<I: ControlIo> {
+    pub io: I,
+    timing: KernelTiming,
+    decim_med: u8,
+    decim_slow: u8,
+    vcal_lpf: VcalLpf,
+    traj: TrajGen,
+    fusion: FusionObs,
+    cur: CurrentLoop,
+    vel: VelocityLoop,
+    limits: LimitState,
+    vbus: VbusEst,
+    thermal: WindingTherm,
+    bemf: BemfObs,
+    faults: faults::FaultLatch,
+    det: faults::Detectors,
+    booted: bool,
+    te_prev: bool,
+    run_prev: bool,
+    mode_prev: Mode,
+    /// MEDIUM's current command, consumed by the FAST current loop.
+    i_ref_cc: i32,
+    /// Position loop output, held for the velocity step (MEDIUM-internal).
+    omega_ref_q16: i32,
+    /// Anti-hunt hold from the position loop; FAST maps it to Coast.
+    hold: bool,
+    /// The duty actually commanded this tick, post-clamp post-gate: 0 while
+    /// Coast/Disabled. Feeds next tick's window select AND the
+    /// `duty_applied_q15` publish - `CurrentLoop::last_duty` is not used for
+    /// telemetry because the gate can override the loop's output.
+    duty_q15: i16,
+    decay: DecayMode,
+    /// Last window-valid measurement, for the `i_hat_counts` publish.
+    i_meas_last: i16,
+    /// ms -> medium-tick conversions, recomputed each SLOW pass; primed
+    /// never-trip so no detector fires before the first pass computes them.
+    stall_time_ticks: u32,
+    pos_error_time_ticks: u32,
+    /// Last `r0_q12` seeded into the thermometer; a calib rewrite re-seeds.
+    therm_r0: u16,
 }
 
 impl<I: ControlIo> Kernel<I> {
-    pub fn new(io: I) -> Self {
+    pub fn new(io: I, timing: KernelTiming) -> Self {
         Self {
             io,
-            state: KernelState::default(),
+            timing,
+            // primed so the FIRST tick runs the full medium+slow chain: the
+            // ms->tick conversions and the vbus reciprocal exist before any
+            // consumer sees them
+            decim_med: DECIM_MED - 1,
+            decim_slow: DECIM_SLOW - 1,
             vcal_lpf: VcalLpf::new(),
+            traj: TrajGen::new(),
+            fusion: FusionObs::new(),
+            cur: CurrentLoop::new(),
+            vel: VelocityLoop::new(),
+            limits: LimitState::new(),
+            vbus: VbusEst::new(),
+            thermal: WindingTherm::new(),
+            bemf: BemfObs::new(),
+            faults: faults::FaultLatch::new(),
+            det: faults::Detectors::new(),
+            booted: false,
+            te_prev: false,
+            run_prev: false,
+            mode_prev: Mode::OpenLoop,
+            i_ref_cc: 0,
+            omega_ref_q16: 0,
+            hold: false,
+            duty_q15: 0,
+            decay: DecayMode::Slow,
+            i_meas_last: 0,
+            stall_time_ticks: u32::MAX,
+            pos_error_time_ticks: u32::MAX,
+            therm_r0: 0,
         }
     }
 
     /// Must complete well inside the kernel period (~50 us at 20 kHz).
     pub fn on_tick(&mut self, frame: SensorFrame, shared: &Shared) {
+        let p = shared.table.region_ptr();
+
+        // SAFETY: reads of transport-owned regions - raw-pointer volatile
+        // block copies, no `&T` formed, aligned repr(C) blocks inside the
+        // static table (single-writer contract in the type doc).
+        let (life, loop_cur, lim_cfg, therm_cfg, sense, motor_cal, bias) = unsafe {
+            (
+                (&raw const (*p).control.lifecycle).read_volatile(),
+                (&raw const (*p).config.loop_current).read_volatile(),
+                (&raw const (*p).config.limits).read_volatile(),
+                (&raw const (*p).config.thermal).read_volatile(),
+                (&raw const (*p).calib.sense).read_volatile(),
+                (&raw const (*p).calib.motor).read_volatile(),
+                (&raw const (*p).telemetry.sensors.current_bias_counts).read_volatile(),
+            )
+        };
+
+        if !self.booted {
+            self.booted = true;
+            self.fusion.seed(frame.pos);
+        }
         let vcal_lpf = self.vcal_lpf.update(frame.vcal);
 
         // SAFETY: ISR context is the region's sole writer (the `sample_tick`
         // contract); volatile per field so the stores survive optimization.
         unsafe {
-            let s = &raw mut (*shared.table.region_ptr()).telemetry.sensors;
+            let s = &raw mut (*p).telemetry.sensors;
             (&raw mut (*s).pos).write_volatile(frame.pos);
             (&raw mut (*s).current).write_volatile(frame.current);
             (&raw mut (*s).vcal).write_volatile(frame.vcal);
@@ -52,6 +180,387 @@ impl<I: ControlIo> Kernel<I> {
             (&raw mut (*s).vmotor_b).write_volatile(frame.vmotor_b);
             (&raw mut (*s).current_trough).write_volatile(frame.current_trough);
         }
-        // TODO: PID + mode dispatch + motor.write once the control loop lands.
+
+        // torque_enable 0->1 is the fault ack: latch, detectors, and the
+        // limits pend all clear; a still-present condition re-latches
+        // through the normal detectors.
+        if life.torque_enable && !self.te_prev {
+            self.faults.clear();
+            self.det.reset();
+            self.limits.ack();
+        }
+        self.te_prev = life.torque_enable;
+
+        // Window from the PREVIOUS tick's command: this frame's scan sampled
+        // the period that command drove.
+        let ticks = window::drive_ticks(self.duty_q15, self.timing.pwm_arr);
+        let sel = window::select(
+            self.decay,
+            ticks,
+            sense.i_window_min_ticks,
+            sense.v_window_min_ticks,
+        );
+        let fwd = self.duty_q15 >= 0;
+        let i_meas = window::i_from_frame(&frame, sel, fwd, bias);
+        if let Some(i) = i_meas {
+            self.i_meas_last = i.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+        }
+        let oc_over = i_meas.map(|i| i.unsigned_abs() > lim_cfg.oc_trip_counts as u32);
+        if self.det.oc_sample(oc_over, lim_cfg.oc_trip_ticks) {
+            self.faults
+                .raise(faults::BIT_OVER_CURRENT, faults::CODE_OVER_CURRENT);
+        }
+
+        let run = life.torque_enable && self.faults.mask() == 0;
+        if run != self.run_prev {
+            // both edges zero the loop chain; the enable edge additionally
+            // reseeds the profile at the estimate - bumpless
+            if run {
+                self.traj.reseed(self.fusion.theta_q16());
+            }
+            self.cur.reset();
+            self.vel.reset();
+            self.i_ref_cc = 0;
+            self.omega_ref_q16 = 0;
+            self.hold = false;
+            self.run_prev = run;
+        }
+        if run && life.mode != self.mode_prev {
+            // mode change mid-run: reference = estimate, at rest
+            self.traj.reseed(self.fusion.theta_q16());
+            self.hold = false;
+        }
+        self.mode_prev = life.mode;
+
+        self.decim_med += 1;
+        if self.decim_med >= DECIM_MED {
+            self.decim_med = 0;
+
+            // SAFETY: same volatile single-writer read contract as above.
+            let (loop_vel, loop_pos, fus_cfg, fault_cfg, pos_lim, winding) = unsafe {
+                (
+                    (&raw const (*p).config.loop_velocity).read_volatile(),
+                    (&raw const (*p).config.loop_position).read_volatile(),
+                    (&raw const (*p).config.fusion).read_volatile(),
+                    (&raw const (*p).config.fault_cfg).read_volatile(),
+                    (&raw const (*p).config.pos_limits).read_volatile(),
+                    (&raw const (*p).calib.winding).read_volatile(),
+                )
+            };
+
+            // i_use: window-valid measurement, else the cached command - the
+            // observer never sees the validity flag (fusion contract). While
+            // disabled or in OpenLoop the cache is 0, so an invalid window
+            // predicts torque-free.
+            let i_use = i_meas.unwrap_or(self.i_ref_cc);
+            let fg = FusionGains {
+                b_i_q016: motor_cal.b_i_q016,
+                l1_q016: fus_cfg.l1_q016,
+                l2_q88: fus_cfg.l2_q88,
+                l3_q88: fus_cfg.l3_q88,
+                l_bemf_q016: fus_cfg.l_bemf_q016,
+                fric_fc_counts: motor_cal.fric_fc_counts,
+            };
+            // previous medium tick's bemf estimate: one tick stale is fine
+            // for a blend that defaults off
+            let omega_bemf_q16 = self.bemf.omega_cps().clamp(-32767, 32767) << 16;
+            self.fusion.step(
+                i_use,
+                frame.pos,
+                Some(omega_bemf_q16),
+                self.timing.dt_med_q32,
+                &fg,
+            );
+            let theta_hat = self.fusion.theta_q16();
+            let omega_hat = self.fusion.omega_q16();
+
+            let tc = TrajCfg {
+                vel_limit_cps: loop_pos.velocity_limit_cps,
+                accel_limit_q88: loop_pos.accel_limit_q88,
+                pos_min_soft_counts: pos_lim.pos_min_soft_counts,
+                pos_max_soft_counts: pos_lim.pos_max_soft_counts,
+                dt_med_q32: self.timing.dt_med_q32,
+            };
+            if run {
+                match life.mode {
+                    Mode::Position => {
+                        self.traj.step_position(life.goal_position, &tc);
+                        let pc = PositionCfg {
+                            kp_q88: loop_pos.p_kp_q88,
+                            pos_deadband_counts: loop_pos.pos_deadband_counts,
+                            hold_omega_cps: loop_pos.hold_omega_cps,
+                            vel_limit_cps: loop_pos.velocity_limit_cps,
+                        };
+                        let out = position::step(
+                            self.traj.theta_star_q16(),
+                            self.traj.omega_star_q16(),
+                            theta_hat,
+                            omega_hat,
+                            &pc,
+                        );
+                        self.omega_ref_q16 = out.omega_ref_q16;
+                        self.hold = out.hold;
+                    }
+                    Mode::Velocity => {
+                        self.traj.step_velocity(life.goal_velocity, &tc);
+                        self.omega_ref_q16 = self.traj.omega_star_q16();
+                        self.hold = false;
+                    }
+                    Mode::Current | Mode::OpenLoop => self.hold = false,
+                }
+            }
+
+            // limits fold; pinned = last command sat at a nonzero ceiling
+            let prev_lim = self.limits.i_lim_counts();
+            let pinned = prev_lim != 0 && self.i_ref_cc.unsigned_abs() >= prev_lim as u32;
+            let lcfg = LimitCfg {
+                current_limit_counts: lim_cfg.current_limit_counts,
+                stall_response: lim_cfg.stall_response,
+                drive_polarity: lim_cfg.drive_polarity,
+                stall_omega_max_cps: lim_cfg.stall_omega_max_cps,
+                stall_time_ticks: self.stall_time_ticks,
+                stall_yield_counts: lim_cfg.stall_yield_counts,
+                stall_release_counts: lim_cfg.stall_release_counts,
+                derate_start_cc: therm_cfg.derate_start_cc,
+                cutoff_cc: therm_cfg.cutoff_cc,
+                pos_min_soft_counts: pos_lim.pos_min_soft_counts,
+                pos_max_soft_counts: pos_lim.pos_max_soft_counts,
+            };
+            let omega_abs_cps = omega_hat.unsigned_abs() >> 16;
+            let i_lim = self.limits.fold(
+                pinned,
+                omega_abs_cps,
+                self.fusion.tau_d_counts().unsigned_abs(),
+                theta_hat >> 16,
+                self.i_ref_cc >= 0,
+                &lcfg,
+            );
+            if run && self.limits.stall_fault_pending() {
+                self.faults.raise(faults::BIT_STALL, faults::CODE_STALL);
+            }
+
+            if run {
+                match life.mode {
+                    Mode::Velocity | Mode::Position => {
+                        let vg = VelocityGains {
+                            kp_q88: loop_vel.v_kp_q88,
+                            ki_q412: loop_vel.v_ki_q412,
+                            kaw_q412: loop_vel.v_kaw_q412,
+                            j_ff_q88: loop_vel.j_ff_q88,
+                            fric_fc_counts: motor_cal.fric_fc_counts,
+                            fric_fv_q016: motor_cal.fric_fv_q016,
+                        };
+                        self.i_ref_cc = self.vel.step(
+                            self.omega_ref_q16,
+                            omega_hat,
+                            self.traj.alpha_star_q16(),
+                            self.traj.omega_star_q16(),
+                            i_lim,
+                            &vg,
+                        );
+                    }
+                    // clamped fresh at the FAST rate below
+                    Mode::Current => {}
+                    Mode::OpenLoop => self.i_ref_cc = 0,
+                }
+            }
+
+            // vbus plus the shared v_mean: computed ONCE here, consumed by
+            // bemf now and the thermometer at SLOW (bemf RECIP_ARR contract)
+            let vdrive = window::vdrive_from_frame(&frame, sel, fwd);
+            self.vbus
+                .step(vdrive.map(|(v, _)| v), therm_cfg.v_undervolt_counts);
+            let v_mean = vdrive.map(|(_, vdiff)| {
+                q_mul(
+                    ticks as i32 * vdiff,
+                    self.timing.recip_arr_q24 as i32,
+                    bemf::RECIP_ARR_SHIFT,
+                )
+            });
+            let omega_bemf = self
+                .bemf
+                .step(v_mean, i_meas, motor_cal.r_q12, motor_cal.recip_ke_q);
+
+            // raw-pot sanity screen runs in every mode, torque-off included
+            if self.det.sensor_sample(
+                frame.pos,
+                fault_cfg.sensor_delta_max,
+                fault_cfg.sensor_bad_count,
+            ) {
+                self.faults.raise(faults::BIT_SENSOR, faults::CODE_SENSOR);
+            }
+            // tracking-error persistence: only meaningful with a live profile
+            let pos_err_over = run
+                && life.mode == Mode::Position
+                && self
+                    .traj
+                    .theta_star_q16()
+                    .saturating_sub(theta_hat)
+                    .unsigned_abs()
+                    > (fault_cfg.pos_error_counts as u32) << 16;
+            if self
+                .det
+                .pos_err_sample(pos_err_over, self.pos_error_time_ticks)
+            {
+                self.faults
+                    .raise(faults::BIT_POSITION_ERROR, faults::CODE_POSITION_ERROR);
+            }
+
+            self.decim_slow += 1;
+            if self.decim_slow >= DECIM_SLOW {
+                self.decim_slow = 0;
+                // ms -> medium ticks each SLOW pass, straight off the live
+                // table values: at 62.5 Hz two q16 multiplies are cheaper and
+                // simpler than write hooks, and a rewrite lands within one
+                // SLOW period (deliberate).
+                self.stall_time_ticks = q_mul_u(
+                    lim_cfg.stall_time_ms as u32,
+                    self.timing.med_ticks_per_ms_q16,
+                    16,
+                );
+                self.pos_error_time_ticks = q_mul_u(
+                    fault_cfg.pos_error_time_ms as u32,
+                    self.timing.med_ticks_per_ms_q16,
+                    16,
+                );
+
+                // thermometer seed tracks the calib anchor: install writes
+                // and host rewrites both land here
+                if winding.r0_q12 != self.therm_r0 {
+                    self.thermal.seed(winding.r0_q12);
+                    self.therm_r0 = winding.r0_q12;
+                }
+                let gates = ThermGates {
+                    i_min_counts: therm_cfg.rtherm_i_min_counts,
+                    omega_max_cps: therm_cfg.rtherm_omega_max_cps,
+                };
+                let anchor = ThermAnchor {
+                    r0_q12: winding.r0_q12,
+                    t0_cc: winding.t0_cc,
+                    k_r2t_q88: winding.k_r2t_q88,
+                    mu_q016: winding.mu_q016,
+                };
+                // the LMS sample needs BOTH window paths valid
+                let (vm, therm_i) = match (v_mean, i_meas) {
+                    (Some(v), Some(i)) => (v, Some(i)),
+                    _ => (0, None),
+                };
+                let t_cc = self
+                    .thermal
+                    .step(vm, therm_i, omega_abs_cps, &gates, &anchor);
+                self.limits.update_derate(t_cc, &lcfg);
+                if t_cc >= therm_cfg.cutoff_cc {
+                    self.faults
+                        .raise(faults::BIT_OVER_TEMP, faults::CODE_OVER_TEMP);
+                }
+                // unseeded vbus reads 0: no undervolt verdict until the
+                // first valid drive-window sample seeds the estimator
+                let vb = self.vbus.vbus_counts();
+                if vb != 0 && vb < therm_cfg.v_undervolt_counts {
+                    self.faults
+                        .raise(faults::BIT_UNDER_VOLT, faults::CODE_UNDER_VOLT);
+                }
+            }
+
+            // SAFETY: sole-telemetry-writer contract (type doc); volatile
+            // per-field stores, medium-boundary publish.
+            unsafe {
+                let e = &raw mut (*p).telemetry.estimates;
+                (&raw mut (*e).theta_hat_q16).write_volatile(theta_hat);
+                (&raw mut (*e).omega_hat_cps).write_volatile(omega_hat);
+                (&raw mut (*e).tau_d_counts).write_volatile(self.fusion.tau_d_counts());
+                (&raw mut (*e).i_lim_counts).write_volatile(i_lim);
+                (&raw mut (*e).t_winding_cc).write_volatile(self.thermal.t_cc());
+                (&raw mut (*e).vbus_counts).write_volatile(self.vbus.vbus_counts());
+                (&raw mut (*e).duty_applied_q15).write_volatile(self.duty_q15);
+                (&raw mut (*e).omega_bemf_cps).write_volatile(omega_bemf);
+                (&raw mut (*e).r_hat_q12).write_volatile(self.thermal.r_q12());
+                (&raw mut (*e).i_hat_counts).write_volatile(self.i_meas_last);
+                let m = &raw mut (*p).telemetry.mode;
+                (&raw mut (*m).mode_active).write_volatile(life.mode as u8);
+                (&raw mut (*m).fault_code).write_volatile(self.faults.code());
+                (&raw mut (*p).telemetry.common.fault_flags).write_volatile(self.faults.mask());
+            }
+        }
+
+        // Re-gate after the medium chain: a fault raised above disables THIS
+        // tick's drive (the loop-reset bookkeeping catches up next tick).
+        let run = run && self.faults.mask() == 0;
+        let cmd = if !run {
+            self.duty_q15 = 0;
+            MotorCmd::Disabled
+        } else {
+            match life.mode {
+                Mode::OpenLoop => {
+                    // raw passthrough, duty_max-clamped; NO vbus comp -
+                    // identification wants unconfounded actuation
+                    let max = loop_cur.duty_max_q15.min(i16::MAX as u16) as i32;
+                    let duty = (life.goal_duty as i32).clamp(-max, max) as i16;
+                    let decay = match lim_cfg.openloop_decay {
+                        DecaySelect::Slow => DecayMode::Slow,
+                        DecaySelect::Fast => DecayMode::Fast,
+                    };
+                    self.duty_q15 = duty;
+                    self.decay = decay;
+                    MotorCmd::Drive {
+                        duty: Effort(duty),
+                        decay,
+                    }
+                }
+                mode => {
+                    if mode == Mode::Current {
+                        let lim = self.limits.i_lim_counts() as i32;
+                        self.i_ref_cc = (life.goal_current as i32).clamp(-lim, lim);
+                    }
+                    if self.hold {
+                        // anti-hunt: park instead of dithering on friction;
+                        // the frozen loop resumes bumplessly on exit
+                        self.duty_q15 = 0;
+                        MotorCmd::Coast
+                    } else {
+                        let gains = CurrentGains {
+                            kp_q88: loop_cur.i_kp_q88,
+                            ki_q412: loop_cur.i_ki_q412,
+                            kaw_q412: loop_cur.i_kaw_q412,
+                            ke_q412: motor_cal.ke_vpc_q,
+                            duty_max_q15: loop_cur.duty_max_q15,
+                        };
+                        // undervolt-floored vbus: the same floor `vbus.step`
+                        // applied to the reciprocal, so (vbus, recip) stay
+                        // the contract pair even before the first seed
+                        let vbus_eff = self.vbus.vbus_counts().max(therm_cfg.v_undervolt_counts);
+                        // An invalid window only happens below the sampling
+                        // floor, where the duty is too small to push real
+                        // current: 0 is the honest estimate THERE, and it
+                        // lets the PI lift off zero duty - a strict freeze
+                        // would deadlock (no duty -> no window -> e = 0 ->
+                        // no duty). OC and the estimators keep the strict
+                        // validity view.
+                        let i_loop = Some(i_meas.unwrap_or(0));
+                        let duty = self.cur.step(
+                            self.i_ref_cc,
+                            i_loop,
+                            self.fusion.omega_q16(),
+                            vbus_eff,
+                            self.vbus.recip_q15(),
+                            &gains,
+                        );
+                        self.duty_q15 = duty;
+                        // closed-loop decay is fixed Slow (spec: config enum
+                        // exists for OpenLoop identification only)
+                        self.decay = DecayMode::Slow;
+                        MotorCmd::Drive {
+                            duty: Effort(duty),
+                            decay: DecayMode::Slow,
+                        }
+                    }
+                }
+            }
+        };
+        let (_sensors, motor) = self.io.parts();
+        motor.write(cmd);
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -87,6 +87,7 @@ pub struct Kernel<I: ControlIo> {
     booted: bool,
     te_prev: bool,
     run_prev: bool,
+    fwd_prev: bool,
     mode_prev: Mode,
     /// MEDIUM's current command, consumed by the FAST current loop.
     i_ref_cc: i32,
@@ -140,6 +141,7 @@ impl<I: ControlIo> Kernel<I> {
             booted: false,
             te_prev: false,
             run_prev: false,
+            fwd_prev: true,
             mode_prev: Mode::OpenLoop,
             i_ref_cc: 0,
             omega_ref_q16: 0,
@@ -204,15 +206,26 @@ impl<I: ControlIo> Kernel<I> {
         self.te_prev = life.torque_enable;
 
         // Window from the PREVIOUS tick's command: this frame's scan sampled
-        // the period that command drove.
+        // the period that command drove. Both extraction paths additionally
+        // require the duty SIGN stable across the last two commands: the
+        // command -> CCR-preload -> scan pipeline is a period deep, and a
+        // sample attributed across a sign flip picks the wrong terminal and
+        // the wrong current sign - under a hunting loop that aliased the
+        // vbus EWMA down to the low-side leg and latched a false undervolt
+        // (caught on the bench).
         let ticks = window::drive_ticks(self.duty_q15, self.timing.pwm_arr);
-        let sel = window::select(
+        let fwd = self.duty_q15 >= 0;
+        let mut sel = window::select(
             self.decay,
             ticks,
             sense.i_window_min_ticks,
             sense.v_window_min_ticks,
         );
-        let fwd = self.duty_q15 >= 0;
+        if fwd != self.fwd_prev {
+            sel.i_valid = false;
+            sel.v_valid = false;
+        }
+        self.fwd_prev = fwd;
         let i_meas = window::i_from_frame(&frame, sel, fwd, bias);
         if let Some(i) = i_meas {
             self.i_meas_last = i.clamp(i16::MIN as i32, i16::MAX as i32) as i16;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -1,8 +1,10 @@
 pub mod current;
 pub mod limits;
+pub mod velocity;
 
 pub use current::{CurrentGains, CurrentLoop};
 pub use limits::{LimitCfg, LimitState};
+pub use velocity::{VelocityGains, VelocityLoop};
 
 use crate::estimator::VcalLpf;
 use crate::traits::ControlIo;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -1,9 +1,13 @@
 pub mod current;
 pub mod limits;
+pub mod position;
+pub mod trajectory;
 pub mod velocity;
 
 pub use current::{CurrentGains, CurrentLoop};
 pub use limits::{LimitCfg, LimitState};
+pub use position::{PosOut, PositionCfg};
+pub use trajectory::{TrajCfg, TrajGen};
 pub use velocity::{VelocityGains, VelocityLoop};
 
 use crate::estimator::VcalLpf;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -247,8 +247,12 @@ impl<I: ControlIo> Kernel<I> {
         let run = life.torque_enable && self.faults.mask() == 0;
         if run != self.run_prev {
             // both edges zero the loop chain; the enable edge additionally
-            // reseeds the profile at the estimate - bumpless
+            // reseeds fusion at the measurement (torque-off tau_d is built
+            // from i_use = 0 fiction - a hand-moved shaft rails it and every
+            // enable would re-latch STALL via the collision check) and the
+            // profile at the fresh estimate - bumpless
             if run {
+                self.fusion.seed(frame.pos);
                 self.traj.reseed(self.fusion.theta_q16());
             }
             self.cur.reset();

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -17,7 +17,7 @@ pub mod trajectory;
 pub mod velocity;
 
 pub use current::{CurrentGains, CurrentLoop};
-pub use limits::{LimitCfg, LimitState};
+pub use limits::{IBand, LimitCfg, LimitState};
 pub use position::{PosOut, PositionCfg};
 pub use trajectory::{TrajCfg, TrajGen};
 pub use velocity::{VelocityGains, VelocityLoop};
@@ -78,6 +78,7 @@ pub struct Kernel<I: ControlIo> {
     cur: CurrentLoop,
     vel: VelocityLoop,
     limits: LimitState,
+    i_band: IBand,
     vbus: VbusEst,
     thermal: WindingTherm,
     bemf: BemfObs,
@@ -130,6 +131,7 @@ impl<I: ControlIo> Kernel<I> {
             cur: CurrentLoop::new(),
             vel: VelocityLoop::new(),
             limits: LimitState::new(),
+            i_band: IBand { lo: 0, hi: 0 },
             vbus: VbusEst::new(),
             thermal: WindingTherm::new(),
             bemf: BemfObs::new(),
@@ -364,14 +366,14 @@ impl<I: ControlIo> Kernel<I> {
                 pos_max_soft_counts: pos_lim.pos_max_soft_counts,
             };
             let omega_abs_cps = omega_hat.unsigned_abs() >> 16;
-            let i_lim = self.limits.fold(
+            let band = self.limits.fold(
                 pinned,
                 omega_abs_cps,
                 self.fusion.tau_d_counts().unsigned_abs(),
                 theta_hat >> 16,
-                self.i_ref_cc >= 0,
                 &lcfg,
             );
+            self.i_band = band;
             if run && self.limits.stall_fault_pending() {
                 self.faults.raise(faults::BIT_STALL, faults::CODE_STALL);
             }
@@ -392,7 +394,7 @@ impl<I: ControlIo> Kernel<I> {
                             omega_hat,
                             self.traj.alpha_star_q16(),
                             self.traj.omega_star_q16(),
-                            i_lim,
+                            band,
                             &vg,
                         );
                     }
@@ -508,7 +510,7 @@ impl<I: ControlIo> Kernel<I> {
                 (&raw mut (*e).theta_hat_q16).write_volatile(theta_hat);
                 (&raw mut (*e).omega_hat_cps).write_volatile(omega_hat);
                 (&raw mut (*e).tau_d_counts).write_volatile(self.fusion.tau_d_counts());
-                (&raw mut (*e).i_lim_counts).write_volatile(i_lim);
+                (&raw mut (*e).i_lim_counts).write_volatile(self.limits.i_lim_counts());
                 (&raw mut (*e).t_winding_cc).write_volatile(self.thermal.t_cc());
                 (&raw mut (*e).vbus_counts).write_volatile(self.vbus.vbus_counts());
                 (&raw mut (*e).duty_applied_q15).write_volatile(self.duty_q15);
@@ -548,8 +550,9 @@ impl<I: ControlIo> Kernel<I> {
                 }
                 mode => {
                     if mode == Mode::Current {
-                        let lim = self.limits.i_lim_counts() as i32;
-                        self.i_ref_cc = (life.goal_current as i32).clamp(-lim, lim);
+                        // directional band: an endstop blocks only inward
+                        // goals; retreat clamps against the composed limit
+                        self.i_ref_cc = self.i_band.clamp(life.goal_current as i32);
                     }
                     if self.hold {
                         // anti-hunt: park instead of dithering on friction;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -361,6 +361,7 @@ impl<I: ControlIo> Kernel<I> {
                 stall_time_ticks: self.stall_time_ticks,
                 stall_yield_counts: lim_cfg.stall_yield_counts,
                 stall_release_counts: lim_cfg.stall_release_counts,
+                stall_tau_trip_counts: lim_cfg.stall_tau_trip_counts,
                 derate_start_cc: therm_cfg.derate_start_cc,
                 cutoff_cc: therm_cfg.cutoff_cc,
                 pos_min_soft_counts: pos_lim.pos_min_soft_counts,

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -490,10 +490,12 @@ impl<I: ControlIo> Kernel<I> {
                     self.faults
                         .raise(faults::BIT_OVER_TEMP, faults::CODE_OVER_TEMP);
                 }
-                // unseeded vbus reads 0: no undervolt verdict until the
-                // first valid drive-window sample seeds the estimator
+                // undervolt needs FRESH evidence: a held estimate frozen by
+                // the fault's own bridge-off (no drive -> no window) would
+                // re-latch forever off a recovered rail. Recovery is a retry
+                // probe: ack -> drive resumes -> fresh sample -> verdict.
                 let vb = self.vbus.vbus_counts();
-                if vb != 0 && vb < therm_cfg.v_undervolt_counts {
+                if self.vbus.take_fresh() && vb < therm_cfg.v_undervolt_counts {
                     self.faults
                         .raise(faults::BIT_UNDER_VOLT, faults::CODE_UNDER_VOLT);
                 }

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -1,6 +1,8 @@
 pub mod current;
+pub mod limits;
 
 pub use current::{CurrentGains, CurrentLoop};
+pub use limits::{LimitCfg, LimitState};
 
 use crate::estimator::VcalLpf;
 use crate::traits::ControlIo;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -88,6 +88,8 @@ pub struct Kernel<I: ControlIo> {
     te_prev: bool,
     run_prev: bool,
     fwd_prev: bool,
+    /// Frames still to drop after a duty-sign flip (window attribution).
+    flip_hold: u8,
     mode_prev: Mode,
     /// MEDIUM's current command, consumed by the FAST current loop.
     i_ref_cc: i32,
@@ -142,6 +144,7 @@ impl<I: ControlIo> Kernel<I> {
             te_prev: false,
             run_prev: false,
             fwd_prev: true,
+            flip_hold: 0,
             mode_prev: Mode::OpenLoop,
             i_ref_cc: 0,
             omega_ref_q16: 0,
@@ -207,12 +210,13 @@ impl<I: ControlIo> Kernel<I> {
 
         // Window from the PREVIOUS tick's command: this frame's scan sampled
         // the period that command drove. Both extraction paths additionally
-        // require the duty SIGN stable across the last two commands: the
-        // command -> CCR-preload -> scan pipeline is a period deep, and a
-        // sample attributed across a sign flip picks the wrong terminal and
-        // the wrong current sign - under a hunting loop that aliased the
-        // vbus EWMA down to the low-side leg and latched a false undervolt
-        // (caught on the bench).
+        // drop the two frames after a duty-sign flip: the command ->
+        // CCR-preload -> drive -> scan -> DMA pipeline means a frame can lag
+        // its command by two ticks, and a sample attributed across a sign
+        // flip picks the wrong terminal and the wrong current sign - under a
+        // hunting loop that aliased the vbus EWMA down to the low-side leg
+        // and latched a false undervolt (caught on the bench; a one-frame
+        // drop was not enough).
         let ticks = window::drive_ticks(self.duty_q15, self.timing.pwm_arr);
         let fwd = self.duty_q15 >= 0;
         let mut sel = window::select(
@@ -222,10 +226,14 @@ impl<I: ControlIo> Kernel<I> {
             sense.v_window_min_ticks,
         );
         if fwd != self.fwd_prev {
+            self.flip_hold = 2;
+        }
+        self.fwd_prev = fwd;
+        if self.flip_hold > 0 {
+            self.flip_hold -= 1;
             sel.i_valid = false;
             sel.v_valid = false;
         }
-        self.fwd_prev = fwd;
         let i_meas = window::i_from_frame(&frame, sel, fwd, bias);
         if let Some(i) = i_meas {
             self.i_meas_last = i.clamp(i16::MIN as i32, i16::MAX as i32) as i16;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -1,3 +1,7 @@
+pub mod current;
+
+pub use current::{CurrentGains, CurrentLoop};
+
 use crate::estimator::VcalLpf;
 use crate::traits::ControlIo;
 use crate::{RegionStorageRaw, SensorFrame, Shared};

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -3,11 +3,14 @@
 //! select, OC trip, current PI, motor write), MEDIUM every DECIM_MED ticks
 //! (fusion, trajectory, position/velocity, limits, vbus/bemf, detectors,
 //! estimates publish), SLOW every DECIM_SLOW medium ticks (thermometer,
-//! derate, undervolt/overtemp). Tick-indexed by design: a missed tick
-//! dilates time, nothing compensates and nothing reads a wall clock.
+//! derate, undervolt/overtemp). Identification aggregates ride their own
+//! /16 fast-tick window (`ident`), independent of DECIM_MED. Tick-indexed
+//! by design: a missed tick dilates time, nothing compensates and nothing
+//! reads a wall clock.
 
 pub mod current;
 pub mod faults;
+pub mod ident;
 pub mod limits;
 pub mod position;
 pub mod trajectory;
@@ -98,6 +101,11 @@ pub struct Kernel<I: ControlIo> {
     decay: DecayMode,
     /// Last window-valid measurement, for the `i_hat_counts` publish.
     i_meas_last: i16,
+    /// Identification aggregator, own /16 fast-tick window.
+    ident: ident::IdentAgg,
+    /// Last v-valid drive-window differential (va - vb), for the ident
+    /// accumulation - same hold-last-valid pattern as `i_meas_last`.
+    vdiff_last: i16,
     /// ms -> medium-tick conversions, recomputed each SLOW pass; primed
     /// never-trip so no detector fires before the first pass computes them.
     stall_time_ticks: u32,
@@ -137,6 +145,8 @@ impl<I: ControlIo> Kernel<I> {
             duty_q15: 0,
             decay: DecayMode::Slow,
             i_meas_last: 0,
+            ident: ident::IdentAgg::new(),
+            vdiff_last: 0,
             stall_time_ticks: u32::MAX,
             pos_error_time_ticks: u32::MAX,
             therm_r0: 0,
@@ -209,6 +219,29 @@ impl<I: ControlIo> Kernel<I> {
         if self.det.oc_sample(oc_over, lim_cfg.oc_trip_ticks) {
             self.faults
                 .raise(faults::BIT_OVER_CURRENT, faults::CODE_OVER_CURRENT);
+        }
+
+        // IDENT: per-tick sample aligned to the window the PREVIOUS command
+        // drove - duty_q15 still holds that command here; i/vdiff hold
+        // last-valid through invalid windows (ident module doc).
+        if let Some((_, vdiff)) = window::vdrive_from_frame(&frame, sel, fwd) {
+            self.vdiff_last = vdiff.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+        }
+        if let Some(agg) = self
+            .ident
+            .sample(self.i_meas_last, self.vdiff_last, self.duty_q15)
+        {
+            // SAFETY: sole-telemetry-writer contract (type doc); volatile
+            // per-field stores at the ident window boundary.
+            unsafe {
+                let d = &raw mut (*p).telemetry.ident;
+                (&raw mut (*d).i_mean_counts).write_volatile(agg.i_mean_counts);
+                (&raw mut (*d).i_min_counts).write_volatile(agg.i_min_counts);
+                (&raw mut (*d).i_max_counts).write_volatile(agg.i_max_counts);
+                (&raw mut (*d).vdiff_mean).write_volatile(agg.vdiff_mean);
+                (&raw mut (*d).duty_mean_q15).write_volatile(agg.duty_mean_q15);
+                (&raw mut (*d).agg_seq).write_volatile(agg.agg_seq);
+            }
         }
 
         let run = life.torque_enable && self.faults.mask() == 0;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -87,9 +87,6 @@ pub struct Kernel<I: ControlIo> {
     booted: bool,
     te_prev: bool,
     run_prev: bool,
-    fwd_prev: bool,
-    /// Frames still to drop after a duty-sign flip (window attribution).
-    flip_hold: u8,
     mode_prev: Mode,
     /// MEDIUM's current command, consumed by the FAST current loop.
     i_ref_cc: i32,
@@ -143,8 +140,6 @@ impl<I: ControlIo> Kernel<I> {
             booted: false,
             te_prev: false,
             run_prev: false,
-            fwd_prev: true,
-            flip_hold: 0,
             mode_prev: Mode::OpenLoop,
             i_ref_cc: 0,
             omega_ref_q16: 0,
@@ -209,31 +204,16 @@ impl<I: ControlIo> Kernel<I> {
         self.te_prev = life.torque_enable;
 
         // Window from the PREVIOUS tick's command: this frame's scan sampled
-        // the period that command drove. Both extraction paths additionally
-        // drop the two frames after a duty-sign flip: the command ->
-        // CCR-preload -> drive -> scan -> DMA pipeline means a frame can lag
-        // its command by two ticks, and a sample attributed across a sign
-        // flip picks the wrong terminal and the wrong current sign - under a
-        // hunting loop that aliased the vbus EWMA down to the low-side leg
-        // and latched a false undervolt (caught on the bench; a one-frame
-        // drop was not enough).
+        // the period that command drove, so terminal and sign attribution
+        // stay correct across sign flips (bang-bang bench test pins this).
         let ticks = window::drive_ticks(self.duty_q15, self.timing.pwm_arr);
         let fwd = self.duty_q15 >= 0;
-        let mut sel = window::select(
+        let sel = window::select(
             self.decay,
             ticks,
             sense.i_window_min_ticks,
             sense.v_window_min_ticks,
         );
-        if fwd != self.fwd_prev {
-            self.flip_hold = 2;
-        }
-        self.fwd_prev = fwd;
-        if self.flip_hold > 0 {
-            self.flip_hold -= 1;
-            sel.i_valid = false;
-            sel.v_valid = false;
-        }
         let i_meas = window::i_from_frame(&frame, sel, fwd, bias);
         if let Some(i) = i_meas {
             self.i_meas_last = i.clamp(i16::MIN as i32, i16::MAX as i32) as i16;

--- a/firmware/lib/core/src/kernel/position.rs
+++ b/firmware/lib/core/src/kernel/position.rs
@@ -1,0 +1,148 @@
+//! Position P loop (control-theory "The Position Loop"): pure proportional -
+//! error times kp gives a velocity command, add the omega* feedforward,
+//! clamp to vel_limit. NO integrator ever (one integrator per band; a
+//! position integrator over Coulomb friction limit-cycles). The anti-hunt
+//! hold predicate tells the kernel to Coast inside the deadband instead of
+//! dithering against friction.
+
+use super::trajectory::VEL_CAP_CPS;
+use crate::math::q_mul;
+
+/// P error clamp, cQ16 (128 counts): 2^16 * 2^23 >> 8 < 2^31 keeps the kp
+/// product i32-exact for any gain encoding (velocity.rs E_LIM discipline).
+/// Past 128 counts of tracking error any practical kp already commands
+/// beyond vel_limit, so the flat region costs nothing; the hold predicate
+/// compares the RAW error, never this clamp.
+const E_LIM_CQ16: i32 = 1 << 23;
+
+/// CONFIG loop_position gain + hold fields, loaded fresh each step by the
+/// kernel (`CurrentGains` convention).
+#[derive(Copy, Clone)]
+pub struct PositionCfg {
+    pub kp_q88: u16,
+    /// 0 disables the hold predicate entirely.
+    pub pos_deadband_counts: u16,
+    pub hold_omega_cps: u16,
+    pub vel_limit_cps: u16,
+}
+
+/// omega_ref for the velocity loop plus the anti-hunt flag (kernel maps
+/// hold -> Coast).
+#[derive(Copy, Clone)]
+pub struct PosOut {
+    pub omega_ref_q16: i32,
+    pub hold: bool,
+}
+
+/// One MEDIUM-tick update; stateless. theta*/omega* come from the
+/// trajectory generator, theta_hat/omega_hat from fusion.
+pub fn step(
+    theta_star_q16: i32,
+    omega_star_q16: i32,
+    theta_hat_q16: i32,
+    omega_hat_q16: i32,
+    cfg: &PositionCfg,
+) -> PosOut {
+    let e_raw = theta_star_q16.saturating_sub(theta_hat_q16);
+    let e = e_raw.clamp(-E_LIM_CQ16, E_LIM_CQ16);
+    let v_lim = (cfg.vel_limit_cps.min(VEL_CAP_CPS) as i32) << 16;
+    // Q8.8 * cQ16 >> 8 -> csQ16, i32-exact per E_LIM
+    let omega_ref = q_mul(cfg.kp_q88 as i32, e, 8)
+        .saturating_add(omega_star_q16)
+        .clamp(-v_lim, v_lim);
+    // raw-magnitude compares as u32: deadband << 16 can reach 2^32 - 2^16,
+    // past i32
+    let hold = cfg.pos_deadband_counts != 0
+        && e_raw.unsigned_abs() <= (cfg.pos_deadband_counts as u32) << 16
+        && omega_star_q16 == 0
+        && omega_hat_q16.unsigned_abs() < (cfg.hold_omega_cps as u32) << 16;
+    PosOut {
+        omega_ref_q16: omega_ref,
+        hold,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn c(kp: u16, db: u16, ho: u16, vl: u16) -> PositionCfg {
+        PositionCfg {
+            kp_q88: kp,
+            pos_deadband_counts: db,
+            hold_omega_cps: ho,
+            vel_limit_cps: vl,
+        }
+    }
+
+    #[test]
+    fn p_term_sign_and_scale() {
+        // kp 1.0 c/s per count: 100 counts of error -> 100 c/s
+        let cfg = c(1 << 8, 0, 0, 32767);
+        assert_eq!(step(100 << 16, 0, 0, 0, &cfg).omega_ref_q16, 100 << 16);
+        assert_eq!(step(0, 0, 100 << 16, 0, &cfg).omega_ref_q16, -(100 << 16));
+        // kp 1/256: 100 counts -> 100/256 c/s = 100 << 8 in csQ16
+        let cfg = c(1, 0, 0, 32767);
+        assert_eq!(step(100 << 16, 0, 0, 0, &cfg).omega_ref_q16, 100 << 8);
+        assert_eq!(step(0, 0, 100 << 16, 0, &cfg).omega_ref_q16, -(100 << 8));
+    }
+
+    #[test]
+    fn feedforward_adds() {
+        // kp 0: pure passthrough of omega*
+        let cfg = c(0, 0, 0, 32767);
+        assert_eq!(
+            step(100 << 16, 200 << 16, 0, 0, &cfg).omega_ref_q16,
+            200 << 16
+        );
+        // kp term and omega* sum
+        let cfg = c(1 << 8, 0, 0, 32767);
+        assert_eq!(
+            step(10 << 16, 200 << 16, 0, 0, &cfg).omega_ref_q16,
+            210 << 16
+        );
+    }
+
+    #[test]
+    fn vel_limit_and_error_clamp() {
+        // 1000 counts of error clamps to E_LIM's 128 first: kp 1.0 -> 128 c/s
+        let cfg = c(1 << 8, 0, 0, 32767);
+        assert_eq!(step(1000 << 16, 0, 0, 0, &cfg).omega_ref_q16, 128 << 16);
+        // vel_limit clamps the sum, both signs
+        let cfg = c(1 << 8, 0, 0, 100);
+        assert_eq!(step(1000 << 16, 0, 0, 0, &cfg).omega_ref_q16, 100 << 16);
+        assert_eq!(step(0, 0, 1000 << 16, 0, &cfg).omega_ref_q16, -(100 << 16));
+        // feedforward alone also cannot escape the limit
+        assert_eq!(step(0, 500 << 16, 0, 0, &cfg).omega_ref_q16, 100 << 16);
+    }
+
+    #[test]
+    fn hold_predicate_each_condition() {
+        let cfg = c(1 << 8, 5, 10, 32767);
+        // all four true: within deadband, profile at rest, servo near rest
+        let base = |cfg: &PositionCfg| step(5 << 16, 0, 0, (10 << 16) - 1, cfg);
+        assert!(base(&cfg).hold);
+        // deadband 0 disables hold outright, even at perfect rest
+        assert!(!step(0, 0, 0, 0, &c(1 << 8, 0, 10, 32767)).hold);
+        // error one cQ16 past the deadband
+        assert!(!step((5 << 16) + 1, 0, 0, 0, &cfg).hold);
+        // omega* nonzero: profile still moving
+        assert!(!step(5 << 16, 1, 0, 0, &cfg).hold);
+        // omega_hat at the bound (strict <)
+        assert!(!step(5 << 16, 0, 0, 10 << 16, &cfg).hold);
+        assert!(step(5 << 16, 0, 0, -(10 << 16) + 1, &cfg).hold);
+    }
+
+    #[test]
+    fn hold_uses_raw_error_not_clamped() {
+        // 6000 counts of error is far past E_LIM's 128 but inside a 65535
+        // deadband: the predicate must see the raw magnitude and hold
+        let cfg = c(1 << 8, 65535, 10, 32767);
+        let out = step(3000 << 16, 0, -(3000 << 16), 0, &cfg);
+        assert!(out.hold);
+        // while the drive command stays E_LIM/vel_limit-clamped
+        assert_eq!(out.omega_ref_q16, 128 << 16);
+        // and a small deadband rejects the same error
+        assert!(!step(3000 << 16, 0, -(3000 << 16), 0, &c(1 << 8, 5, 10, 32767)).hold);
+    }
+}

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -1,0 +1,603 @@
+//! Kernel-level orchestration tests plus the closed-loop plant smoke suite.
+//! The per-block tests carry the numeric precision; these pin the wiring:
+//! gate, ack, dispatch shapes, publishes, and qualitative closed-loop
+//! behavior against a crude integer plant.
+
+use super::*;
+use crate::regions::config::StallResponse;
+use crate::traits::Sensors;
+use crate::{RegionStorage, Shared};
+
+const BIAS: u16 = 2048;
+const ARR: u16 = 1200;
+
+// The chip-side const-eval for a 20 kHz FAST rate (MED 2 kHz).
+const TIMING: KernelTiming = KernelTiming {
+    pwm_arr: ARR,
+    recip_arr_q24: (1 << bemf::RECIP_ARR_SHIFT) / ARR as u32,
+    tick_hz: 20_000,
+    dt_med_q32: ((1u64 << 32) / 2000) as u32,
+    med_ticks_per_ms_q16: 2 << 16,
+};
+
+struct FakeSensors;
+impl Sensors for FakeSensors {
+    fn frame(&mut self) -> SensorFrame {
+        SensorFrame::default()
+    }
+}
+
+struct FakeMotor {
+    last: Option<MotorCmd>,
+}
+impl Motor for FakeMotor {
+    fn write(&mut self, cmd: MotorCmd) {
+        self.last = Some(cmd);
+    }
+}
+
+struct FakeIo {
+    sensors: FakeSensors,
+    motor: FakeMotor,
+}
+impl ControlIo for FakeIo {
+    type Sensors = FakeSensors;
+    type Motor = FakeMotor;
+    fn parts(&mut self) -> (&mut FakeSensors, &mut FakeMotor) {
+        (&mut self.sensors, &mut self.motor)
+    }
+}
+
+fn kernel() -> Kernel<FakeIo> {
+    Kernel::new(
+        FakeIo {
+            sensors: FakeSensors,
+            motor: FakeMotor { last: None },
+        },
+        TIMING,
+    )
+}
+
+fn last_cmd(k: &Kernel<FakeIo>) -> MotorCmd {
+    k.io.motor.last.expect("a motor write happened")
+}
+
+/// Hand-stable rig baseline; tests override per case via `with_mut`.
+fn seed(shared: &Shared) {
+    shared.table.with_mut(|t| {
+        let c = &mut t.config;
+        c.pos_limits.pos_min_soft_counts = 0;
+        c.pos_limits.pos_max_soft_counts = 4095;
+        c.loop_current.i_kp_q88 = 256;
+        c.loop_current.i_ki_q412 = 200;
+        c.loop_current.i_kaw_q412 = 2048;
+        c.loop_current.duty_max_q15 = 32767;
+        c.loop_velocity.v_kp_q88 = 64;
+        c.loop_velocity.v_ki_q412 = 40;
+        c.loop_velocity.v_kaw_q412 = 2048;
+        c.loop_velocity.j_ff_q88 = 0;
+        c.loop_position.p_kp_q88 = 256;
+        c.loop_position.pos_deadband_counts = 8;
+        c.loop_position.hold_omega_cps = 200;
+        c.loop_position.velocity_limit_cps = 3000;
+        c.loop_position.accel_limit_q88 = 50 << 8;
+        c.limits.current_limit_counts = 1200;
+        c.limits.stall_response = StallResponse::Yield;
+        c.limits.drive_polarity = true;
+        c.limits.stall_omega_max_cps = 500;
+        c.limits.stall_time_ms = 50;
+        c.limits.stall_yield_counts = 300;
+        c.limits.stall_release_counts = 150;
+        c.limits.oc_trip_counts = 2400;
+        c.limits.oc_trip_ticks = 4;
+        c.limits.openloop_decay = DecaySelect::Slow;
+        c.thermal.derate_start_cc = 8000;
+        c.thermal.cutoff_cc = 10000;
+        c.thermal.recover_cc = 9000;
+        c.thermal.v_undervolt_counts = 2200;
+        c.thermal.rtherm_i_min_counts = 300;
+        c.thermal.rtherm_omega_max_cps = 400;
+        c.fusion.l1_q016 = 16384;
+        c.fusion.l2_q88 = 1024;
+        c.fusion.l3_q88 = 16384;
+        c.fusion.l_bemf_q016 = 0;
+        c.fault_cfg.pos_error_counts = 400;
+        c.fault_cfg.pos_error_time_ms = 500;
+        c.fault_cfg.sensor_delta_max = 256;
+        c.fault_cfg.sensor_bad_count = 4;
+        let cal = &mut t.calib;
+        cal.sense.i_window_min_ticks = 100;
+        cal.sense.v_window_min_ticks = 100;
+        cal.motor.ke_vpc_q = 256; // 0.0625 vcounts per c/s
+        cal.motor.r_q12 = 8192; // 2.0 vcounts/ccount
+        cal.motor.recip_ke_q = 16 << 10; // 16 c/s per vcount
+        cal.motor.b_i_q016 = 65535;
+        t.telemetry.sensors.current_bias_counts = BIAS;
+        t.control.lifecycle.torque_enable = false;
+        t.control.lifecycle.mode = Mode::Position;
+    });
+}
+
+fn frame(pos: u16, current: u16) -> SensorFrame {
+    SensorFrame {
+        pos,
+        current,
+        current_trough: current,
+        vmotor_a: 3000,
+        vmotor_a_trough: 3000,
+        vmotor_b: 40,
+        vmotor_b_trough: 40,
+        vcal: 1200,
+        tick: 0,
+    }
+}
+
+// --- Gate / ack / dispatch ------------------------------------------------
+
+#[test]
+fn torque_off_disables_and_estimators_still_track() {
+    let sh = Shared::new();
+    seed(&sh);
+    let mut k = kernel();
+    for _ in 0..40 {
+        k.on_tick(frame(2500, BIAS), &sh);
+    }
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+    // boot seeded the fusion at the first measurement
+    assert_eq!(k.fusion.theta_q16(), 2500 << 16);
+    // the pot moves while disabled: the observer follows it anyway
+    for _ in 0..4000 {
+        k.on_tick(frame(1000, BIAS), &sh);
+    }
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+    let err = (k.fusion.theta_q16() - (1000 << 16)).abs();
+    assert!(err < 5 << 16, "theta_hat={}", k.fusion.theta_q16());
+    // published while disabled
+    sh.table.with(|t| {
+        assert_eq!(t.telemetry.estimates.theta_hat_q16, k.fusion.theta_q16());
+    });
+}
+
+#[test]
+fn enable_edge_reseeds_without_transient() {
+    let sh = Shared::new();
+    seed(&sh);
+    let mut k = kernel();
+    for _ in 0..2000 {
+        k.on_tick(frame(2000, BIAS), &sh);
+    }
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 2000;
+    });
+    // at-goal enable: every command in the first stretch is at rest or a
+    // bounded nudge - no integrator kick, no profile teleport
+    for _ in 0..50 {
+        k.on_tick(frame(2000, BIAS), &sh);
+        match last_cmd(&k) {
+            MotorCmd::Coast | MotorCmd::Disabled => {}
+            MotorCmd::Drive { duty, .. } => {
+                assert!(duty.0.unsigned_abs() < 2000, "duty={}", duty.0)
+            }
+            MotorCmd::Brake => panic!("brake is never commanded"),
+        }
+    }
+    assert_eq!(k.traj.theta_star_q16(), 2000 << 16);
+}
+
+#[test]
+fn oc_latch_forces_disabled_despite_torque_enable() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 16000;
+    });
+    let mut k = kernel();
+    // tick 1 drives (windows still invalid: previous duty was 0)
+    k.on_tick(frame(2000, BIAS + 3000), &sh);
+    assert!(matches!(last_cmd(&k), MotorCmd::Drive { .. }));
+    // 4 consecutive valid over-trip samples latch on the 4th
+    for _ in 0..3 {
+        k.on_tick(frame(2000, BIAS + 3000), &sh);
+        assert_eq!(k.faults.mask(), 0);
+    }
+    k.on_tick(frame(2000, BIAS + 3000), &sh);
+    assert_eq!(k.faults.mask(), faults::BIT_OVER_CURRENT);
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+    // torque_enable still set: stays disabled, publish lands at medium
+    for _ in 0..10 {
+        k.on_tick(frame(2000, BIAS + 3000), &sh);
+        assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+    }
+    sh.table.with(|t| {
+        assert_eq!(t.telemetry.common.fault_flags, faults::BIT_OVER_CURRENT);
+        assert_eq!(t.telemetry.mode.fault_code, faults::CODE_OVER_CURRENT);
+        assert_eq!(t.telemetry.mode.mode_active, Mode::OpenLoop as u8);
+    });
+}
+
+#[test]
+fn ack_clears_then_relatches_while_condition_persists() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 16000;
+    });
+    let mut k = kernel();
+    for _ in 0..8 {
+        k.on_tick(frame(2000, BIAS + 3000), &sh);
+    }
+    assert_eq!(k.faults.mask(), faults::BIT_OVER_CURRENT);
+    // ack: drop then raise torque_enable
+    sh.table
+        .with_mut(|t| t.control.lifecycle.torque_enable = false);
+    k.on_tick(frame(2000, BIAS + 3000), &sh);
+    sh.table
+        .with_mut(|t| t.control.lifecycle.torque_enable = true);
+    k.on_tick(frame(2000, BIAS + 3000), &sh);
+    assert_eq!(k.faults.mask(), 0);
+    assert!(matches!(last_cmd(&k), MotorCmd::Drive { .. }));
+    // the overcurrent persists: a fresh window re-latches
+    for _ in 0..5 {
+        k.on_tick(frame(2000, BIAS + 3000), &sh);
+    }
+    assert_eq!(k.faults.mask(), faults::BIT_OVER_CURRENT);
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+}
+
+#[test]
+fn oc_gap_rearms_the_window() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 16000;
+    });
+    let mut k = kernel();
+    k.on_tick(frame(2000, BIAS + 3000), &sh); // warmup: invalid window
+    for _ in 0..3 {
+        k.on_tick(frame(2000, BIAS + 3000), &sh);
+    }
+    // one clean sample re-arms; three more over-samples do not latch
+    k.on_tick(frame(2000, BIAS + 100), &sh);
+    for _ in 0..3 {
+        k.on_tick(frame(2000, BIAS + 3000), &sh);
+    }
+    assert_eq!(k.faults.mask(), 0);
+    // the 4th consecutive does
+    k.on_tick(frame(2000, BIAS + 3000), &sh);
+    assert_eq!(k.faults.mask(), faults::BIT_OVER_CURRENT);
+}
+
+#[test]
+fn openloop_duty_passthrough_clamped_with_decay() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 8000;
+        t.config.limits.openloop_decay = DecaySelect::Fast;
+    });
+    let mut k = kernel();
+    k.on_tick(frame(2000, BIAS), &sh);
+    match last_cmd(&k) {
+        MotorCmd::Drive { duty, decay } => {
+            assert_eq!(duty.0, 8000);
+            assert!(matches!(decay, DecayMode::Fast));
+        }
+        other => panic!("expected Drive, got {other:?}"),
+    }
+    // duty_max clamps the passthrough
+    sh.table.with_mut(|t| {
+        t.config.loop_current.duty_max_q15 = 5000;
+        t.control.lifecycle.goal_duty = 8000;
+    });
+    k.on_tick(frame(2000, BIAS), &sh);
+    match last_cmd(&k) {
+        MotorCmd::Drive { duty, .. } => assert_eq!(duty.0, 5000),
+        other => panic!("expected Drive, got {other:?}"),
+    }
+}
+
+#[test]
+fn current_mode_clamps_goal_to_i_lim() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::Current;
+        t.control.lifecycle.goal_current = 5000;
+    });
+    let mut k = kernel();
+    k.on_tick(frame(2000, BIAS), &sh);
+    assert_eq!(k.i_ref_cc, 1200);
+    assert!(matches!(
+        last_cmd(&k),
+        MotorCmd::Drive {
+            decay: DecayMode::Slow,
+            ..
+        }
+    ));
+    sh.table
+        .with_mut(|t| t.control.lifecycle.goal_current = -5000);
+    k.on_tick(frame(2000, BIAS), &sh);
+    assert_eq!(k.i_ref_cc, -1200);
+}
+
+#[test]
+fn position_error_latches_after_persistence() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 3500;
+        t.config.fault_cfg.pos_error_counts = 100;
+        t.config.fault_cfg.pos_error_time_ms = 10; // 20 medium ticks
+        // keep the stall path out of this test
+        t.config.limits.stall_time_ms = 60000;
+    });
+    let mut k = kernel();
+    // pot frozen at 500 while the profile marches away
+    for _ in 0..4000 {
+        k.on_tick(frame(500, BIAS), &sh);
+        if k.faults.mask() != 0 {
+            break;
+        }
+    }
+    assert_eq!(k.faults.mask(), faults::BIT_POSITION_ERROR);
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+}
+
+#[test]
+fn publishes_land_in_the_table() {
+    let sh = Shared::new();
+    seed(&sh);
+    let mut k = kernel();
+    for _ in 0..20 {
+        k.on_tick(frame(1234, 2100), &sh);
+    }
+    sh.table.with(|t| {
+        assert_eq!(t.telemetry.sensors.pos, 1234);
+        assert_eq!(t.telemetry.sensors.current, 2100);
+        assert_eq!(t.telemetry.sensors.vmotor_a, 3000);
+        assert_eq!(t.telemetry.estimates.theta_hat_q16, k.fusion.theta_q16());
+        assert_eq!(t.telemetry.estimates.omega_hat_cps, k.fusion.omega_q16());
+        assert_eq!(t.telemetry.estimates.i_lim_counts, 1200);
+        assert_eq!(t.telemetry.estimates.duty_applied_q15, 0);
+        assert_eq!(t.telemetry.estimates.vbus_counts, 0); // never driven
+        assert_eq!(t.telemetry.mode.mode_active, Mode::Position as u8);
+        assert_eq!(t.telemetry.mode.fault_code, faults::CODE_NONE);
+        assert_eq!(t.telemetry.common.fault_flags, 0);
+    });
+}
+
+// --- Closed-loop plant ----------------------------------------------------
+
+/// Crude integer plant in the identification-model shape:
+/// `omega[k+1] = a*omega[k] + b*duty - coulomb`, theta integrates, pot =
+/// theta >> 16 clamped 0..4095, `i = (duty*vbus>>15 - ke*omega)/R`. Units
+/// loose on purpose - qualitative closed-loop behavior, not fidelity.
+struct Plant {
+    theta_q16: i64,
+    omega_cps: i32,
+    vbus: u16,
+    frozen: bool,
+}
+
+impl Plant {
+    fn new(pos: u16) -> Self {
+        Self {
+            theta_q16: (pos as i64) << 16,
+            omega_cps: 0,
+            vbus: 3000,
+            frozen: false,
+        }
+    }
+
+    /// One FAST tick: a = 1 - 1/64, b*duty = duty*200>>15, coulomb 8 c/s
+    /// toward zero; frozen = hard wall (theta pinned, omega 0).
+    fn step(&mut self, duty: i16) -> SensorFrame {
+        if self.frozen {
+            self.omega_cps = 0;
+        } else {
+            self.omega_cps += ((duty as i32 * 200) >> 15) - (self.omega_cps >> 6);
+            if self.omega_cps > 0 {
+                self.omega_cps = (self.omega_cps - 8).max(0);
+            } else {
+                self.omega_cps = (self.omega_cps + 8).min(0);
+            }
+            self.theta_q16 += ((self.omega_cps as i64) << 16) / 20_000;
+        }
+        let pos = (self.theta_q16 >> 16).clamp(0, 4095) as u16;
+        // ke = 1/16 vcounts per c/s, R = 2 vcounts/ccount
+        let v = (duty as i32 * self.vbus as i32) >> 15;
+        let i = (v - (self.omega_cps >> 4)) >> 1;
+        let mag = if duty >= 0 { i } else { -i };
+        let sample = (BIAS as i32 + mag).clamp(0, 4095) as u16;
+        let (va, vb) = if duty >= 0 {
+            (self.vbus, 40)
+        } else {
+            (40, self.vbus)
+        };
+        SensorFrame {
+            pos,
+            current: sample,
+            current_trough: sample,
+            vmotor_a: va,
+            vmotor_a_trough: va,
+            vmotor_b: vb,
+            vmotor_b_trough: vb,
+            vcal: 1200,
+            tick: 0,
+        }
+    }
+
+    fn pos(&self) -> i32 {
+        (self.theta_q16 >> 16) as i32
+    }
+}
+
+fn run_plant(k: &mut Kernel<FakeIo>, sh: &Shared, plant: &mut Plant, ticks: u32) {
+    for _ in 0..ticks {
+        let f = plant.step(k.duty_q15);
+        k.on_tick(f, sh);
+    }
+}
+
+#[test]
+fn position_step_settles_without_limit_cycle() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 3000;
+        // the plant/gain pair is qualitative; keep the tracking screen out
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+        // this plant accelerates far beyond what the (deliberately
+        // degenerate) b_i predict explains, so a large l3 rails tau_d into
+        // the collision trip on every ramp; keep it gentle here
+        t.config.fusion.l3_q88 = 256;
+        // tighter position loop so the post-profile residual closes inside
+        // the run instead of creeping on a 1 s time constant
+        t.config.loop_position.p_kp_q88 = 1024;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(1000);
+    run_plant(&mut k, &sh, &mut plant, 40_000); // 2 s
+    assert_eq!(k.faults.mask(), 0);
+    assert!(
+        (plant.pos() - 3000).abs() <= 16,
+        "settled at {}",
+        plant.pos()
+    );
+    assert_eq!(k.traj.theta_star_q16(), 3000 << 16, "profile landed");
+    // trailing window: position parked, motor overwhelmingly coasting
+    let (mut lo, mut hi, mut coast) = (i32::MAX, i32::MIN, 0u32);
+    for _ in 0..2000 {
+        let f = plant.step(k.duty_q15);
+        k.on_tick(f, &sh);
+        lo = lo.min(plant.pos());
+        hi = hi.max(plant.pos());
+        if matches!(last_cmd(&k), MotorCmd::Coast) {
+            coast += 1;
+        }
+    }
+    assert!(hi - lo <= 2, "limit cycle: spread {}", hi - lo);
+    assert!(coast >= 1500, "coast ticks {coast}");
+}
+
+#[test]
+fn velocity_mode_tracks_a_ramp() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::Velocity;
+        // plenty of travel so the pot never rails
+        t.config.pos_limits.pos_max_soft_counts = 1_000_000;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(100);
+    for seg in 1..=4i32 {
+        sh.table
+            .with_mut(|t| t.control.lifecycle.goal_velocity = 500 * seg);
+        run_plant(&mut k, &sh, &mut plant, 4000); // 200 ms per segment
+    }
+    assert_eq!(k.faults.mask(), 0);
+    let omega_hat = k.fusion.omega_q16() >> 16;
+    assert!((omega_hat - 2000).abs() <= 300, "omega_hat={omega_hat}");
+    assert!(
+        (plant.omega_cps - 2000).abs() <= 300,
+        "plant omega={}",
+        plant.omega_cps
+    );
+}
+
+#[test]
+fn hard_wall_stall_yields() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 3500;
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(500);
+    plant.frozen = true;
+    // into the push, the command pins at the full limit
+    run_plant(&mut k, &sh, &mut plant, 2000);
+    assert_eq!(k.i_ref_cc, 1200, "pinned at i_lim");
+    run_plant(&mut k, &sh, &mut plant, 20_000); // 1 s against the wall
+    assert_eq!(k.faults.mask(), 0, "Yield never latches");
+    assert!(k.limits.stalled());
+    sh.table.with(|t| {
+        assert_eq!(t.telemetry.estimates.i_lim_counts, 300, "folded to yield");
+    });
+}
+
+#[test]
+fn hard_wall_stall_faults() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 3500;
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+        t.config.limits.stall_response = StallResponse::Fault;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(500);
+    plant.frozen = true;
+    run_plant(&mut k, &sh, &mut plant, 20_000);
+    assert_eq!(k.faults.mask(), faults::BIT_STALL);
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+    sh.table
+        .with(|t| assert_eq!(t.telemetry.mode.fault_code, faults::CODE_STALL));
+}
+
+#[test]
+fn position_step_survives_tick_deletion() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 3000;
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+        t.config.fusion.l3_q88 = 256;
+        t.config.loop_position.p_kp_q88 = 1024;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(1000);
+    // ~10% of ISR invocations vanish; the plant keeps running on the stale
+    // duty (tick-indexed contract: dilation, never compensation)
+    let mut rng: u32 = 0x1357_9bdf;
+    for _ in 0..40_000 {
+        let f = plant.step(k.duty_q15);
+        rng = rng.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        if !rng.is_multiple_of(10) {
+            k.on_tick(f, &sh);
+        }
+    }
+    assert_eq!(k.faults.mask(), 0);
+    assert!(
+        (plant.pos() - 3000).abs() <= 24,
+        "settled at {}",
+        plant.pos()
+    );
+    // still parks: trailing spread stays flat
+    let (mut lo, mut hi) = (i32::MAX, i32::MIN);
+    for _ in 0..2000 {
+        let f = plant.step(k.duty_q15);
+        k.on_tick(f, &sh);
+        lo = lo.min(plant.pos());
+        hi = hi.max(plant.pos());
+    }
+    assert!(hi - lo <= 4, "limit cycle: spread {}", hi - lo);
+}

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -377,6 +377,107 @@ fn publishes_land_in_the_table() {
     });
 }
 
+// --- Ident aggregates -----------------------------------------------------
+
+fn ident_setup(sh: &Shared) {
+    seed(sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        // drive_ticks(8000) = 293 >= the 100-tick floors: windows valid
+        // from tick 2 on (tick 1 measures the boot duty of 0)
+        t.control.lifecycle.goal_duty = 8000;
+    });
+}
+
+#[test]
+fn ident_window_pins_aggregates() {
+    let sh = Shared::new();
+    ident_setup(&sh);
+    let mut k = kernel();
+    // window 1 (ticks 1-16) is boot-mixed; spend it
+    for _ in 0..16 {
+        k.on_tick(frame(2000, BIAS + 100), &sh);
+    }
+    sh.table.with(|t| assert_eq!(t.telemetry.ident.agg_seq, 1));
+    // window 2: 8 ticks at +100, 4 at +300, 4 at -60, all windows valid
+    for _ in 0..8 {
+        k.on_tick(frame(2000, BIAS + 100), &sh);
+    }
+    // seq holds mid-window: publish only at the /16 boundary
+    sh.table.with(|t| assert_eq!(t.telemetry.ident.agg_seq, 1));
+    for _ in 0..4 {
+        k.on_tick(frame(2000, BIAS + 300), &sh);
+    }
+    for _ in 0..4 {
+        k.on_tick(frame(2000, BIAS - 60), &sh);
+    }
+    sh.table.with(|t| {
+        let d = &t.telemetry.ident;
+        // (8*100 + 4*300 + 4*-60) >> 4 = 1760/16 = 110
+        assert_eq!(d.i_mean_counts, 110);
+        assert_eq!(d.i_min_counts, -60);
+        assert_eq!(d.i_max_counts, 300);
+        assert_eq!(d.vdiff_mean, 2960); // va 3000 - vb 40, every tick
+        assert_eq!(d.duty_mean_q15, 8000);
+        assert_eq!(d.agg_seq, 2);
+    });
+}
+
+#[test]
+fn ident_invalid_ticks_hold_last_valid() {
+    let sh = Shared::new();
+    ident_setup(&sh);
+    let mut k = kernel();
+    for _ in 0..32 {
+        k.on_tick(frame(2000, BIAS + 200), &sh);
+    }
+    // disable: windows go invalid one tick later (tick 33 still measures
+    // the period tick 32's command drove)
+    sh.table
+        .with_mut(|t| t.control.lifecycle.torque_enable = false);
+    for _ in 0..16 {
+        k.on_tick(frame(2000, BIAS + 200), &sh);
+    }
+    sh.table.with(|t| {
+        let d = &t.telemetry.ident;
+        // 15 invalid ticks held the last valid i/vdiff: means stay put
+        assert_eq!(d.i_mean_counts, 200);
+        assert_eq!(d.i_min_counts, 200);
+        assert_eq!(d.i_max_counts, 200);
+        assert_eq!(d.vdiff_mean, 2960);
+        // duty is per-tick truth: 8000 on tick 33 only -> 8000>>4 = 500
+        assert_eq!(d.duty_mean_q15, 500);
+        assert_eq!(d.agg_seq, 3);
+    });
+}
+
+#[test]
+fn ident_accumulators_reset_between_windows() {
+    let sh = Shared::new();
+    ident_setup(&sh);
+    let mut k = kernel();
+    // windows 1 (boot-mixed) and 2 at a big current
+    for _ in 0..32 {
+        k.on_tick(frame(2000, BIAS + 1000), &sh);
+    }
+    sh.table
+        .with(|t| assert_eq!(t.telemetry.ident.i_max_counts, 1000));
+    // window 3: 15 ticks at 0, one at -5; window 2's 1000 must not leak
+    for _ in 0..15 {
+        k.on_tick(frame(2000, BIAS), &sh);
+    }
+    k.on_tick(frame(2000, BIAS - 5), &sh);
+    sh.table.with(|t| {
+        let d = &t.telemetry.ident;
+        assert_eq!(d.i_max_counts, 0);
+        assert_eq!(d.i_min_counts, -5);
+        // sum -5 >> 4: arithmetic shift floors to -1
+        assert_eq!(d.i_mean_counts, -1);
+        assert_eq!(d.agg_seq, 3);
+    });
+}
+
 // --- Closed-loop plant ----------------------------------------------------
 
 /// Crude integer plant in the identification-model shape:

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -215,6 +215,47 @@ fn enable_edge_clears_hand_era_tau_d() {
 }
 
 #[test]
+fn undervolt_needs_fresh_evidence_no_stale_relatch() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 8192;
+    });
+    let mut k = kernel();
+    // sagged rail: valid drive windows carry va under the undervolt floor
+    let mut sagged = frame(2000, BIAS);
+    sagged.vmotor_a = 1000;
+    sagged.vmotor_a_trough = 1000;
+    for _ in 0..400 {
+        k.on_tick(sagged, &sh);
+    }
+    assert_eq!(k.faults.mask(), faults::BIT_UNDER_VOLT, "sag latches");
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+    // bridge off -> no window -> vbus estimate frozen at the sag; the ack
+    // must stick because there is no fresh evidence
+    sh.table
+        .with_mut(|t| t.control.lifecycle.torque_enable = false);
+    for _ in 0..400 {
+        k.on_tick(sagged, &sh);
+    }
+    sh.table
+        .with_mut(|t| t.control.lifecycle.torque_enable = true);
+    // recovered rail from here on
+    for _ in 0..2000 {
+        k.on_tick(frame(2000, BIAS), &sh);
+    }
+    assert_eq!(k.faults.mask(), 0, "stale sag re-latched undervolt");
+    assert!(matches!(last_cmd(&k), MotorCmd::Drive { .. }));
+    // a genuinely low rail re-latches through the same retry probe
+    for _ in 0..2000 {
+        k.on_tick(sagged, &sh);
+    }
+    assert_eq!(k.faults.mask(), faults::BIT_UNDER_VOLT);
+}
+
+#[test]
 fn oc_latch_forces_disabled_despite_torque_enable() {
     let sh = Shared::new();
     seed(&sh);

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -256,38 +256,6 @@ fn endstop_allows_retreat_from_the_wall() {
 }
 
 #[test]
-fn sign_flip_drops_two_frames_before_reattributing() {
-    let sh = Shared::new();
-    seed(&sh);
-    sh.table.with_mut(|t| {
-        t.control.lifecycle.torque_enable = true;
-        t.control.lifecycle.mode = Mode::OpenLoop;
-        t.control.lifecycle.goal_duty = 8000;
-    });
-    let mut k = kernel();
-    for _ in 0..50 {
-        k.on_tick(frame(2000, BIAS + 300), &sh);
-    }
-    assert_eq!(k.i_meas_last, 300, "forward attribution settled");
-    // Reverse command. The frame pipeline lags the command, so the
-    // shunt sample can belong to either sign for two ticks - both
-    // frames must be dropped (hold last-valid), the third re-attributes
-    // with the new sign.
-    sh.table.with_mut(|t| t.control.lifecycle.goal_duty = -8000);
-    // tick 1: select still sees the last +cmd, sign stable - accepted
-    k.on_tick(frame(2000, BIAS + 500), &sh);
-    assert_eq!(k.i_meas_last, 500);
-    // ticks 2-3: flip observed - dropped despite a valid window
-    k.on_tick(frame(2000, BIAS + 700), &sh);
-    assert_eq!(k.i_meas_last, 500, "first post-flip frame not dropped");
-    k.on_tick(frame(2000, BIAS + 700), &sh);
-    assert_eq!(k.i_meas_last, 500, "second post-flip frame not dropped");
-    // tick 4: pipeline flushed - attributed with the reverse sign
-    k.on_tick(frame(2000, BIAS + 700), &sh);
-    assert_eq!(k.i_meas_last, -700);
-}
-
-#[test]
 fn undervolt_needs_fresh_evidence_no_stale_relatch() {
     let sh = Shared::new();
     seed(&sh);

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -256,6 +256,38 @@ fn endstop_allows_retreat_from_the_wall() {
 }
 
 #[test]
+fn sign_flip_drops_two_frames_before_reattributing() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 8000;
+    });
+    let mut k = kernel();
+    for _ in 0..50 {
+        k.on_tick(frame(2000, BIAS + 300), &sh);
+    }
+    assert_eq!(k.i_meas_last, 300, "forward attribution settled");
+    // Reverse command. The frame pipeline lags the command, so the
+    // shunt sample can belong to either sign for two ticks - both
+    // frames must be dropped (hold last-valid), the third re-attributes
+    // with the new sign.
+    sh.table.with_mut(|t| t.control.lifecycle.goal_duty = -8000);
+    // tick 1: select still sees the last +cmd, sign stable - accepted
+    k.on_tick(frame(2000, BIAS + 500), &sh);
+    assert_eq!(k.i_meas_last, 500);
+    // ticks 2-3: flip observed - dropped despite a valid window
+    k.on_tick(frame(2000, BIAS + 700), &sh);
+    assert_eq!(k.i_meas_last, 500, "first post-flip frame not dropped");
+    k.on_tick(frame(2000, BIAS + 700), &sh);
+    assert_eq!(k.i_meas_last, 500, "second post-flip frame not dropped");
+    // tick 4: pipeline flushed - attributed with the reverse sign
+    k.on_tick(frame(2000, BIAS + 700), &sh);
+    assert_eq!(k.i_meas_last, -700);
+}
+
+#[test]
 fn undervolt_needs_fresh_evidence_no_stale_relatch() {
     let sh = Shared::new();
     seed(&sh);

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -186,6 +186,35 @@ fn enable_edge_reseeds_without_transient() {
 }
 
 #[test]
+fn enable_edge_clears_hand_era_tau_d() {
+    let sh = Shared::new();
+    seed(&sh);
+    let mut k = kernel();
+    // torque off, shaft hand-swept: i_use = 0 fiction rails tau_d
+    for i in 0..4000u32 {
+        let pos = 1000 + ((i / 4) % 2000) as u16;
+        k.on_tick(frame(pos, BIAS), &sh);
+    }
+    assert!(
+        k.fusion.tau_d_counts().unsigned_abs() > 200,
+        "precondition: hand motion railed tau_d, got {}",
+        k.fusion.tau_d_counts()
+    );
+    // enable at rest: fusion reseeds, so the collision check never sees the
+    // stale disturbance and STALL must not latch
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::Current;
+        t.control.lifecycle.goal_current = 0;
+    });
+    for _ in 0..200 {
+        k.on_tick(frame(1500, BIAS), &sh);
+    }
+    assert_eq!(k.faults.mask(), 0, "stale tau_d re-latched STALL");
+    assert!(k.fusion.tau_d_counts().unsigned_abs() < 50);
+}
+
+#[test]
 fn oc_latch_forces_disabled_despite_torque_enable() {
     let sh = Shared::new();
     seed(&sh);

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -88,6 +88,7 @@ fn seed(shared: &Shared) {
         c.limits.stall_time_ms = 50;
         c.limits.stall_yield_counts = 300;
         c.limits.stall_release_counts = 150;
+        c.limits.stall_tau_trip_counts = 1200;
         c.limits.oc_trip_counts = 2400;
         c.limits.oc_trip_ticks = 4;
         c.limits.openloop_decay = DecaySelect::Slow;

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -215,6 +215,47 @@ fn enable_edge_clears_hand_era_tau_d() {
 }
 
 #[test]
+fn endstop_allows_retreat_from_the_wall() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::Current;
+        t.control.lifecycle.goal_current = 120;
+    });
+    let mut k = kernel();
+    // parked hard against the top wall (bench: horn ratcheted to the rail)
+    for _ in 0..400 {
+        k.on_tick(frame(4095, BIAS), &sh);
+    }
+    // inward goal is banded to zero: no drive into the wall
+    match last_cmd(&k) {
+        MotorCmd::Drive { duty, .. } => assert_eq!(duty.0, 0),
+        MotorCmd::Coast | MotorCmd::Disabled => {}
+        MotorCmd::Brake => panic!("brake is never commanded"),
+    }
+    // the door back out must be open: a retreat goal drives immediately
+    // (the magnitude-fold deadlock read the zeroed i_ref as inward forever).
+    // Reverse drive samples the OTHER terminal, so the frame carries the
+    // rail on vmotor_b - a forward-shaped frame would read the low leg as
+    // a collapsed rail and latch UNDER_VOLT.
+    sh.table
+        .with_mut(|t| t.control.lifecycle.goal_current = -120);
+    let mut rev = frame(4095, BIAS);
+    (rev.vmotor_a, rev.vmotor_a_trough) = (40, 40);
+    (rev.vmotor_b, rev.vmotor_b_trough) = (3000, 3000);
+    let mut drove = false;
+    for _ in 0..400 {
+        k.on_tick(rev, &sh);
+        if let MotorCmd::Drive { duty, .. } = last_cmd(&k) {
+            drove |= duty.0 < 0;
+        }
+    }
+    assert!(drove, "retreat from the wall never drove");
+    assert_eq!(k.faults.mask(), 0);
+}
+
+#[test]
 fn undervolt_needs_fresh_evidence_no_stale_relatch() {
     let sh = Shared::new();
     seed(&sh);

--- a/firmware/lib/core/src/kernel/trajectory.rs
+++ b/firmware/lib/core/src/kernel/trajectory.rs
@@ -1,0 +1,462 @@
+//! Trapezoid trajectory generator (control-theory "The Trajectory
+//! Generator"): shapes goal steps into accel/vel-limited profiles and emits
+//! theta*/omega*/alpha* - the references plus the feedforward pair. alpha*
+//! is the ACTUALLY-APPLIED delta-omega each tick, so the velocity loop's J
+//! term follows what the profile really did, clamps and terminal snap
+//! included. The decel decision is a discrete per-tick test done
+//! multiply-only (wide_ge cross-compare, no divide, no v^2/2a quotient).
+
+use crate::math::{q_mul, wide_ge};
+
+/// theta_ref guard, matching fusion's THETA_LIM: pot tops 4095<<16 < 2^28
+/// and goals clamp to soft limits, so 2^29 only guards i32 arithmetic
+/// (goal - theta_ref stays exact).
+const THETA_LIM_CQ16: i32 = 1 << 29;
+
+/// Whole-count goal bound implied by THETA_LIM.
+const GOAL_LIM_COUNTS: i32 = THETA_LIM_CQ16 >> 16;
+
+/// omega_ref cap in c/s: i16 full scale (fusion OMEGA_LIM convention); also
+/// keeps v_up + a inside u32 for the decel compare. Shared with position.rs,
+/// which clamps its output against the same CONFIG field.
+pub(crate) const VEL_CAP_CPS: u16 = 32767;
+
+/// Terminal snap floor: below one accel step of omega and within one whole
+/// count, land exactly instead of creeping forever. Assumes one accel step
+/// travels under a count per tick - true for Q8.8 accel (<= 256 c/s per
+/// tick) at the 2 kHz MEDIUM rate.
+const SNAP_D_CQ16: u32 = 1 << 16;
+
+/// CONFIG loop_position profile fields + soft limits, loaded fresh each
+/// step by the kernel (`CurrentGains` convention). `dt_med_q32` =
+/// 2^32 / MED_HZ, the kernel's compile-time constant; MED_HZ > 2 keeps it
+/// under 2^31 so the i32 cast in q_mul is value-preserving (fusion
+/// convention).
+#[derive(Copy, Clone)]
+pub struct TrajCfg {
+    pub vel_limit_cps: u16,
+    /// c/s of omega change per MEDIUM tick, Q8.8.
+    pub accel_limit_q88: u16,
+    pub pos_min_soft_counts: i32,
+    pub pos_max_soft_counts: i32,
+    pub dt_med_q32: u32,
+}
+
+/// State: theta_ref cQ16, omega_ref csQ16, alpha_last csQ16 per tick (the
+/// applied delta, emitted as alpha*).
+#[derive(Default)]
+pub struct TrajGen {
+    theta_ref_q16: i32,
+    omega_ref_q16: i32,
+    alpha_last_q16: i32,
+}
+
+impl TrajGen {
+    pub const fn new() -> Self {
+        Self {
+            theta_ref_q16: 0,
+            omega_ref_q16: 0,
+            alpha_last_q16: 0,
+        }
+    }
+
+    /// Enable edge / mode change: reference = estimate, at rest - bumpless.
+    pub fn reseed(&mut self, theta_hat_q16: i32) {
+        self.theta_ref_q16 = theta_hat_q16.clamp(-THETA_LIM_CQ16, THETA_LIM_CQ16);
+        self.omega_ref_q16 = 0;
+        self.alpha_last_q16 = 0;
+    }
+
+    /// One MEDIUM-tick trapezoid step toward `goal_counts` clamped to the
+    /// soft limits (table rules pin min < max; the min/max reorder below
+    /// only keeps a corrupt image panic-free).
+    ///
+    /// Decel decision: a decel chain shedding a per tick from v travels
+    /// dt*sum(v - k*a) = (v^2 - a*v)*dt/(2a) - exact when a divides v, else
+    /// the closed form undershoots by < a*dt/8, sub-count for real configs.
+    /// Cruising one more tick at v_up then stopping therefore needs
+    ///   v_up*dt + (v_up^2 - a*v_up)*dt/(2a) = v_up*(v_up + a)*dt/(2a) <= |d|
+    /// Multiply-only: with vt = q_mul(v_up, dt, 32) (per-tick travel, cQ16,
+    /// the same floored product the integrator applies), decelerate when
+    /// (v_up + a) * vt >= 2a * |d|. Scales: (v_up + a) csQ16 x vt cQ16 vs
+    /// 2a csQ16-per-tick x |d| cQ16 - both u64 products carry physical
+    /// value x 2^32, since vt already absorbed dt (c/s x s = c). Choosing
+    /// v_up by this test every tick is inductively overshoot-free: a safe
+    /// v_up leaves the whole decel tail inside |d| - vt, and each decel tick
+    /// preserves the remaining-travel identity D(v) = v_next*dt + D(v_next).
+    pub fn step_position(&mut self, goal_counts: i32, cfg: &TrajCfg) {
+        // Q8.8 c/s-per-tick -> csQ16; <= 2^24
+        let a = (cfg.accel_limit_q88 as i32) << 8;
+        let v_lim = (cfg.vel_limit_cps.min(VEL_CAP_CPS) as i32) << 16;
+        let lo = cfg.pos_min_soft_counts.min(cfg.pos_max_soft_counts);
+        let hi = cfg.pos_max_soft_counts.max(cfg.pos_min_soft_counts);
+        let goal = goal_counts
+            .clamp(lo, hi)
+            .clamp(-GOAL_LIM_COUNTS, GOAL_LIM_COUNTS)
+            << 16;
+        // both operands within +-2^29 -> exact
+        let d = goal - self.theta_ref_q16;
+        let d_abs = d.unsigned_abs();
+        let dir_pos = d >= 0;
+        let prev = self.omega_ref_q16;
+        // magnitudes along the goal direction; v < 0 means moving away
+        let v = if dir_pos { prev } else { -prev };
+        let v_next = if v < 0 {
+            // moving away: slew toward the goal through zero; the decel test
+            // is meaningless until the sign flips
+            (v + a).min(v_lim)
+        } else {
+            let v_up = v + (v_lim - v).clamp(-a, a);
+            let vt = q_mul(v_up, cfg.dt_med_q32 as i32, 32) as u32;
+            if wide_ge(v_up as u32 + a as u32, vt, 2 * (a as u32), d_abs) {
+                (v - a).max(0)
+            } else {
+                v_up
+            }
+        };
+        let omega = if dir_pos { v_next } else { -v_next };
+        let step_mag = q_mul(
+            if omega < 0 { -omega } else { omega },
+            cfg.dt_med_q32 as i32,
+            32,
+        );
+        let toward = if omega > 0 {
+            d >= 0
+        } else if omega < 0 {
+            d <= 0
+        } else {
+            true
+        };
+        let land = (toward && step_mag as u32 >= d_abs)
+            || (omega.unsigned_abs() <= a as u32 && d_abs < SNAP_D_CQ16);
+        if land {
+            self.theta_ref_q16 = goal;
+            self.omega_ref_q16 = 0;
+            self.alpha_last_q16 = prev.saturating_neg();
+        } else {
+            let travel = if omega >= 0 { step_mag } else { -step_mag };
+            // |theta| <= 2^29 and |travel| <= 2^30 -> the sum is exact
+            self.theta_ref_q16 =
+                (self.theta_ref_q16 + travel).clamp(-THETA_LIM_CQ16, THETA_LIM_CQ16);
+            self.omega_ref_q16 = omega;
+            self.alpha_last_q16 = omega.saturating_sub(prev);
+        }
+    }
+
+    /// Velocity-mode entry: slew omega_ref toward the clamped goal by +-a
+    /// per tick. theta_ref keeps integrating - unused downstream in this
+    /// mode, but a switch back to position mode then starts from a
+    /// consistent pose.
+    pub fn step_velocity(&mut self, goal_velocity_cps: i32, cfg: &TrajCfg) {
+        let a = (cfg.accel_limit_q88 as i32) << 8;
+        let v_cap = cfg.vel_limit_cps.min(VEL_CAP_CPS) as i32;
+        let goal = goal_velocity_cps.clamp(-v_cap, v_cap) << 16;
+        let prev = self.omega_ref_q16;
+        // goal - prev can span 2^32; saturation past +-a is clamped away
+        let omega = prev + goal.saturating_sub(prev).clamp(-a, a);
+        let step_mag = q_mul(
+            if omega < 0 { -omega } else { omega },
+            cfg.dt_med_q32 as i32,
+            32,
+        );
+        let travel = if omega >= 0 { step_mag } else { -step_mag };
+        self.theta_ref_q16 = (self.theta_ref_q16 + travel).clamp(-THETA_LIM_CQ16, THETA_LIM_CQ16);
+        self.omega_ref_q16 = omega;
+        self.alpha_last_q16 = omega - prev;
+    }
+
+    pub fn theta_star_q16(&self) -> i32 {
+        self.theta_ref_q16
+    }
+
+    pub fn omega_star_q16(&self) -> i32 {
+        self.omega_ref_q16
+    }
+
+    pub fn alpha_star_q16(&self) -> i32 {
+        self.alpha_last_q16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 2 kHz MEDIUM rate, matching the kernel's DT_MED_Q32 derivation.
+    const DT: u32 = ((1u64 << 32) / 2000) as u32;
+    // 50 c/s per tick in csQ16 (= 100000 c/s^2 continuous at 2 kHz)
+    const A: i32 = 50 << 16;
+
+    fn cfg(vel: u16, accel_q88: u16) -> TrajCfg {
+        TrajCfg {
+            vel_limit_cps: vel,
+            accel_limit_q88: accel_q88,
+            pos_min_soft_counts: -100_000,
+            pos_max_soft_counts: 100_000,
+            dt_med_q32: DT,
+        }
+    }
+
+    fn run_to_land(t: &mut TrajGen, goal: i32, target_q16: i32, c: &TrajCfg, max: u32) -> u32 {
+        for k in 1..=max {
+            t.step_position(goal, c);
+            if t.omega_star_q16() == 0 && t.theta_star_q16() == target_q16 {
+                return k;
+            }
+        }
+        panic!(
+            "no landing: theta={} omega={}",
+            t.theta_star_q16(),
+            t.omega_star_q16()
+        );
+    }
+
+    #[test]
+    fn reseed_bumpless() {
+        let c = cfg(1000, 50 << 8);
+        let mut t = TrajGen::new();
+        for _ in 0..30 {
+            t.step_position(500, &c);
+        }
+        assert_ne!(t.omega_star_q16(), 0);
+        t.reseed(123 << 16);
+        assert_eq!(t.theta_star_q16(), 123 << 16);
+        assert_eq!(t.omega_star_q16(), 0);
+        assert_eq!(t.alpha_star_q16(), 0);
+        // extreme estimate clamps to the arithmetic guard
+        t.reseed(i32::MAX);
+        assert_eq!(t.theta_star_q16(), THETA_LIM_CQ16);
+    }
+
+    #[test]
+    fn full_profile_plateau_and_exact_landing() {
+        // 2000-count step at vel 1000 c/s, accel 50 c/s/tick: 20-tick ramp,
+        // long plateau, decel, creep, exact landing - and theta_ref is
+        // monotone with no overshoot at EVERY tick.
+        let c = cfg(1000, 50 << 8);
+        let goal_q = 2000 << 16;
+        let mut t = TrajGen::new();
+        t.reseed(0);
+        let mut peak = 0i32;
+        let mut plateau = 0u32;
+        let mut landed = 0u32;
+        let mut prev_o = 0i32;
+        let mut prev_th = 0i32;
+        for k in 1..=4400u32 {
+            t.step_position(2000, &c);
+            let o = t.omega_star_q16();
+            let th = t.theta_star_q16();
+            // alpha* IS the applied delta-omega, snap ticks included
+            assert_eq!(t.alpha_star_q16(), o - prev_o);
+            // 2a only on the landing tick: the snap zeroes the creep value a
+            // plus at most one accel step
+            assert!((o - prev_o).abs() <= 2 * A, "tick {k}: alpha past accel");
+            assert!((0..=1000 << 16).contains(&o), "tick {k}: omega={o}");
+            assert!(th <= goal_q, "tick {k}: overshoot theta={th}");
+            assert!(th >= prev_th, "tick {k}: non-monotone theta");
+            peak = peak.max(o);
+            if o == 1000 << 16 {
+                plateau += 1;
+            }
+            prev_o = o;
+            prev_th = th;
+            if o == 0 && th == goal_q {
+                landed = k;
+                break;
+            }
+        }
+        assert!(landed > 0, "never landed");
+        assert_eq!(peak, 1000 << 16, "plateau below vel_limit");
+        assert!(plateau > 3500, "plateau={plateau}");
+        // landed state is a fixed point
+        for _ in 0..5 {
+            t.step_position(2000, &c);
+            assert_eq!(t.theta_star_q16(), goal_q);
+            assert_eq!(t.omega_star_q16(), 0);
+            assert_eq!(t.alpha_star_q16(), 0);
+        }
+    }
+
+    #[test]
+    fn decel_distance_pinned() {
+        // Hand example: v = 1000 c/s, a = 50 c/s per tick at 2 kHz.
+        // Continuous stop distance s = v^2*dt/(2a) = 1000*1000*0.0005/100
+        // = 5 counts; the discrete decision adds this tick's travel:
+        // v*(v + a)*dt/(2a) = 5.25 counts.
+        let c = cfg(1000, 50 << 8);
+        // per-tick travel at 1000 c/s is half a count = 32768 cQ16, minus 1
+        // from the dt_med_q32 floor (2147483 vs 2147483.648)
+        let vt = q_mul(1000 << 16, DT as i32, 32);
+        assert_eq!(vt, 32767);
+        // exact decision boundary: decel iff (1050<<16)*vt >= (100<<16)*d,
+        // i.e. d <= floor(10.5 * 32767) = 344053 cQ16; the ideal 5.25
+        // counts = 344064 sits 11 cQ16 above, the vt floor times 10.5
+        let omega_after = |d_q16: i32| {
+            let mut t = TrajGen::new();
+            t.theta_ref_q16 = -d_q16;
+            t.omega_ref_q16 = 1000 << 16;
+            t.step_position(0, &c);
+            (t.omega_star_q16(), t.alpha_star_q16())
+        };
+        // 6 counts out: cruise holds, alpha 0
+        assert_eq!(omega_after(6 << 16), (1000 << 16, 0));
+        // 5 counts out (= the continuous s): inside the decision distance,
+        // shed exactly one accel step
+        assert_eq!(omega_after(5 << 16), (950 << 16, -A));
+        // the boundary itself, exact to the cQ16
+        assert_eq!(omega_after(344054).0, 1000 << 16);
+        assert_eq!(omega_after(344053).0, 950 << 16);
+
+        // ride the 5-count case to standstill: never past the goal, lands
+        // exactly (decel travel 4.75 counts, creep covers the rest)
+        let mut t = TrajGen::new();
+        t.theta_ref_q16 = -(5 << 16);
+        t.omega_ref_q16 = 1000 << 16;
+        for _ in 0..100 {
+            t.step_position(0, &c);
+            assert!(t.theta_star_q16() <= 0, "overshoot {}", t.theta_star_q16());
+            if t.omega_star_q16() == 0 && t.theta_star_q16() == 0 {
+                return;
+            }
+        }
+        panic!("no landing");
+    }
+
+    #[test]
+    fn short_move_triangle() {
+        // 4 counts: peak sqrt(2 * 100000 * 2) ~ 632 c/s, under the limit
+        let c = cfg(1000, 50 << 8);
+        let goal_q = 4 << 16;
+        let mut t = TrajGen::new();
+        t.reseed(0);
+        let mut peak = 0i32;
+        for _ in 0..200 {
+            t.step_position(4, &c);
+            peak = peak.max(t.omega_star_q16());
+            assert!(t.theta_star_q16() <= goal_q);
+            if t.omega_star_q16() == 0 && t.theta_star_q16() == goal_q {
+                assert!(peak > 0 && peak < 1000 << 16, "peak={peak}");
+                return;
+            }
+        }
+        panic!("no landing");
+    }
+
+    #[test]
+    fn goal_clamped_to_soft_limits() {
+        let c = TrajCfg {
+            pos_min_soft_counts: -300,
+            pos_max_soft_counts: 500,
+            ..cfg(1000, 50 << 8)
+        };
+        let mut t = TrajGen::new();
+        t.reseed(0);
+        run_to_land(&mut t, 100_000, 500 << 16, &c, 2000);
+        run_to_land(&mut t, -100_000, -(300 << 16), &c, 4000);
+    }
+
+    #[test]
+    fn velocity_mode_slews_and_clamps() {
+        let c = cfg(1000, 50 << 8);
+        let mut t = TrajGen::new();
+        t.reseed(0);
+        for k in 1..=10i32 {
+            t.step_velocity(500, &c);
+            assert_eq!(t.omega_star_q16(), (50 * k) << 16);
+            assert_eq!(t.alpha_star_q16(), A);
+        }
+        t.step_velocity(500, &c);
+        assert_eq!(t.omega_star_q16(), 500 << 16);
+        assert_eq!(t.alpha_star_q16(), 0);
+        // goal past vel_limit clamps at the limit
+        for _ in 0..100 {
+            t.step_velocity(5000, &c);
+        }
+        assert_eq!(t.omega_star_q16(), 1000 << 16);
+        // theta tracked the motion
+        assert!(t.theta_star_q16() > 0);
+        // reversal: exactly one accel step per tick through zero
+        let mut prev = t.omega_star_q16();
+        for _ in 0..40 {
+            t.step_velocity(-5000, &c);
+            assert_eq!(prev - t.omega_star_q16(), A);
+            prev = t.omega_star_q16();
+        }
+        assert_eq!(prev, -(1000 << 16));
+    }
+
+    #[test]
+    fn reversal_decelerates_through_zero() {
+        let c = cfg(1000, 50 << 8);
+        let mut t = TrajGen::new();
+        t.reseed(0);
+        for _ in 0..200 {
+            t.step_position(2000, &c);
+        }
+        assert_eq!(t.omega_star_q16(), 1000 << 16);
+        // flip the goal mid-cruise: omega walks down by at most a per tick
+        // (2a on the one landing tick, where the snap zeroes creep + step)
+        // and theta by at most one tick of travel - no teleport anywhere
+        let mut prev_o = t.omega_star_q16();
+        let mut prev_th = t.theta_star_q16();
+        let mut seen_negative = false;
+        for _ in 0..6000 {
+            t.step_position(-2000, &c);
+            let o = t.omega_star_q16();
+            let th = t.theta_star_q16();
+            assert!(
+                (o - prev_o).abs() <= 2 * A,
+                "omega jump {} -> {}",
+                prev_o,
+                o
+            );
+            assert!(
+                (th - prev_th).abs() <= 32767,
+                "theta jump {} -> {}",
+                prev_th,
+                th
+            );
+            seen_negative |= o < 0;
+            prev_o = o;
+            prev_th = th;
+            if o == 0 && th == -(2000 << 16) {
+                assert!(seen_negative);
+                return;
+            }
+        }
+        panic!("no landing");
+    }
+
+    #[test]
+    fn hostile_inputs_no_panic_bounded() {
+        // extreme goals/seeds/configs (inverted soft limits included): no
+        // panic, omega inside the i16 c/s cap, theta inside the guard
+        for accel in [0u16, 1, u16::MAX] {
+            for vel in [0u16, 1, u16::MAX] {
+                for (lo, hi) in [(i32::MIN, i32::MAX), (100, -100)] {
+                    let c = TrajCfg {
+                        vel_limit_cps: vel,
+                        accel_limit_q88: accel,
+                        pos_min_soft_counts: lo,
+                        pos_max_soft_counts: hi,
+                        dt_med_q32: DT,
+                    };
+                    for goal in [i32::MIN, -1, 0, 1, i32::MAX] {
+                        for seed in [i32::MIN, 0, i32::MAX] {
+                            let mut t = TrajGen::new();
+                            t.reseed(seed);
+                            for _ in 0..50 {
+                                t.step_position(goal, &c);
+                                assert!(t.omega_star_q16().unsigned_abs() <= 32767u32 << 16);
+                                assert!(t.theta_star_q16().unsigned_abs() <= 1 << 29);
+                                t.step_velocity(goal, &c);
+                                assert!(t.omega_star_q16().unsigned_abs() <= 32767u32 << 16);
+                                assert!(t.theta_star_q16().unsigned_abs() <= 1 << 29);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/firmware/lib/core/src/kernel/velocity.rs
+++ b/firmware/lib/core/src/kernel/velocity.rs
@@ -1,0 +1,288 @@
+//! Velocity PI with model feedforward (control-theory "The Velocity Loop"):
+//! PI on the fused velocity plus the mechanical model run backwards - J*alpha
+//! along the profile and the friction model at the profile velocity - so the
+//! PI only cleans up what the model missed. Kt never appears: gains are
+//! host-synthesized in current counts per velocity count. The downstream
+//! i_lim clip is the limits fold, and its excess back-calculates into the one
+//! integrator - "whatever clips here back-propagates". Cogging reads 0 in v1.
+
+use crate::math::q_mul;
+
+/// PI error clamp, csQ16 (16384 c/s). omega spans +-32767<<16 so the raw
+/// difference spans 2^32 - saturating_sub first, then clamp. The bound keeps
+/// q_mul(ki, e, 16) i32-exact (2^16 * 2^30 >> 16 = 2^30) and the kp product
+/// far inside i32 after its shift. SG90 tops ~9000 c/s; past 16384 c/s of
+/// error any practical gain already commands far beyond the 4095-count shunt
+/// full scale, so the flat region costs nothing.
+const E_LIM_CSQ16: i32 = 16384 << 16;
+
+/// Back-calculation excess clamp, ccounts. i_ref - i_raw is unbounded
+/// (i_raw saturates i32 under hostile inputs); 8192 is 2x shunt full scale,
+/// so clamping only limits the per-tick unwind rate, and kaw * 2^13 <= 2^29
+/// stays i32-exact (current.rs AW_LIM_VC discipline).
+const AW_LIM_CC: i32 = 8192;
+
+/// Coulomb feedforward zero band, ~1 c/s (fusion's constant): omega_star
+/// dithering around zero must not chatter +-fric_fc into i_ref.
+const FRIC_OMEGA_EPS_CSQ16: i32 = 1 << 16;
+
+/// CONFIG loop_velocity gains plus the CALIB friction model, loaded fresh
+/// each step by the kernel (`CurrentGains` convention).
+#[derive(Copy, Clone)]
+pub struct VelocityGains {
+    pub kp_q88: u16,
+    pub ki_q412: u16,
+    pub kaw_q412: u16,
+    pub j_ff_q88: u16,
+    pub fric_fc_counts: u16,
+    pub fric_fv_q016: u16,
+}
+
+/// sgn(omega_star)*fric_fc outside the zero band plus the viscous slope:
+/// Q0.16 * csQ16 >> 32 -> whole ccounts, <= 2^15 for any omega.
+fn fric_ff(omega_q16: i32, gains: &VelocityGains) -> i32 {
+    let coulomb = if omega_q16 > FRIC_OMEGA_EPS_CSQ16 {
+        gains.fric_fc_counts as i32
+    } else if omega_q16 < -FRIC_OMEGA_EPS_CSQ16 {
+        -(gains.fric_fc_counts as i32)
+    } else {
+        0
+    };
+    coulomb.saturating_add(q_mul(gains.fric_fv_q016 as i32, omega_q16, 32))
+}
+
+/// State: one current-counts integrator (ccQ16).
+#[derive(Default)]
+pub struct VelocityLoop {
+    integ_ccq16: i32,
+}
+
+impl VelocityLoop {
+    pub const fn new() -> Self {
+        Self { integ_ccq16: 0 }
+    }
+
+    /// Zero state; kernel calls on the enable edge so a stale integrator
+    /// never kicks a fresh enable.
+    pub fn reset(&mut self) {
+        self.integ_ccq16 = 0;
+    }
+
+    /// One MEDIUM-tick update -> i_ref, whole ccounts clamped to +-i_lim.
+    /// `omega_ref_q16` is the position loop's output; alpha_star/omega_star
+    /// come from the trajectory generator; `i_lim_counts` from the limits
+    /// fold. The clip excess i_ref - i_raw IS that fold's clip, fed back
+    /// through kaw. The integrator is also clamped to +-(i_lim << 16) - a
+    /// belt on top of back-calc, and when i_lim shrinks mid-run (derate,
+    /// stall fold, endstop) the clamp drains the stale charge to the new
+    /// ceiling in one tick: intended, the fold propagates instantly.
+    pub fn step(
+        &mut self,
+        omega_ref_q16: i32,
+        omega_hat_q16: i32,
+        alpha_star_q16: i32,
+        omega_star_q16: i32,
+        i_lim_counts: u16,
+        gains: &VelocityGains,
+    ) -> i32 {
+        let e = omega_ref_q16
+            .saturating_sub(omega_hat_q16)
+            .clamp(-E_LIM_CSQ16, E_LIM_CSQ16);
+        // Q8.8 * csQ16 >> 24 -> whole ccounts; <= 2^16 * 2^30 >> 24 = 2^22
+        let i_p = q_mul(gains.kp_q88 as i32, e, 24);
+        // j term <= 2^16 * 2^31 >> 24 = 2^23 for any alpha
+        let i_ff = q_mul(gains.j_ff_q88 as i32, alpha_star_q16, 24)
+            .saturating_add(fric_ff(omega_star_q16, gains));
+        let i_raw = i_p
+            .saturating_add(self.integ_ccq16 >> 16)
+            .saturating_add(i_ff);
+        let i_lim = i_lim_counts as i32;
+        let i_ref = i_raw.clamp(-i_lim, i_lim);
+        let aw = i_ref.saturating_sub(i_raw).clamp(-AW_LIM_CC, AW_LIM_CC);
+        // Q4.12 * csQ16 -> ccQ16 needs >> 12, split as >> 16 then << 4 so
+        // the q_mul result stays i32-exact (<= 2^30 per E_LIM) and only the
+        // shift saturates; kaw term mirrors current.rs (<= 2^29, << 4 can
+        // reach 2^33). Integrator clamp: i_lim <= 65535 so the << 16 can
+        // saturate too (12-bit shunt scale keeps real limits far below).
+        let ki_term = q_mul(gains.ki_q412 as i32, e, 16).saturating_mul(1 << 4);
+        let aw_term = q_mul(gains.kaw_q412 as i32, aw, 0).saturating_mul(1 << 4);
+        let lim = i_lim.saturating_mul(1 << 16);
+        self.integ_ccq16 = self
+            .integ_ccq16
+            .saturating_add(ki_term)
+            .saturating_add(aw_term)
+            .clamp(-lim, lim);
+        i_ref
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const I_LIM: u16 = 4095;
+
+    fn g(kp: u16, ki: u16, kaw: u16, j_ff: u16, fc: u16, fv: u16) -> VelocityGains {
+        VelocityGains {
+            kp_q88: kp,
+            ki_q412: ki,
+            kaw_q412: kaw,
+            j_ff_q88: j_ff,
+            fric_fc_counts: fc,
+            fric_fv_q016: fv,
+        }
+    }
+
+    /// First-order toy plant: drive b = 2^10 csQ16 per ccount per tick,
+    /// viscous drain omega/16 per tick -> steady omega = i_ref << 14
+    /// (0.25 c/s per ccount, i.e. 2000 ccounts hold 500 c/s).
+    fn plant_omega(omega_q16: i32, i_ref: i32) -> i32 {
+        omega_q16 - (omega_q16 >> 4) + (i_ref << 10)
+    }
+
+    #[test]
+    fn p_term_sign_and_scale() {
+        // kp 1.0 ccount per c/s: e = +-500 c/s -> +-500 ccounts exactly
+        let gains = g(1 << 8, 0, 0, 0, 0, 0);
+        let mut vel = VelocityLoop::new();
+        assert_eq!(vel.step(500 << 16, 0, 0, 0, I_LIM, &gains), 500);
+        assert_eq!(vel.step(-(500 << 16), 0, 0, 0, I_LIM, &gains), -500);
+        // kp 1/256: 500/256 floors to 1, arithmetic shift floors -500/256
+        // to -2
+        let gains = g(1, 0, 0, 0, 0, 0);
+        let mut vel = VelocityLoop::new();
+        assert_eq!(vel.step(500 << 16, 0, 0, 0, I_LIM, &gains), 1);
+        assert_eq!(vel.step(-(500 << 16), 0, 0, 0, I_LIM, &gains), -2);
+    }
+
+    #[test]
+    fn integrator_eliminates_steady_state_error() {
+        // Plant wants i = 2000 for 500 c/s. P-only settles where
+        // kp*e/4 (ccounts) holds omega: omega = ref/17 - huge standing
+        // error; PI closes it.
+        let p_only = g(64, 0, 0, 0, 0, 0);
+        let mut vel = VelocityLoop::new();
+        let mut omega = 0i32;
+        for _ in 0..500 {
+            let i_ref = vel.step(500 << 16, omega, 0, 0, I_LIM, &p_only);
+            omega = plant_omega(omega, i_ref);
+        }
+        assert!(omega >> 16 < 100, "p-only omega={}", omega >> 16);
+
+        let pi = g(64, 40, 0, 0, 0, 0);
+        let mut vel = VelocityLoop::new();
+        let mut omega = 0i32;
+        let mut i_ref = 0i32;
+        for _ in 0..5000 {
+            i_ref = vel.step(500 << 16, omega, 0, 0, I_LIM, &pi);
+            omega = plant_omega(omega, i_ref);
+        }
+        assert!(((omega >> 16) - 500).abs() <= 1, "pi omega={}", omega >> 16);
+        assert!((i_ref - 2000).abs() <= 8, "pi i_ref={i_ref}");
+    }
+
+    #[test]
+    fn feedforward_only_path() {
+        // kp=ki=0: output is pure model. j_ff 1.0 * alpha 100 -> 100;
+        // Coulomb 50 signed by omega_star; viscous 1/256 per c/s.
+        let gains = g(0, 0, 0, 1 << 8, 50, 1 << 8);
+        let mut vel = VelocityLoop::new();
+        // 100 + 50 + floor(1000/256) = 100 + 50 + 3
+        assert_eq!(vel.step(0, 0, 100 << 16, 1000 << 16, I_LIM, &gains), 153);
+        // reverse: -50 + floor(-1000/256) = -50 - 4 (arithmetic shift)
+        assert_eq!(vel.step(0, 0, 0, -(1000 << 16), I_LIM, &gains), -54);
+        // zero band: |omega_star| <= 1 c/s suppresses Coulomb, viscous
+        // 1/256 of 1 c/s floors to 0
+        assert_eq!(vel.step(0, 0, 0, 1 << 16, I_LIM, &gains), 0);
+        assert_eq!(vel.step(0, 0, 0, -(1 << 16), I_LIM, &gains), -1);
+        // one past the band: Coulomb kicks in
+        assert_eq!(vel.step(0, 0, 0, (1 << 16) + 1, I_LIM, &gains), 50);
+    }
+
+    #[test]
+    fn back_calc_prevents_windup() {
+        // Phase 1: 500 c/s unreachable at i_lim 100 (plant caps at 25 c/s);
+        // phase 2: drop to reachable 10 c/s and count ticks pinned high.
+        // Back-calc holds the integrator at the saturation equilibrium
+        // i_raw = i_lim + (ki/kaw)*e, so the release unsaturates on the
+        // first tick; without it the integrator rails at the i_lim<<16
+        // clamp and must grind back down through ki alone.
+        let run = |kaw: u16| -> u32 {
+            let gains = g(64, 40, kaw, 0, 0, 0);
+            let mut vel = VelocityLoop::new();
+            let mut omega = 0i32;
+            let mut i_ref = 0i32;
+            for _ in 0..300 {
+                i_ref = vel.step(500 << 16, omega, 0, 0, 100, &gains);
+                omega = plant_omega(omega, i_ref);
+            }
+            assert_eq!(i_ref, 100, "saturated, kaw={kaw}");
+            let mut ticks = 0u32;
+            while ticks < 500 {
+                i_ref = vel.step(10 << 16, omega, 0, 0, 100, &gains);
+                omega = plant_omega(omega, i_ref);
+                if i_ref <= 60 {
+                    break;
+                }
+                ticks += 1;
+            }
+            ticks
+        };
+        let with_aw = run(2048);
+        let without_aw = run(0);
+        assert!(with_aw <= 3, "with_aw={with_aw}");
+        assert!(without_aw > 3 * (with_aw + 1), "without_aw={without_aw}");
+    }
+
+    #[test]
+    fn integrator_drains_when_lim_folds() {
+        // Pure I (ki 1.0) charges 1000 cc/tick against a held error and
+        // rails at 4000<<16. Folding i_lim to 500 clamps the integrator to
+        // 500<<16 in that same step - restoring the limit afterwards shows
+        // the charge is gone, not merely masked by the output clamp.
+        let gains = g(0, 1 << 12, 0, 0, 0, 0);
+        let mut vel = VelocityLoop::new();
+        for _ in 0..200 {
+            vel.step(1000 << 16, 0, 0, 0, 4000, &gains);
+        }
+        assert_eq!(vel.step(0, 0, 0, 0, 4000, &gains), 4000);
+        assert_eq!(vel.step(0, 0, 0, 0, 500, &gains), 500);
+        assert_eq!(vel.step(0, 0, 0, 0, 4000, &gains), 500);
+    }
+
+    #[test]
+    fn i_ref_capped_for_any_input() {
+        // All-max gains, i32-extreme inputs, 20 ticks of accumulated state:
+        // output never escapes +-i_lim, nothing panics.
+        let gains = g(u16::MAX, u16::MAX, u16::MAX, u16::MAX, u16::MAX, u16::MAX);
+        let ext = [i32::MIN, -(9000 << 16), 0, 9000 << 16, i32::MAX];
+        for lim in [0u16, 100, 4095, u16::MAX] {
+            for o_ref in ext {
+                for o_hat in ext {
+                    for star in [i32::MIN, 0, i32::MAX] {
+                        let mut vel = VelocityLoop::new();
+                        for _ in 0..20 {
+                            let i = vel.step(o_ref, o_hat, star, star, lim, &gains);
+                            assert!(
+                                i.unsigned_abs() <= lim as u32,
+                                "i={i} lim={lim} o_ref={o_ref} o_hat={o_hat} star={star}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn reset_zeroes_state() {
+        let gains = g(64, 200, 0, 0, 0, 0);
+        let mut vel = VelocityLoop::new();
+        for _ in 0..50 {
+            vel.step(500 << 16, 0, 0, 0, I_LIM, &gains);
+        }
+        assert_ne!(vel.step(0, 0, 0, 0, I_LIM, &gains), 0);
+        vel.reset();
+        assert_eq!(vel.step(0, 0, 0, 0, I_LIM, &gains), 0);
+    }
+}

--- a/firmware/lib/core/src/kernel/velocity.rs
+++ b/firmware/lib/core/src/kernel/velocity.rs
@@ -68,21 +68,22 @@ impl VelocityLoop {
         self.integ_ccq16 = 0;
     }
 
-    /// One MEDIUM-tick update -> i_ref, whole ccounts clamped to +-i_lim.
+    /// One MEDIUM-tick update -> i_ref, whole ccounts clamped into `band`.
     /// `omega_ref_q16` is the position loop's output; alpha_star/omega_star
-    /// come from the trajectory generator; `i_lim_counts` from the limits
-    /// fold. The clip excess i_ref - i_raw IS that fold's clip, fed back
-    /// through kaw. The integrator is also clamped to +-(i_lim << 16) - a
-    /// belt on top of back-calc, and when i_lim shrinks mid-run (derate,
-    /// stall fold, endstop) the clamp drains the stale charge to the new
-    /// ceiling in one tick: intended, the fold propagates instantly.
+    /// come from the trajectory generator; `band` from the limits fold
+    /// (directional: an endstop zeroes only the inward side). The clip
+    /// excess i_ref - i_raw IS that fold's clip, fed back through kaw. The
+    /// integrator is also clamped to the band's widest side << 16 - a belt
+    /// on top of back-calc, and when the band shrinks mid-run (derate,
+    /// stall fold) the clamp drains the stale charge to the new ceiling in
+    /// one tick: intended, the fold propagates instantly.
     pub fn step(
         &mut self,
         omega_ref_q16: i32,
         omega_hat_q16: i32,
         alpha_star_q16: i32,
         omega_star_q16: i32,
-        i_lim_counts: u16,
+        band: super::limits::IBand,
         gains: &VelocityGains,
     ) -> i32 {
         let e = omega_ref_q16
@@ -96,8 +97,7 @@ impl VelocityLoop {
         let i_raw = i_p
             .saturating_add(self.integ_ccq16 >> 16)
             .saturating_add(i_ff);
-        let i_lim = i_lim_counts as i32;
-        let i_ref = i_raw.clamp(-i_lim, i_lim);
+        let i_ref = band.clamp(i_raw);
         let aw = i_ref.saturating_sub(i_raw).clamp(-AW_LIM_CC, AW_LIM_CC);
         // Q4.12 * csQ16 -> ccQ16 needs >> 12, split as >> 16 then << 4 so
         // the q_mul result stays i32-exact (<= 2^30 per E_LIM) and only the
@@ -106,7 +106,7 @@ impl VelocityLoop {
         // saturate too (12-bit shunt scale keeps real limits far below).
         let ki_term = q_mul(gains.ki_q412 as i32, e, 16).saturating_mul(1 << 4);
         let aw_term = q_mul(gains.kaw_q412 as i32, aw, 0).saturating_mul(1 << 4);
-        let lim = i_lim.saturating_mul(1 << 16);
+        let lim = band.hi.abs().max(band.lo.abs()).saturating_mul(1 << 16);
         self.integ_ccq16 = self
             .integ_ccq16
             .saturating_add(ki_term)
@@ -119,6 +119,11 @@ impl VelocityLoop {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::kernel::limits::IBand;
+
+    fn band(l: i32) -> IBand {
+        IBand { lo: -l, hi: l }
+    }
 
     const I_LIM: u16 = 4095;
 
@@ -145,14 +150,23 @@ mod tests {
         // kp 1.0 ccount per c/s: e = +-500 c/s -> +-500 ccounts exactly
         let gains = g(1 << 8, 0, 0, 0, 0, 0);
         let mut vel = VelocityLoop::new();
-        assert_eq!(vel.step(500 << 16, 0, 0, 0, I_LIM, &gains), 500);
-        assert_eq!(vel.step(-(500 << 16), 0, 0, 0, I_LIM, &gains), -500);
+        assert_eq!(
+            vel.step(500 << 16, 0, 0, 0, band(I_LIM as i32), &gains),
+            500
+        );
+        assert_eq!(
+            vel.step(-(500 << 16), 0, 0, 0, band(I_LIM as i32), &gains),
+            -500
+        );
         // kp 1/256: 500/256 floors to 1, arithmetic shift floors -500/256
         // to -2
         let gains = g(1, 0, 0, 0, 0, 0);
         let mut vel = VelocityLoop::new();
-        assert_eq!(vel.step(500 << 16, 0, 0, 0, I_LIM, &gains), 1);
-        assert_eq!(vel.step(-(500 << 16), 0, 0, 0, I_LIM, &gains), -2);
+        assert_eq!(vel.step(500 << 16, 0, 0, 0, band(I_LIM as i32), &gains), 1);
+        assert_eq!(
+            vel.step(-(500 << 16), 0, 0, 0, band(I_LIM as i32), &gains),
+            -2
+        );
     }
 
     #[test]
@@ -164,7 +178,7 @@ mod tests {
         let mut vel = VelocityLoop::new();
         let mut omega = 0i32;
         for _ in 0..500 {
-            let i_ref = vel.step(500 << 16, omega, 0, 0, I_LIM, &p_only);
+            let i_ref = vel.step(500 << 16, omega, 0, 0, band(I_LIM as i32), &p_only);
             omega = plant_omega(omega, i_ref);
         }
         assert!(omega >> 16 < 100, "p-only omega={}", omega >> 16);
@@ -174,7 +188,7 @@ mod tests {
         let mut omega = 0i32;
         let mut i_ref = 0i32;
         for _ in 0..5000 {
-            i_ref = vel.step(500 << 16, omega, 0, 0, I_LIM, &pi);
+            i_ref = vel.step(500 << 16, omega, 0, 0, band(I_LIM as i32), &pi);
             omega = plant_omega(omega, i_ref);
         }
         assert!(((omega >> 16) - 500).abs() <= 1, "pi omega={}", omega >> 16);
@@ -188,15 +202,27 @@ mod tests {
         let gains = g(0, 0, 0, 1 << 8, 50, 1 << 8);
         let mut vel = VelocityLoop::new();
         // 100 + 50 + floor(1000/256) = 100 + 50 + 3
-        assert_eq!(vel.step(0, 0, 100 << 16, 1000 << 16, I_LIM, &gains), 153);
+        assert_eq!(
+            vel.step(0, 0, 100 << 16, 1000 << 16, band(I_LIM as i32), &gains),
+            153
+        );
         // reverse: -50 + floor(-1000/256) = -50 - 4 (arithmetic shift)
-        assert_eq!(vel.step(0, 0, 0, -(1000 << 16), I_LIM, &gains), -54);
+        assert_eq!(
+            vel.step(0, 0, 0, -(1000 << 16), band(I_LIM as i32), &gains),
+            -54
+        );
         // zero band: |omega_star| <= 1 c/s suppresses Coulomb, viscous
         // 1/256 of 1 c/s floors to 0
-        assert_eq!(vel.step(0, 0, 0, 1 << 16, I_LIM, &gains), 0);
-        assert_eq!(vel.step(0, 0, 0, -(1 << 16), I_LIM, &gains), -1);
+        assert_eq!(vel.step(0, 0, 0, 1 << 16, band(I_LIM as i32), &gains), 0);
+        assert_eq!(
+            vel.step(0, 0, 0, -(1 << 16), band(I_LIM as i32), &gains),
+            -1
+        );
         // one past the band: Coulomb kicks in
-        assert_eq!(vel.step(0, 0, 0, (1 << 16) + 1, I_LIM, &gains), 50);
+        assert_eq!(
+            vel.step(0, 0, 0, (1 << 16) + 1, band(I_LIM as i32), &gains),
+            50
+        );
     }
 
     #[test]
@@ -213,13 +239,13 @@ mod tests {
             let mut omega = 0i32;
             let mut i_ref = 0i32;
             for _ in 0..300 {
-                i_ref = vel.step(500 << 16, omega, 0, 0, 100, &gains);
+                i_ref = vel.step(500 << 16, omega, 0, 0, band(100), &gains);
                 omega = plant_omega(omega, i_ref);
             }
             assert_eq!(i_ref, 100, "saturated, kaw={kaw}");
             let mut ticks = 0u32;
             while ticks < 500 {
-                i_ref = vel.step(10 << 16, omega, 0, 0, 100, &gains);
+                i_ref = vel.step(10 << 16, omega, 0, 0, band(100), &gains);
                 omega = plant_omega(omega, i_ref);
                 if i_ref <= 60 {
                     break;
@@ -243,11 +269,11 @@ mod tests {
         let gains = g(0, 1 << 12, 0, 0, 0, 0);
         let mut vel = VelocityLoop::new();
         for _ in 0..200 {
-            vel.step(1000 << 16, 0, 0, 0, 4000, &gains);
+            vel.step(1000 << 16, 0, 0, 0, band(4000), &gains);
         }
-        assert_eq!(vel.step(0, 0, 0, 0, 4000, &gains), 4000);
-        assert_eq!(vel.step(0, 0, 0, 0, 500, &gains), 500);
-        assert_eq!(vel.step(0, 0, 0, 0, 4000, &gains), 500);
+        assert_eq!(vel.step(0, 0, 0, 0, band(4000), &gains), 4000);
+        assert_eq!(vel.step(0, 0, 0, 0, band(500), &gains), 500);
+        assert_eq!(vel.step(0, 0, 0, 0, band(4000), &gains), 500);
     }
 
     #[test]
@@ -262,7 +288,7 @@ mod tests {
                     for star in [i32::MIN, 0, i32::MAX] {
                         let mut vel = VelocityLoop::new();
                         for _ in 0..20 {
-                            let i = vel.step(o_ref, o_hat, star, star, lim, &gains);
+                            let i = vel.step(o_ref, o_hat, star, star, band(lim as i32), &gains);
                             assert!(
                                 i.unsigned_abs() <= lim as u32,
                                 "i={i} lim={lim} o_ref={o_ref} o_hat={o_hat} star={star}"
@@ -279,10 +305,10 @@ mod tests {
         let gains = g(64, 200, 0, 0, 0, 0);
         let mut vel = VelocityLoop::new();
         for _ in 0..50 {
-            vel.step(500 << 16, 0, 0, 0, I_LIM, &gains);
+            vel.step(500 << 16, 0, 0, 0, band(I_LIM as i32), &gains);
         }
-        assert_ne!(vel.step(0, 0, 0, 0, I_LIM, &gains), 0);
+        assert_ne!(vel.step(0, 0, 0, 0, band(I_LIM as i32), &gains), 0);
         vel.reset();
-        assert_eq!(vel.step(0, 0, 0, 0, I_LIM, &gains), 0);
+        assert_eq!(vel.step(0, 0, 0, 0, band(I_LIM as i32), &gains), 0);
     }
 }

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -27,8 +27,8 @@ pub use regions::config::{BaudRate, ConfigDefaults};
 pub use regions::{
     BemfCalibBlock, BootMode, CalibRegs, CalibSense, CalibWinding, ConfigCommon,
     ConfigControlPosition, ConfigPosLimits, ConfigRegs, ConfigStall, ConfigThermal,
-    ControlLifecycle, ControlRegs, ControlStreaming, ControlSystem, ControlTable, ControlTableCell,
-    Mode, PotLutBlock, StallResponse, TelemetryCommon, TelemetryIntermediaries, TelemetryMode,
+    ControlLifecycle, ControlRegs, ControlSystem, ControlTable, ControlTableCell, Mode,
+    PotLutBlock, StallResponse, TelemetryCommon, TelemetryIntermediaries, TelemetryMode,
     TelemetryRegs, TelemetrySensors,
 };
 pub use sensor_frame::SensorFrame;

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -25,7 +25,7 @@ pub use kernel::{Kernel, KernelState};
 pub use persist::{ConfigStore, StoreError};
 pub use regions::config::{BaudRate, ConfigDefaults};
 pub use regions::{
-    BemfCalibBlock, BootMode, CalibRegs, CalibSense, CalibWinding, ConfigCommon, ConfigFaultCfg,
+    BootMode, CalibMotor, CalibRegs, CalibSense, CalibWinding, ConfigCommon, ConfigFaultCfg,
     ConfigFusion, ConfigLimits, ConfigLoopCurrent, ConfigLoopPosition, ConfigLoopVelocity,
     ConfigPosLimits, ConfigRegs, ConfigThermal, ControlLifecycle, ControlRegs, ControlSystem,
     ControlTable, ControlTableCell, DecaySelect, Mode, PotLutBlock, StallResponse, TelemetryCommon,

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -22,7 +22,7 @@ pub mod traits;
 pub use control_table::{
     Error, Region, RegionStorage, RegionStorageRaw, StagedWrites, ValidationKind,
 };
-pub use kernel::{Kernel, KernelState};
+pub use kernel::{Kernel, KernelTiming};
 pub use persist::{ConfigStore, StoreError};
 pub use regions::config::{BaudRate, ConfigDefaults};
 pub use regions::{

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod kernel;
 pub const FIRMWARE_VERSION: u8 = 1;
 
 pub mod log;
+pub mod math;
 pub mod persist;
 pub mod regions;
 pub mod sensor_frame;

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -25,11 +25,11 @@ pub use kernel::{Kernel, KernelState};
 pub use persist::{ConfigStore, StoreError};
 pub use regions::config::{BaudRate, ConfigDefaults};
 pub use regions::{
-    BemfCalibBlock, BootMode, CalibRegs, CalibSense, CalibWinding, ConfigCommon,
-    ConfigControlPosition, ConfigPosLimits, ConfigRegs, ConfigStall, ConfigThermal,
-    ControlLifecycle, ControlRegs, ControlSystem, ControlTable, ControlTableCell, Mode,
-    PotLutBlock, StallResponse, TelemetryCommon, TelemetryIntermediaries, TelemetryMode,
-    TelemetryRegs, TelemetrySensors,
+    BemfCalibBlock, BootMode, CalibRegs, CalibSense, CalibWinding, ConfigCommon, ConfigFaultCfg,
+    ConfigFusion, ConfigLimits, ConfigLoopCurrent, ConfigLoopPosition, ConfigLoopVelocity,
+    ConfigPosLimits, ConfigRegs, ConfigThermal, ControlLifecycle, ControlRegs, ControlSystem,
+    ControlTable, ControlTableCell, DecaySelect, Mode, PotLutBlock, StallResponse, TelemetryCommon,
+    TelemetryIntermediaries, TelemetryMode, TelemetryRegs, TelemetrySensors,
 };
 pub use sensor_frame::SensorFrame;
 pub use services::bus::{Dispatcher, Session};

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -29,7 +29,7 @@ pub use regions::{
     ConfigFusion, ConfigLimits, ConfigLoopCurrent, ConfigLoopPosition, ConfigLoopVelocity,
     ConfigPosLimits, ConfigRegs, ConfigThermal, ControlLifecycle, ControlRegs, ControlSystem,
     ControlTable, ControlTableCell, DecaySelect, Mode, PotLutBlock, StallResponse, TelemetryCommon,
-    TelemetryIntermediaries, TelemetryMode, TelemetryRegs, TelemetrySensors,
+    TelemetryEstimates, TelemetryIdent, TelemetryMode, TelemetryRegs, TelemetrySensors,
 };
 pub use sensor_frame::SensorFrame;
 pub use services::bus::{Dispatcher, Session};

--- a/firmware/lib/core/src/math.rs
+++ b/firmware/lib/core/src/math.rs
@@ -28,17 +28,34 @@ pub fn wide_ge(a: u32, b: u32, c: u32, d: u32) -> bool {
     a as u64 * b as u64 >= c as u64 * d as u64
 }
 
-/// clz-based seed for a Q15 reciprocal Newton iteration. Contract: the
-/// converged recip satisfies `(recip * v) >> 15 ~= 32767`, i.e.
-/// `duty = q_mul(u, recip, 15)` maps `u == vbus` to ~full-scale 32767. The
-/// seed is `2^(clz(v)-1)`, so `seed * v` lands in `[2^30, 2^31)` - within a
-/// factor of 2 of the `32767 << 15` target for any `v` in `1..2^31` (vbus
-/// counts are 12-bit in practice); the vbus estimator's Newton steps refine
-/// it. `v == 0` has no reciprocal and just yields the max seed - no panic.
-/// `leading_zeros` is an intrinsic, no libcall.
-#[inline]
-pub fn recip_seed_q15(v: u32) -> u32 {
-    1u32 << v.leading_zeros().saturating_sub(1)
+// Q1.30 linear reciprocal seed r0 = 48/17 - (32/17)x for the normalized
+// x in [0.5, 1): max relative error 1/17, so two Newton steps land at
+// (1/17)^4 ~ 1.2e-5. A clz power-of-two seed can start a factor of 2 off,
+// where r*(2 - r*d) convergence stalls and needs ~8 steps; the linear seed
+// keeps the full-accuracy reciprocal one-shot at ~10 multiplies, cheap
+// enough for every caller to share this implementation.
+const SEED_C1_Q30: u32 = 3_031_741_621; // round(48/17 << 30)
+const SEED_C2_Q30: u32 = 2_021_161_080; // round(32/17 << 30)
+
+/// `num / d` without a divide. Normalize d into [2^31, 2^32) (Q0.32), linear
+/// seed + two Newton steps `r' = r*(2 - r*d)` in Q1.30, then one widening
+/// multiply denormalizes straight into the quotient. Error <= 1.2e-5
+/// relative plus truncation (pinned in tests). d == 0 has no quotient;
+/// callers gate the degenerate span, num is the no-panic backstop.
+pub fn recip_div(num: u32, d: u32) -> u32 {
+    if d <= 1 {
+        return num;
+    }
+    let n = d.leading_zeros(); // 1..=30 for d >= 2
+    let dn = d << n;
+    let mut r = SEED_C1_Q30 - q_mul_u(SEED_C2_Q30, dn, 32);
+    r = q_mul_u(r, (2u32 << 30) - q_mul_u(r, dn, 32), 30);
+    r = q_mul_u(r, (2u32 << 30) - q_mul_u(r, dn, 32), 30);
+    // num/d = num*r >> (62-n), split as (>> 32) then (>> 30-n): identical
+    // bits, but the u64 shift stays constant and the variable shift is u32 -
+    // a variable 64-bit shift is soft on rv32ec (check-soft-arith.sh bans it)
+    let p = num as u64 * r as u64;
+    ((p >> 32) as u32) >> (30 - n)
 }
 
 #[cfg(test)]
@@ -102,21 +119,21 @@ mod tests {
     }
 
     #[test]
-    fn recip_seed_within_factor_of_two() {
-        let target = (32767u64) << 15;
-        for v in 512..=4095u32 {
-            let seed = recip_seed_q15(v);
-            assert!(seed > 0);
-            let p = seed as u64 * v as u64;
-            assert!(p >= target / 2, "v={v} seed={seed} p={p}");
-            assert!(p <= target * 2, "v={v} seed={seed} p={p}");
+    fn recip_div_accuracy_pinned() {
+        // worst seeds are just under a power of two (x -> 1 from below maps
+        // to r near the interval edge); sweep those plus a dense band and
+        // the u32-extreme numerator. Bound: 1.2e-5 relative + 2 LSB.
+        let spot = [32767u32, 32768, 65534, 65535];
+        for d in (1..=4096u32).chain(spot) {
+            for num in [1u32, 999, 1_200 * 2_000, 4_294_836_225] {
+                let got = recip_div(num, d);
+                let exact = (num / d) as i64;
+                let err = (got as i64 - exact).abs();
+                assert!(
+                    err <= exact / 65536 + 2,
+                    "num={num} d={d} got={got} exact={exact}"
+                );
+            }
         }
-    }
-
-    #[test]
-    fn recip_seed_edges_no_panic() {
-        assert_eq!(recip_seed_q15(0), 1 << 31);
-        assert_eq!(recip_seed_q15(1), 1 << 30);
-        assert_eq!(recip_seed_q15(u32::MAX), 1);
     }
 }

--- a/firmware/lib/core/src/math.rs
+++ b/firmware/lib/core/src/math.rs
@@ -1,0 +1,122 @@
+//! Fixed-point primitives. Every widening multiply in the kernel funnels
+//! through here - a single fix point if codegen regresses. On rv32ec+Zmmul
+//! LLVM lowers the extended 32x32 products to inline mul+mulh and the
+//! constant 64-bit shifts to short register-pair sequences (no __muldi3);
+//! check-soft-arith.sh is the CI backstop.
+
+/// `(a * b) >> k` via an i64 widening product. Arithmetic shift: truncates
+/// toward negative infinity, so `q_mul(-3, 1, 1) == -2` while
+/// `q_mul(3, 1, 1) == 1`.
+#[inline(always)]
+pub const fn q_mul(a: i32, b: i32, k: u32) -> i32 {
+    ((a as i64 * b as i64) >> k) as i32
+}
+
+/// Unsigned twin of `q_mul`. The u64 product cannot overflow for any
+/// operands; the caller picks `k` so the result fits u32.
+#[inline(always)]
+pub const fn q_mul_u(a: u32, b: u32, k: u32) -> u32 {
+    ((a as u64 * b as u64) >> k) as u32
+}
+
+/// `a*b >= c*d` via u64 widening products compared directly. The trajectory
+/// decel test needs only the comparison, never a quotient - rv32ec has no
+/// hardware divide, so cross-multiplying keeps it a mul+mulh pair per side
+/// plus a 64-bit compare.
+#[inline(always)]
+pub fn wide_ge(a: u32, b: u32, c: u32, d: u32) -> bool {
+    a as u64 * b as u64 >= c as u64 * d as u64
+}
+
+/// clz-based seed for a Q15 reciprocal Newton iteration. Contract: the
+/// converged recip satisfies `(recip * v) >> 15 ~= 32767`, i.e.
+/// `duty = q_mul(u, recip, 15)` maps `u == vbus` to ~full-scale 32767. The
+/// seed is `2^(clz(v)-1)`, so `seed * v` lands in `[2^30, 2^31)` - within a
+/// factor of 2 of the `32767 << 15` target for any `v` in `1..2^31` (vbus
+/// counts are 12-bit in practice); the vbus estimator's Newton steps refine
+/// it. `v == 0` has no reciprocal and just yields the max seed - no panic.
+/// `leading_zeros` is an intrinsic, no libcall.
+#[inline]
+pub fn recip_seed_q15(v: u32) -> u32 {
+    1u32 << v.leading_zeros().saturating_sub(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn q_mul_identity() {
+        for x in [0, 1, -1, 12345, -12345, i32::MAX >> 1, i32::MIN >> 1] {
+            assert_eq!(q_mul(x, 1 << 12, 12), x);
+        }
+    }
+
+    #[test]
+    fn q_mul_scales() {
+        assert_eq!(q_mul(3 << 15, 5 << 15, 15), 15 << 15);
+        assert_eq!(q_mul(1000, 256, 8), 1000);
+        assert_eq!(q_mul(i32::MAX, i32::MAX, 61), 1);
+    }
+
+    #[test]
+    fn q_mul_signs() {
+        assert_eq!(q_mul(-1000, 256, 8), -1000);
+        assert_eq!(q_mul(-1000, -256, 8), 1000);
+        assert_eq!(q_mul(1000, -256, 8), -1000);
+    }
+
+    #[test]
+    fn q_mul_truncates_toward_negative_infinity() {
+        assert_eq!(q_mul(3, 1, 1), 1);
+        assert_eq!(q_mul(-3, 1, 1), -2);
+        assert_eq!(q_mul(-1, 1, 1), -1);
+        assert_eq!(q_mul(-1, 1, 31), -1);
+    }
+
+    #[test]
+    fn q_mul_u_extremes() {
+        // MAX*MAX = 2^64 - 2^33 + 1 fits u64; >> 32 floors to 2^32 - 2.
+        assert_eq!(q_mul_u(u32::MAX, u32::MAX, 32), u32::MAX - 1);
+        assert_eq!(q_mul_u(u32::MAX, u32::MAX, 63), 1);
+        assert_eq!(q_mul_u(u32::MAX, 1, 0), u32::MAX);
+        assert_eq!(q_mul_u(0, u32::MAX, 15), 0);
+    }
+
+    #[test]
+    fn wide_ge_equality() {
+        assert!(wide_ge(0, 0, 0, 0));
+        assert!(wide_ge(u32::MAX, u32::MAX, u32::MAX, u32::MAX));
+        // 6*4 == 8*3
+        assert!(wide_ge(6, 4, 8, 3));
+        assert!(wide_ge(8, 3, 6, 4));
+    }
+
+    #[test]
+    fn wide_ge_off_by_one_large() {
+        // 65536*65536 = 2^32; 65537*65535 = 2^32 - 1
+        assert!(wide_ge(65536, 65536, 65537, 65535));
+        assert!(!wide_ge(65537, 65535, 65536, 65536));
+        assert!(wide_ge(u32::MAX, u32::MAX, u32::MAX, u32::MAX - 1));
+        assert!(!wide_ge(u32::MAX, u32::MAX - 1, u32::MAX, u32::MAX));
+    }
+
+    #[test]
+    fn recip_seed_within_factor_of_two() {
+        let target = (32767u64) << 15;
+        for v in 512..=4095u32 {
+            let seed = recip_seed_q15(v);
+            assert!(seed > 0);
+            let p = seed as u64 * v as u64;
+            assert!(p >= target / 2, "v={v} seed={seed} p={p}");
+            assert!(p <= target * 2, "v={v} seed={seed} p={p}");
+        }
+    }
+
+    #[test]
+    fn recip_seed_edges_no_panic() {
+        assert_eq!(recip_seed_q15(0), 1 << 31);
+        assert_eq!(recip_seed_q15(1), 1 << 30);
+        assert_eq!(recip_seed_q15(u32::MAX), 1);
+    }
+}

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -284,7 +284,7 @@ mod tests {
         // A CRC-valid image planting an out-of-range discriminant must not
         // parse -- overlay would construct an invalid enum (UB).
         let (mut config, profile) = body();
-        config[addr::stall::STALL_RESPONSE as usize] = 2;
+        config[addr::limits::STALL_RESPONSE as usize] = 2;
         let mut img = [0u8; IMAGE_LEN];
         assemble(&mut img, 1, &config, &profile);
         assert!(Image::parse(&img).is_none());

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -31,7 +31,7 @@ pub const IMAGE_LEN: usize = HEADER_LEN + CONFIG_LEN + PROFILE_LEN;
 pub const IMAGE_MAGIC: u8 = b'C';
 /// Bump on any CONFIG/PROFILE layout change; a mismatched image is ignored
 /// (boot keeps board defaults) rather than migrated.
-pub const IMAGE_VERSION: u8 = 1;
+pub const IMAGE_VERSION: u8 = 2;
 
 /// Store failure (erase/program/verify); dispatch answers `hardware` (sec 5.3).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -50,8 +50,11 @@ pub struct CalibWinding {
 /// Motor identification: `ke_uvs_per_rad` is the host-facing record; the rest
 /// are firmware-shaped -- bemf subtract R (Q4.12), reciprocal Ke (c/s per
 /// vcount Q6.10, estimator::bemf convention), fusion current gain (bakes
-/// Ts/J), and the friction model (Coulomb ccounts, viscous Q0.16, breakaway
-/// ccounts).
+/// Ts/J), the friction model (Coulomb ccounts, viscous Q0.16, breakaway
+/// ccounts), and forward Ke (vcounts per c/s Q4.12, the current loop's bemf
+/// decoupling feedforward). Forward and reciprocal Ke are both host-written:
+/// the chip has no divide to derive one from the other. SG90 scale ~0.28
+/// vcounts per c/s (~1150 stored); the u16 caps at 16, 57x headroom.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct CalibMotor {
@@ -62,6 +65,7 @@ pub struct CalibMotor {
     pub fric_fc_counts: u16,
     pub fric_fv_q016: u16,
     pub fric_breakaway_counts: u16,
+    pub ke_vpc_q: u16,
 }
 
 /// Calibration section: always writable (normal field validation applies),
@@ -78,5 +82,5 @@ pub struct CalibRegs {
     pub winding: CalibWinding,
     pub motor: CalibMotor,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 104],
+    pub _rsvd_tail: [u8; 102],
 }

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -5,21 +5,15 @@ use control_table::{Block, Section};
 pub struct PotLutBlock {
     pub raw_min: u16,
     pub raw_max: u16,
-    pub lut: [i32; 55],
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Block)]
-pub struct BemfCalibBlock {
-    pub ke_uvs_per_rad: u16,
-    pub r_motor_mohm: u16,
-    pub calib_v_bus_mv: u16,
-    pub calib_i_ma: u16,
+    /// Corrections vs the identity ramp raw_min..raw_max; all-zero = identity.
+    pub lut_corr: [i16; 55],
 }
 
 /// Sense-chain primitives the host converts raw counts with (protocol sec
 /// 5.5): divider legs in ohms, amplifier gain x1000. `vdd_mv` is the
 /// host-measured VDD at the chip pin -- the v006 ADC reference is VDD itself.
+/// `tick_hz` is stamped at install from the same chip constant that programs
+/// TIM1; the window floors are board data in TIM1 ticks.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct CalibSense {
@@ -32,16 +26,41 @@ pub struct CalibSense {
     #[ct_field(access = ro)]
     pub vmotor_div_bot: u16,
     pub vdd_mv: u16,
+    #[ct_field(access = ro)]
+    pub tick_hz: u16,
+    #[ct_field(access = ro)]
+    pub i_window_min_ticks: u16,
+    #[ct_field(access = ro)]
+    pub v_window_min_ticks: u16,
 }
 
-/// Winding-resistance thermometry anchor: `r0_mohm` is the cold winding
-/// resistance the calibration routine measures, `t0_cc` the ambient the user
-/// entered for it (centi-degC).
+/// Winding-resistance thermometry anchor, firmware-shaped: `r0_q12` is the
+/// cold winding resistance in vcounts-per-ccount Q4.12 (host computes it from
+/// its measurement), `t0_cc` the ambient the user entered for it (centi-degC),
+/// `k_r2t_q88` the R-to-T slope, `mu_q016` the LMS step.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct CalibWinding {
-    pub r0_mohm: u16,
+    pub r0_q12: u16,
     pub t0_cc: i16,
+    pub k_r2t_q88: u16,
+    pub mu_q016: u16,
+}
+
+/// Motor identification: `ke_uvs_per_rad` is the host-facing record; the rest
+/// are firmware-shaped -- bemf subtract R (Q4.12), reciprocal Ke (c/s per
+/// vcount), fusion current gain (bakes Ts/J), and the friction model
+/// (Coulomb ccounts, viscous Q0.16, breakaway ccounts).
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct CalibMotor {
+    pub ke_uvs_per_rad: u16,
+    pub r_q12: u16,
+    pub recip_ke_q: u16,
+    pub b_i_q016: u16,
+    pub fric_fc_counts: u16,
+    pub fric_fv_q016: u16,
+    pub fric_breakaway_counts: u16,
 }
 
 /// Calibration section: always writable (normal field validation applies),
@@ -54,9 +73,9 @@ pub struct CalibWinding {
 )]
 pub struct CalibRegs {
     pub pot_lut: PotLutBlock,
-    pub bemf: BemfCalibBlock,
     pub sense: CalibSense,
     pub winding: CalibWinding,
+    pub motor: CalibMotor,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 10],
+    pub _rsvd_tail: [u8; 104],
 }

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -49,8 +49,9 @@ pub struct CalibWinding {
 
 /// Motor identification: `ke_uvs_per_rad` is the host-facing record; the rest
 /// are firmware-shaped -- bemf subtract R (Q4.12), reciprocal Ke (c/s per
-/// vcount), fusion current gain (bakes Ts/J), and the friction model
-/// (Coulomb ccounts, viscous Q0.16, breakaway ccounts).
+/// vcount Q6.10, estimator::bemf convention), fusion current gain (bakes
+/// Ts/J), and the friction model (Coulomb ccounts, viscous Q0.16, breakaway
+/// ccounts).
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct CalibMotor {

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -6,14 +6,25 @@ use control_table::{Block, Enum, Section};
 // crate defines the type.
 pub use osc_protocol::wire::{BaudRate, DEFAULT_RESPONSE_DEADLINE_US};
 
-/// Stall detector policy. `repr(u8)`; constructing from an unlisted discriminant is UB,
-/// so validators MUST gate writes to `StallResponse::ALLOWED`.
+/// Stall policy: Fault latches STALL; Yield folds the current limit.
+/// `repr(u8)`; constructing from an unlisted discriminant is UB, so
+/// validators MUST gate writes to `StallResponse::ALLOWED`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
 #[repr(u8)]
 pub enum StallResponse {
     #[default]
-    Disable = 0,
-    Comply = 1,
+    Fault = 0,
+    Yield = 1,
+}
+
+/// Off-window decay for OpenLoop drive; closed-loop modes force Slow.
+/// `repr(u8)`; same UB gate as `StallResponse`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
+#[repr(u8)]
+pub enum DecaySelect {
+    #[default]
+    Slow = 0,
+    Fast = 1,
 }
 
 /// protocol sec 5.4 CONFIG-COMMON block: identity RO at the region front,
@@ -67,50 +78,122 @@ pub struct ConfigPosLimits {
     pub pos_max_soft_counts: i32,
 }
 
+/// Current PI gains, voltage-domain clamp + back-calc anti-windup.
+/// Gains carry i_/v_/p_ prefixes: descriptor field names are table-flat.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
-pub struct ConfigStall {
-    pub stall_response: StallResponse,
-    #[ct_field(skip)]
-    pub _rsvd_align: u8,
-    pub stall_effort_threshold: i16,
-    pub stall_motion_threshold_urad: u32,
-    pub stall_time_threshold_ms: u16,
-    pub comply_release_window_ms: u16,
+pub struct ConfigLoopCurrent {
+    pub i_kp_q88: u16,
+    pub i_ki_q412: u16,
+    pub i_kaw_q412: u16,
+    #[ct_field(le = 32767u16)]
+    pub duty_max_q15: u16,
 }
 
+// Full-scale duty by default; gains stay zero so the loop boots inert.
+pub const DEFAULT_DUTY_MAX_Q15: u16 = 32767;
+
+/// Velocity PI gains + inertia feedforward.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigLoopVelocity {
+    pub v_kp_q88: u16,
+    pub v_ki_q412: u16,
+    pub v_kaw_q412: u16,
+    pub j_ff_q88: u16,
+}
+
+/// Position P gain, anti-hunt hold window, trajectory limits.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigLoopPosition {
+    pub p_kp_q88: u16,
+    /// 0 = hold disabled.
+    pub pos_deadband_counts: u16,
+    pub hold_omega_cps: u16,
+    pub velocity_limit_cps: u16,
+    /// c/s per medium tick.
+    pub accel_limit_q88: u16,
+}
+
+/// Current ceiling, stall policy, overcurrent trip window.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigLimits {
+    pub current_limit_counts: u16,
+    pub stall_response: StallResponse,
+    /// true = positive duty increases position counts.
+    pub drive_polarity: bool,
+    pub stall_omega_max_cps: u16,
+    pub stall_time_ms: u16,
+    pub stall_yield_counts: u16,
+    pub stall_release_counts: u16,
+    pub oc_trip_counts: u16,
+    pub oc_trip_ticks: u8,
+    pub openloop_decay: DecaySelect,
+}
+
+// Permissive-safe SG90-class limits: core-owned policy seeded at boot,
+// host-tunable per rig.
+pub const DEFAULT_CURRENT_LIMIT_COUNTS: u16 = 1200;
+pub const DEFAULT_DRIVE_POLARITY: bool = true;
+pub const DEFAULT_STALL_OMEGA_MAX_CPS: u16 = 500;
+pub const DEFAULT_STALL_TIME_MS: u16 = 500;
+pub const DEFAULT_STALL_YIELD_COUNTS: u16 = 300;
+pub const DEFAULT_STALL_RELEASE_COUNTS: u16 = 150;
+pub const DEFAULT_OC_TRIP_COUNTS: u16 = 2400;
+pub const DEFAULT_OC_TRIP_TICKS: u8 = 8;
+
+/// Thermal derate/cutoff, undervolt floor, winding-R estimator gates.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct ConfigThermal {
-    pub motor_thermal_k_q88: u16,
-    pub motor_thermal_tau_ms: u16,
-    #[ct_field(gt = &addr::thermal::WINDING_RECOVER_CC)]
-    pub winding_cutoff_cc: i16,
-    #[ct_field(lt = &addr::thermal::WINDING_CUTOFF_CC)]
-    pub winding_recover_cc: i16,
-    pub v_undervolt_mv: u16,
-    #[ct_field(skip)]
-    pub _rsvd_tail: u16,
+    pub derate_start_cc: i16,
+    #[ct_field(gt = &addr::thermal::RECOVER_CC)]
+    pub cutoff_cc: i16,
+    #[ct_field(lt = &addr::thermal::CUTOFF_CC)]
+    pub recover_cc: i16,
+    pub v_undervolt_counts: u16,
+    pub rtherm_i_min_counts: u16,
+    pub rtherm_omega_max_cps: u16,
 }
 
+// 80C derate onset / 100C cutoff / 90C recover; undervolt below the 2S
+// brown-out floor in vbus counts.
+pub const DEFAULT_DERATE_START_CC: i16 = 8000;
+pub const DEFAULT_CUTOFF_CC: i16 = 10000;
+pub const DEFAULT_RECOVER_CC: i16 = 9000;
+pub const DEFAULT_V_UNDERVOLT_COUNTS: u16 = 2200;
+pub const DEFAULT_RTHERM_I_MIN_COUNTS: u16 = 300;
+pub const DEFAULT_RTHERM_OMEGA_MAX_CPS: u16 = 400;
+
+/// Fusion observer correction gains; l_bemf 0 = bemf blend off.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
-pub struct ConfigControlPosition {
-    pub pid_kp_q88: u16,
-    pub pid_ki_q88: u16,
-    pub pid_kd_q88: u16,
-    #[ct_field(skip)]
-    pub _rsvd_align: u16,
-    pub pid_i_limit: i32,
-    pub pos_deadband_urad: u32,
-    #[ct_field(le = 50u8)]
-    pub pwm_deadband_pct: u8,
-    pub v_comp_enable: bool,
-    pub max_effort: i16,
-    pub v_nominal_mv: u16,
-    #[ct_field(skip)]
-    pub _rsvd_tail: u16,
+pub struct ConfigFusion {
+    pub l1_q016: u16,
+    pub l2_q88: u16,
+    pub l3_q88: u16,
+    pub l_bemf_q016: u16,
 }
+
+/// Fault thresholds: position-error window, sensor-delta screen.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigFaultCfg {
+    pub pos_error_counts: u16,
+    pub pos_error_time_ms: u16,
+    pub sensor_delta_max: u16,
+    pub sensor_bad_count: u8,
+    #[ct_field(skip)]
+    pub _rsvd_align: u8,
+}
+
+// Wide screens so healthy motion never trips; tighten per application.
+pub const DEFAULT_POS_ERROR_COUNTS: u16 = 400;
+pub const DEFAULT_POS_ERROR_TIME_MS: u16 = 500;
+pub const DEFAULT_SENSOR_DELTA_MAX: u16 = 256;
+pub const DEFAULT_SENSOR_BAD_COUNT: u8 = 4;
 
 /// Config section: always writable (normal field validation applies), volatile
 /// until `MGMT SAVE` persists it -- SAVE is the only torque-gated operation
@@ -125,11 +208,15 @@ pub struct ConfigControlPosition {
 pub struct ConfigRegs {
     pub common: ConfigCommon,
     pub pos_limits: ConfigPosLimits,
-    pub stall: ConfigStall,
+    pub loop_current: ConfigLoopCurrent,
+    pub loop_velocity: ConfigLoopVelocity,
+    pub loop_position: ConfigLoopPosition,
+    pub limits: ConfigLimits,
     pub thermal: ConfigThermal,
-    pub ctrl_pos: ConfigControlPosition,
+    pub fusion: ConfigFusion,
+    pub fault_cfg: ConfigFaultCfg,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 32],
+    pub _rsvd_tail: [u8; 10],
 }
 
 /// Boot-time seed for `ControlTable.config`; stamped pre-IRQ, then host-owned.

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -49,22 +49,22 @@ pub struct ConfigCommon {
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct ConfigPosLimits {
-    #[ct_field(lt = &addr::pos_limits::POS_MAX_PHYS_URAD)]
-    pub pos_min_phys_urad: i32,
-    #[ct_field(gt = &addr::pos_limits::POS_MIN_PHYS_URAD)]
-    pub pos_max_phys_urad: i32,
+    #[ct_field(lt = &addr::pos_limits::POS_MAX_PHYS_COUNTS)]
+    pub pos_min_phys_counts: i32,
+    #[ct_field(gt = &addr::pos_limits::POS_MIN_PHYS_COUNTS)]
+    pub pos_max_phys_counts: i32,
     #[ct_field(
-        ge = &addr::pos_limits::POS_MIN_PHYS_URAD,
-        le = &addr::pos_limits::POS_MAX_PHYS_URAD,
-        lt = &addr::pos_limits::POS_MAX_SOFT_URAD,
+        ge = &addr::pos_limits::POS_MIN_PHYS_COUNTS,
+        le = &addr::pos_limits::POS_MAX_PHYS_COUNTS,
+        lt = &addr::pos_limits::POS_MAX_SOFT_COUNTS,
     )]
-    pub pos_min_soft_urad: i32,
+    pub pos_min_soft_counts: i32,
     #[ct_field(
-        ge = &addr::pos_limits::POS_MIN_PHYS_URAD,
-        le = &addr::pos_limits::POS_MAX_PHYS_URAD,
-        gt = &addr::pos_limits::POS_MIN_SOFT_URAD,
+        ge = &addr::pos_limits::POS_MIN_PHYS_COUNTS,
+        le = &addr::pos_limits::POS_MAX_PHYS_COUNTS,
+        gt = &addr::pos_limits::POS_MIN_SOFT_COUNTS,
     )]
-    pub pos_max_soft_urad: i32,
+    pub pos_max_soft_counts: i32,
 }
 
 #[repr(C)]
@@ -135,8 +135,8 @@ pub struct ConfigRegs {
 /// Boot-time seed for `ControlTable.config`; stamped pre-IRQ, then host-owned.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct ConfigDefaults {
-    pub pos_min_phys_urad: i32,
-    pub pos_max_phys_urad: i32,
+    pub pos_min_phys_counts: i32,
+    pub pos_max_phys_counts: i32,
     pub id: u8,
     pub baud: BaudRate,
     pub response_deadline_us: u16,

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -128,6 +128,8 @@ pub struct ConfigLimits {
     pub stall_time_ms: u16,
     pub stall_yield_counts: u16,
     pub stall_release_counts: u16,
+    /// Collision trip: |tau_d| above this is model-unexplained torque.
+    pub stall_tau_trip_counts: u16,
     pub oc_trip_counts: u16,
     pub oc_trip_ticks: u8,
     pub openloop_decay: DecaySelect,
@@ -141,6 +143,7 @@ pub const DEFAULT_STALL_OMEGA_MAX_CPS: u16 = 500;
 pub const DEFAULT_STALL_TIME_MS: u16 = 500;
 pub const DEFAULT_STALL_YIELD_COUNTS: u16 = 300;
 pub const DEFAULT_STALL_RELEASE_COUNTS: u16 = 150;
+pub const DEFAULT_STALL_TAU_TRIP_COUNTS: u16 = 1200;
 pub const DEFAULT_OC_TRIP_COUNTS: u16 = 2400;
 pub const DEFAULT_OC_TRIP_TICKS: u8 = 8;
 
@@ -216,7 +219,7 @@ pub struct ConfigRegs {
     pub fusion: ConfigFusion,
     pub fault_cfg: ConfigFaultCfg,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 10],
+    pub _rsvd_tail: [u8; 8],
 }
 
 /// Boot-time seed for `ControlTable.config`; stamped pre-IRQ, then host-owned.

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -41,18 +41,6 @@ pub struct ControlLifecycle {
 
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
-pub struct ControlStreaming {
-    pub stream_enable: bool,
-    pub stream_decimation: u8,
-    #[ct_field(ge = 1u16)]
-    pub stream_duration_ms: u16,
-    pub stream_field_mask: u32,
-    #[ct_field(access = ro)]
-    pub stream_dropped: u32,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Block)]
 pub struct ControlSystem {
     pub boot_mode: BootMode,
 }
@@ -62,10 +50,9 @@ pub struct ControlSystem {
 #[ct_section(base = crate::regions::CONTROL_BASE_ADDR, size = crate::regions::CONTROL_REGION_SIZE)]
 pub struct ControlRegs {
     pub lifecycle: ControlLifecycle,
-    pub streaming: ControlStreaming,
     pub system: ControlSystem,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 99],
+    pub _rsvd_tail: [u8; 111],
 }
 
 #[cfg(test)]

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -1,7 +1,7 @@
 use crate::regions::config;
 use control_table::{Block, Enum, Section};
 
-/// Position controller mode. `repr(u8)` so the byte-level commit path round-trips
+/// Control mode. `repr(u8)` so the byte-level commit path round-trips
 /// cleanly; validators MUST gate writes to `Mode::ALLOWED` because constructing a
 /// `Mode` from an unlisted discriminant is UB.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
@@ -9,7 +9,9 @@ use control_table::{Block, Enum, Section};
 pub enum Mode {
     #[default]
     OpenLoop = 0,
-    PositionPid = 1,
+    Current = 1,
+    Velocity = 2,
+    Position = 3,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
@@ -25,16 +27,16 @@ pub enum BootMode {
 pub struct ControlLifecycle {
     pub torque_enable: bool,
     pub mode: Mode,
-    #[ct_field(skip)]
-    pub _rsvd_align: [u8; 2],
+    // abs-le duty_max rule lands with the loop-gain block
+    pub goal_duty: i16,
     #[ct_field(
         ge = &config::addr::pos_limits::POS_MIN_SOFT_COUNTS,
         le = &config::addr::pos_limits::POS_MAX_SOFT_COUNTS,
     )]
     pub goal_position: i32,
     pub goal_velocity: i32,
-    #[ct_field(le = &config::addr::ctrl_pos::MAX_EFFORT, abs)]
-    pub goal_effort: i16,
+    // abs-le current_limit_counts rule lands with the loop-gain block
+    pub goal_current: i16,
     #[ct_field(skip)]
     pub _rsvd_tail: [u8; 2],
 }

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -28,8 +28,8 @@ pub struct ControlLifecycle {
     #[ct_field(skip)]
     pub _rsvd_align: [u8; 2],
     #[ct_field(
-        ge = &config::addr::pos_limits::POS_MIN_SOFT_URAD,
-        le = &config::addr::pos_limits::POS_MAX_SOFT_URAD,
+        ge = &config::addr::pos_limits::POS_MIN_SOFT_COUNTS,
+        le = &config::addr::pos_limits::POS_MAX_SOFT_COUNTS,
     )]
     pub goal_position: i32,
     pub goal_velocity: i32,

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -27,7 +27,7 @@ pub enum BootMode {
 pub struct ControlLifecycle {
     pub torque_enable: bool,
     pub mode: Mode,
-    // abs-le duty_max rule lands with the loop-gain block
+    #[ct_field(le = &config::addr::loop_current::DUTY_MAX_Q15, abs)]
     pub goal_duty: i16,
     #[ct_field(
         ge = &config::addr::pos_limits::POS_MIN_SOFT_COUNTS,
@@ -35,7 +35,7 @@ pub struct ControlLifecycle {
     )]
     pub goal_position: i32,
     pub goal_velocity: i32,
-    // abs-le current_limit_counts rule lands with the loop-gain block
+    #[ct_field(le = &config::addr::limits::CURRENT_LIMIT_COUNTS, abs)]
     pub goal_current: i16,
     #[ct_field(skip)]
     pub _rsvd_tail: [u8; 2],

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -23,8 +23,9 @@ pub mod telemetry;
 
 pub use calib::{BemfCalibBlock, CalibRegs, CalibSense, CalibWinding, PotLutBlock};
 pub use config::{
-    BaudRate, ConfigCommon, ConfigControlPosition, ConfigPosLimits, ConfigRegs, ConfigStall,
-    ConfigThermal, StallResponse,
+    BaudRate, ConfigCommon, ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent,
+    ConfigLoopPosition, ConfigLoopVelocity, ConfigPosLimits, ConfigRegs, ConfigThermal,
+    DecaySelect, StallResponse,
 };
 pub use control::{BootMode, ControlLifecycle, ControlRegs, ControlSystem, Mode};
 pub use profile::{PROFILE_SLOTS, ProfileRegs, ProfileSlots, SPANS_PER_SLOT};
@@ -81,6 +82,27 @@ impl ControlTableCell {
             cfg.common.id = defaults.id;
             cfg.common.baud_rate_idx = defaults.baud.as_idx();
             cfg.common.response_deadline_us = defaults.response_deadline_us;
+            // Core-owned safe defaults; gains stay at their zero seed so
+            // every loop boots inert. Enum defaults are discriminant 0.
+            cfg.loop_current.duty_max_q15 = config::DEFAULT_DUTY_MAX_Q15;
+            cfg.limits.current_limit_counts = config::DEFAULT_CURRENT_LIMIT_COUNTS;
+            cfg.limits.drive_polarity = config::DEFAULT_DRIVE_POLARITY;
+            cfg.limits.stall_omega_max_cps = config::DEFAULT_STALL_OMEGA_MAX_CPS;
+            cfg.limits.stall_time_ms = config::DEFAULT_STALL_TIME_MS;
+            cfg.limits.stall_yield_counts = config::DEFAULT_STALL_YIELD_COUNTS;
+            cfg.limits.stall_release_counts = config::DEFAULT_STALL_RELEASE_COUNTS;
+            cfg.limits.oc_trip_counts = config::DEFAULT_OC_TRIP_COUNTS;
+            cfg.limits.oc_trip_ticks = config::DEFAULT_OC_TRIP_TICKS;
+            cfg.thermal.derate_start_cc = config::DEFAULT_DERATE_START_CC;
+            cfg.thermal.cutoff_cc = config::DEFAULT_CUTOFF_CC;
+            cfg.thermal.recover_cc = config::DEFAULT_RECOVER_CC;
+            cfg.thermal.v_undervolt_counts = config::DEFAULT_V_UNDERVOLT_COUNTS;
+            cfg.thermal.rtherm_i_min_counts = config::DEFAULT_RTHERM_I_MIN_COUNTS;
+            cfg.thermal.rtherm_omega_max_cps = config::DEFAULT_RTHERM_OMEGA_MAX_CPS;
+            cfg.fault_cfg.pos_error_counts = config::DEFAULT_POS_ERROR_COUNTS;
+            cfg.fault_cfg.pos_error_time_ms = config::DEFAULT_POS_ERROR_TIME_MS;
+            cfg.fault_cfg.sensor_delta_max = config::DEFAULT_SENSOR_DELTA_MAX;
+            cfg.fault_cfg.sensor_bad_count = config::DEFAULT_SENSOR_BAD_COUNT;
         });
     }
 
@@ -224,11 +246,11 @@ mod tests {
             by("stall_response").kind,
             FieldKind::Enum(&[
                 EnumVariant {
-                    name: "Disable",
+                    name: "Fault",
                     value: 0
                 },
                 EnumVariant {
-                    name: "Comply",
+                    name: "Yield",
                     value: 1
                 },
             ])

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -92,6 +92,7 @@ impl ControlTableCell {
             cfg.limits.stall_time_ms = config::DEFAULT_STALL_TIME_MS;
             cfg.limits.stall_yield_counts = config::DEFAULT_STALL_YIELD_COUNTS;
             cfg.limits.stall_release_counts = config::DEFAULT_STALL_RELEASE_COUNTS;
+            cfg.limits.stall_tau_trip_counts = config::DEFAULT_STALL_TAU_TRIP_COUNTS;
             cfg.limits.oc_trip_counts = config::DEFAULT_OC_TRIP_COUNTS;
             cfg.limits.oc_trip_ticks = config::DEFAULT_OC_TRIP_TICKS;
             cfg.thermal.derate_start_cc = config::DEFAULT_DERATE_START_CC;

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -30,7 +30,8 @@ pub use config::{
 pub use control::{BootMode, ControlLifecycle, ControlRegs, ControlSystem, Mode};
 pub use profile::{PROFILE_SLOTS, ProfileRegs, ProfileSlots, SPANS_PER_SLOT};
 pub use telemetry::{
-    TelemetryCommon, TelemetryIntermediaries, TelemetryMode, TelemetryRegs, TelemetrySensors,
+    TelemetryCommon, TelemetryEstimates, TelemetryIdent, TelemetryMode, TelemetryRegs,
+    TelemetrySensors,
 };
 
 use crate::regions::config::ConfigDefaults;
@@ -134,7 +135,7 @@ impl ControlTableCell {
     pub fn seed_current_bias(&self, counts: u16) {
         crate::log::debug!("seed current bias: {} counts", counts);
         // SAFETY: install-time, pre-IRQ, sole writer.
-        self.with_mut(|t| t.telemetry.intermediaries.current_bias_counts = counts);
+        self.with_mut(|t| t.telemetry.sensors.current_bias_counts = counts);
     }
 }
 

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -65,19 +65,19 @@ impl ControlTableCell {
     /// Caller must be sole writer (install-time, pre-IRQ).
     pub fn seed_config_defaults(&self, defaults: &ConfigDefaults) {
         crate::log::debug!(
-            "seed CONFIG: phys=[{}, {}] urad  id={}  baud_idx={}",
-            defaults.pos_min_phys_urad,
-            defaults.pos_max_phys_urad,
+            "seed CONFIG: phys=[{}, {}] counts  id={}  baud_idx={}",
+            defaults.pos_min_phys_counts,
+            defaults.pos_max_phys_counts,
             defaults.id,
             defaults.baud.as_idx(),
         );
         // SAFETY: install-time, pre-IRQ, sole writer.
         self.with_mut(|t| {
             let cfg = &mut t.config;
-            cfg.pos_limits.pos_min_phys_urad = defaults.pos_min_phys_urad;
-            cfg.pos_limits.pos_max_phys_urad = defaults.pos_max_phys_urad;
-            cfg.pos_limits.pos_min_soft_urad = defaults.pos_min_phys_urad;
-            cfg.pos_limits.pos_max_soft_urad = defaults.pos_max_phys_urad;
+            cfg.pos_limits.pos_min_phys_counts = defaults.pos_min_phys_counts;
+            cfg.pos_limits.pos_max_phys_counts = defaults.pos_max_phys_counts;
+            cfg.pos_limits.pos_min_soft_counts = defaults.pos_min_phys_counts;
+            cfg.pos_limits.pos_max_soft_counts = defaults.pos_max_phys_counts;
             cfg.common.id = defaults.id;
             cfg.common.baud_rate_idx = defaults.baud.as_idx();
             cfg.common.response_deadline_us = defaults.response_deadline_us;
@@ -162,7 +162,7 @@ mod tests {
             table::RESPONSE_DEADLINE_US
         );
         assert_eq!(
-            config_addr::pos_limits::POS_MIN_PHYS_URAD,
+            config_addr::pos_limits::POS_MIN_PHYS_COUNTS,
             table::CONFIG_COMMON_END
         );
 

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod hooks;
 pub mod profile;
 pub mod telemetry;
 
-pub use calib::{BemfCalibBlock, CalibRegs, CalibSense, CalibWinding, PotLutBlock};
+pub use calib::{CalibMotor, CalibRegs, CalibSense, CalibWinding, PotLutBlock};
 pub use config::{
     BaudRate, ConfigCommon, ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent,
     ConfigLoopPosition, ConfigLoopVelocity, ConfigPosLimits, ConfigRegs, ConfigThermal,
@@ -262,9 +262,9 @@ mod tests {
         assert!(goal.writable);
         assert_eq!((goal.min, goal.max), (None, None));
 
-        let lut = by("lut");
+        let lut = by("lut_corr");
         assert_eq!(lut.kind, FieldKind::Bytes);
-        assert_eq!(lut.width, 220);
+        assert_eq!(lut.width, 110);
     }
 
     /// Pins the profile region to its protocol sec 5.4 address pin and its

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -26,7 +26,7 @@ pub use config::{
     BaudRate, ConfigCommon, ConfigControlPosition, ConfigPosLimits, ConfigRegs, ConfigStall,
     ConfigThermal, StallResponse,
 };
-pub use control::{BootMode, ControlLifecycle, ControlRegs, ControlStreaming, ControlSystem, Mode};
+pub use control::{BootMode, ControlLifecycle, ControlRegs, ControlSystem, Mode};
 pub use profile::{PROFILE_SLOTS, ProfileRegs, ProfileSlots, SPANS_PER_SLOT};
 pub use telemetry::{
     TelemetryCommon, TelemetryIntermediaries, TelemetryMode, TelemetryRegs, TelemetrySensors,

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -1,26 +1,5 @@
 use control_table::{Block, Section};
 
-#[repr(C)]
-#[derive(Copy, Clone, Block)]
-pub struct TelemetryIntermediaries {
-    #[ct_field(access = ro)]
-    pub current_bias_counts: u16,
-    #[ct_field(access = ro)]
-    pub t_winding_dc: i16,
-    #[ct_field(access = ro)]
-    pub pwm_duty_actual: i16,
-    #[ct_field(skip)]
-    pub _rsvd_align: u16,
-    #[ct_field(access = ro)]
-    pub pid_error_last: i32,
-    #[ct_field(access = ro)]
-    pub pid_output_last: i32,
-    #[ct_field(access = ro)]
-    pub internal_goal: i32,
-    #[ct_field(access = ro)]
-    pub sample_tick: u32,
-}
-
 /// protocol sec 5.4 TELEMETRY-COMMON block, at the region front. Counters:
 /// host can Write zero to clear (bench instrumentation); the chip publishes
 /// deltas via raw pointer, bypassing the regmap, so a concurrent host clear +
@@ -64,6 +43,44 @@ pub struct TelemetryMode {
     pub _rsvd_align: u16,
 }
 
+/// Estimator outputs, published at the medium boundary (`sample_tick` at
+/// every fast tick). Counts-domain throughout; conversion is the host's job.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryEstimates {
+    /// Fused position, cQ16 (pot counts x 2^16).
+    #[ct_field(access = ro)]
+    pub theta_hat_q16: i32,
+    /// Fused velocity, raw csQ16 ((counts/s) x 2^16) -- published unshifted.
+    #[ct_field(access = ro)]
+    pub omega_hat_cps: i32,
+    /// Disturbance-torque estimate, current counts.
+    #[ct_field(access = ro)]
+    pub tau_d_counts: i16,
+    /// Effective current ceiling after limit folds.
+    #[ct_field(access = ro)]
+    pub i_lim_counts: u16,
+    /// Winding temperature, centi-C.
+    #[ct_field(access = ro)]
+    pub t_winding_cc: i16,
+    #[ct_field(access = ro)]
+    pub vbus_counts: u16,
+    /// Post-clamp post-gate duty actually written to the bridge.
+    #[ct_field(access = ro)]
+    pub duty_applied_q15: i16,
+    /// Telemetry-only bemf observer, whole c/s.
+    #[ct_field(access = ro)]
+    pub omega_bemf_cps: i16,
+    /// Winding-R LMS estimate, vcounts/ccount Q4.12.
+    #[ct_field(access = ro)]
+    pub r_hat_q12: u16,
+    /// Window-selected, bias-subtracted, signed current sample.
+    #[ct_field(access = ro)]
+    pub i_hat_counts: i16,
+    #[ct_field(access = ro)]
+    pub sample_tick: u32,
+}
+
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct TelemetrySensors {
@@ -83,6 +100,31 @@ pub struct TelemetrySensors {
     pub enc_a: u16,
     #[ct_field(access = ro)]
     pub enc_b: u16,
+    #[ct_field(access = ro)]
+    pub current_trough: u16,
+    /// Boot-measured zero-current sense-chain output, raw ADC counts.
+    #[ct_field(access = ro)]
+    pub current_bias_counts: u16,
+}
+
+/// Identification aggregates on their own fast-tick /16 window (mean =
+/// sum>>4); `agg_seq` increments per window so the host pairs a consistent
+/// set.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryIdent {
+    #[ct_field(access = ro)]
+    pub i_mean_counts: u16,
+    #[ct_field(access = ro)]
+    pub i_min_counts: u16,
+    #[ct_field(access = ro)]
+    pub i_max_counts: u16,
+    #[ct_field(access = ro)]
+    pub vdiff_mean: i16,
+    #[ct_field(access = ro)]
+    pub duty_mean_q15: i16,
+    #[ct_field(access = ro)]
+    pub agg_seq: u16,
 }
 
 #[repr(C)]
@@ -91,10 +133,9 @@ pub struct TelemetrySensors {
 pub struct TelemetryRegs {
     pub common: TelemetryCommon,
     pub mode: TelemetryMode,
-    #[ct_section(skip)]
-    pub _rsvd_converted: [u8; 16],
-    pub intermediaries: TelemetryIntermediaries,
+    pub estimates: TelemetryEstimates,
     pub sensors: TelemetrySensors,
+    pub ident: TelemetryIdent,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 36],
+    pub _rsvd_tail: [u8; 32],
 }

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -108,19 +108,23 @@ pub struct TelemetrySensors {
 }
 
 /// Identification aggregates on their own fast-tick /16 window (mean =
-/// sum>>4); `agg_seq` increments per window so the host pairs a consistent
-/// set.
+/// sum>>4, arithmetic); `agg_seq` increments per window so the host pairs a
+/// consistent set. Current fields are SIGNED bias-subtracted counts - the
+/// fitter's domain. Ticks with an invalid window contribute the last valid
+/// current/vdiff sample, not zero (kernel/ident.rs doc).
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct TelemetryIdent {
     #[ct_field(access = ro)]
-    pub i_mean_counts: u16,
+    pub i_mean_counts: i16,
     #[ct_field(access = ro)]
-    pub i_min_counts: u16,
+    pub i_min_counts: i16,
     #[ct_field(access = ro)]
-    pub i_max_counts: u16,
+    pub i_max_counts: i16,
+    /// Drive-window `va - vb` differential mean.
     #[ct_field(access = ro)]
     pub vdiff_mean: i16,
+    /// Mean of the per-tick commanded duty (always defined, 0 while off).
     #[ct_field(access = ro)]
     pub duty_mean_q15: i16,
     #[ct_field(access = ro)]

--- a/firmware/lib/integration/tests/chains.rs
+++ b/firmware/lib/integration/tests/chains.rs
@@ -8,7 +8,6 @@ use osc_integration::sim::{Source, WireFrame, assert_valid, instruction, status}
 use osc_protocol::wire::{Inst, Opcode, ResultCode};
 use osc_servo_core::regions::config::addr::common::{FIRMWARE_VERSION, MODEL_NUMBER};
 use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
-use osc_servo_core::regions::control::addr::streaming::{STREAM_DECIMATION, STREAM_FIELD_MASK};
 use osc_servo_core::regions::profile::span_word;
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -395,19 +394,21 @@ fn gwrite_hold_commit_is_atomic_fleet_update(baud_idx: u8) {
 }
 
 #[apply(matrix)]
-fn gwrite_per_target_applies_distinct_fields(baud_idx: u8) {
+fn gwrite_per_target_applies_distinct_entries(baud_idx: u8) {
     let mut sim = sim(baud_idx);
     for id in [1u8, 2, 3] {
         sim.add_servo(id);
     }
     let gv: i32 = 0x1234_5678;
-    let mask: u32 = 0xDEAD_BEEF;
-    let deci: u8 = 7;
+    let gv2: i32 = 0x5EED_F00D;
+    let lo: u8 = 7;
 
+    // Entry strides vary (4, 4, 1): the 1-byte entry pins per-entry length
+    // parsing, landing in goal_velocity's low byte over a zeroed field.
     let payload = gwrite_per_target(&[
         (1, GOAL_VELOCITY, &gv.to_le_bytes()),
-        (2, STREAM_FIELD_MASK, &mask.to_le_bytes()),
-        (3, STREAM_DECIMATION, &[deci]),
+        (2, GOAL_VELOCITY, &gv2.to_le_bytes()),
+        (3, GOAL_VELOCITY, &[lo]),
     ]);
     sim.host_send(&instruction(
         BCAST,
@@ -423,12 +424,12 @@ fn gwrite_per_target_applies_distinct_fields(baud_idx: u8) {
         gv
     );
     assert_eq!(
-        sim.servo_table(1, |t| t.control.streaming.stream_field_mask),
-        mask
+        sim.servo_table(1, |t| t.control.lifecycle.goal_velocity),
+        gv2
     );
     assert_eq!(
-        sim.servo_table(2, |t| t.control.streaming.stream_decimation),
-        deci
+        sim.servo_table(2, |t| t.control.lifecycle.goal_velocity),
+        lo as i32
     );
 }
 
@@ -442,7 +443,7 @@ fn back_to_back_instructions_all_land(baud_idx: u8) {
     let mut sim = sim(baud_idx);
     sim.add_servo(1);
     let gv: i32 = 0x0AA0_1BB1;
-    let mask: u32 = 0x00C0_FFEE;
+    let gv2: i32 = 0x00C0_FFEE;
 
     let addr_gv = GOAL_VELOCITY.to_le_bytes();
     let mut w1 = vec![addr_gv[0], addr_gv[1]];
@@ -454,23 +455,23 @@ fn back_to_back_instructions_all_land(baud_idx: u8) {
     let (res1, data1) = decoded(r1[0]);
     assert_eq!(res1, ResultCode::Ok);
     assert!(data1.is_empty(), "write ack is empty");
+    assert_eq!(
+        sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
+        gv,
+        "first write applied before the second lands"
+    );
 
-    let addr_mask = STREAM_FIELD_MASK.to_le_bytes();
-    let mut w2 = vec![addr_mask[0], addr_mask[1]];
-    w2.extend_from_slice(&mask.to_le_bytes());
+    let mut w2 = vec![addr_gv[0], addr_gv[1]];
+    w2.extend_from_slice(&gv2.to_le_bytes());
     sim.host_send(&instruction(1, Opcode::Write, 0, &w2));
     let f2 = sim.run();
     let r2 = replies(&f2);
     assert_eq!(r2.len(), 1, "second write acked: {f2:#?}");
     assert_eq!(decoded(r2[0]).0, ResultCode::Ok);
 
-    // Both applied, in order.
     assert_eq!(
         sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
-        gv
-    );
-    assert_eq!(
-        sim.servo_table(0, |t| t.control.streaming.stream_field_mask),
-        mask
+        gv2,
+        "second write applied"
     );
 }

--- a/firmware/lib/integration/tests/hot_loop.rs
+++ b/firmware/lib/integration/tests/hot_loop.rs
@@ -12,7 +12,8 @@
 use osc_integration::sim::{Source, WireFrame, assert_valid, instruction, status};
 use osc_protocol::wire::{Inst, Opcode, ResultCode};
 use osc_servo_core::BaudRate;
-use osc_servo_core::regions::config::addr::stall::STALL_TIME_THRESHOLD_MS;
+use osc_servo_core::regions::config::DEFAULT_STALL_TIME_MS;
+use osc_servo_core::regions::config::addr::limits::STALL_TIME_MS;
 use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -106,11 +107,11 @@ fn hot_loop_cycles_survive_zero_gap(baud_idx: u8) {
             &gwrite_uniform(GOAL_VELOCITY, 4, &entries),
         ));
         // Second staged register: a 1-byte per-target write into the u16's
-        // low byte (high byte stays at its zero seed), so the per-target
+        // low byte (high byte keeps its boot seed), so the per-target
         // stride differs from the uniform frame's 4-byte stride.
         let aux_entries: Vec<(u8, u16, &[u8])> = IDS
             .iter()
-            .map(|&id| (id, STALL_TIME_THRESHOLD_MS, std::slice::from_ref(&aux)))
+            .map(|&id| (id, STALL_TIME_MS, std::slice::from_ref(&aux)))
             .collect();
         sim.host_send(&instruction(
             BCAST,
@@ -139,9 +140,9 @@ fn hot_loop_cycles_survive_zero_gap(baud_idx: u8) {
                 "cycle {cycle}: servo {i} goal_velocity committed"
             );
             assert_eq!(
-                sim.servo_table(i, |t| t.config.stall.stall_time_threshold_ms),
-                aux as u16,
-                "cycle {cycle}: servo {i} stall_time_threshold_ms committed"
+                sim.servo_table(i, |t| t.config.limits.stall_time_ms),
+                (DEFAULT_STALL_TIME_MS & 0xFF00) | aux as u16,
+                "cycle {cycle}: servo {i} stall_time_ms low byte committed"
             );
         }
 

--- a/firmware/lib/integration/tests/hot_loop.rs
+++ b/firmware/lib/integration/tests/hot_loop.rs
@@ -12,8 +12,8 @@
 use osc_integration::sim::{Source, WireFrame, assert_valid, instruction, status};
 use osc_protocol::wire::{Inst, Opcode, ResultCode};
 use osc_servo_core::BaudRate;
+use osc_servo_core::regions::config::addr::stall::STALL_TIME_THRESHOLD_MS;
 use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
-use osc_servo_core::regions::control::addr::streaming::STREAM_DECIMATION;
 use rstest::rstest;
 use rstest_reuse::apply;
 
@@ -90,7 +90,7 @@ fn hot_loop_cycles_survive_zero_gap(baud_idx: u8) {
             .iter()
             .map(|&id| (cycle as i32) * 100 + id as i32)
             .collect();
-        let deci = (cycle % 128) as u8 + 1;
+        let aux = (cycle % 128) as u8 + 1;
 
         // GWRITE(HOLD) x 2, COMMIT, GREAD -- one burst, zero gap throughout.
         let bytes: Vec<[u8; 4]> = gv.iter().map(|v| v.to_le_bytes()).collect();
@@ -105,15 +105,18 @@ fn hot_loop_cycles_survive_zero_gap(baud_idx: u8) {
             Inst::FLAG_HOLD,
             &gwrite_uniform(GOAL_VELOCITY, 4, &entries),
         ));
-        let deci_entries: Vec<(u8, u16, &[u8])> = IDS
+        // Second staged register: a 1-byte per-target write into the u16's
+        // low byte (high byte stays at its zero seed), so the per-target
+        // stride differs from the uniform frame's 4-byte stride.
+        let aux_entries: Vec<(u8, u16, &[u8])> = IDS
             .iter()
-            .map(|&id| (id, STREAM_DECIMATION, std::slice::from_ref(&deci)))
+            .map(|&id| (id, STALL_TIME_THRESHOLD_MS, std::slice::from_ref(&aux)))
             .collect();
         sim.host_send(&instruction(
             BCAST,
             Opcode::Gwrite,
             Inst::FLAG_HOLD | Inst::FLAG_PER_TARGET,
-            &gwrite_per_target(&deci_entries),
+            &gwrite_per_target(&aux_entries),
         ));
         sim.host_send(&instruction(BCAST, Opcode::Commit, 0, &[]));
         sim.host_send(&instruction(
@@ -136,9 +139,9 @@ fn hot_loop_cycles_survive_zero_gap(baud_idx: u8) {
                 "cycle {cycle}: servo {i} goal_velocity committed"
             );
             assert_eq!(
-                sim.servo_table(i, |t| t.control.streaming.stream_decimation),
-                deci,
-                "cycle {cycle}: servo {i} stream_decimation committed"
+                sim.servo_table(i, |t| t.config.stall.stall_time_threshold_ms),
+                aux as u16,
+                "cycle {cycle}: servo {i} stall_time_threshold_ms committed"
             );
         }
 

--- a/firmware/lib/integration/tests/protocol.rs
+++ b/firmware/lib/integration/tests/protocol.rs
@@ -210,16 +210,17 @@ fn hold_then_commit_applies_atomically(baud_idx: u8) {
 
 #[apply(matrix)]
 fn large_write_stages_and_applies(baud_idx: u8) {
-    // LEN is the only size limit (sec 5.1): a >128 B write stages like any other
-    // (the buffer fits the largest legal write) and commits at its verdict.
-    // Target the calib pot-LUT span (writable, no field rules).
+    // LEN is the only size limit (sec 5.1): the largest legal write -- the
+    // full 114 B pot-LUT block, the map's widest rule-free writable span --
+    // stages like any other and commits at its verdict.
     let mut sim = sim(baud_idx);
     let s = sim.add_servo(ID5);
 
-    let mut data = vec![0u8; 130];
+    let mut data = vec![0u8; 114];
     data[0..2].copy_from_slice(&0x1234u16.to_le_bytes()); // raw_min
     data[2..4].copy_from_slice(&0x5678u16.to_le_bytes()); // raw_max
     data[4] = 0xAB; // first LUT byte
+    data[113] = 0x7C; // last LUT byte
 
     let a = CALIB_BASE_ADDR.to_le_bytes();
     let mut payload = vec![a[0], a[1]];
@@ -230,16 +231,18 @@ fn large_write_stages_and_applies(baud_idx: u8) {
     let (inst, _) = status(sole_reply(&frames));
     assert_eq!(inst.result(), Some(ResultCode::Ok));
     assert_eq!(sim.servo_diag(s).crc_fail_count, 0);
-    let (raw_min, raw_max, lut0) = sim.servo_table(s, |t| {
+    let (raw_min, raw_max, lut0, lut54) = sim.servo_table(s, |t| {
         (
             t.calib.pot_lut.raw_min,
             t.calib.pot_lut.raw_max,
-            t.calib.pot_lut.lut[0],
+            t.calib.pot_lut.lut_corr[0],
+            t.calib.pot_lut.lut_corr[54],
         )
     });
     assert_eq!(raw_min, 0x1234);
     assert_eq!(raw_max, 0x5678);
-    assert_eq!((lut0 as u32) & 0xFF, 0xAB, "the >128 B payload landed");
+    assert_eq!((lut0 as u16) & 0xFF, 0xAB);
+    assert_eq!((lut54 as u16) >> 8, 0x7C, "the full 114 B payload landed");
 }
 
 #[apply(matrix)]

--- a/firmware/lib/integration/tests/timing.rs
+++ b/firmware/lib/integration/tests/timing.rs
@@ -9,7 +9,7 @@
 use osc_integration::sim::{Sim, Source, WireFrame, assert_valid, instruction, status};
 use osc_protocol::wire::{Opcode, ResultCode};
 use osc_servo_core::BaudRate;
-use osc_servo_core::regions::calib::addr::pot_lut::LUT;
+use osc_servo_core::regions::calib::addr::pot_lut::LUT_CORR;
 use osc_servo_core::regions::config::addr::common::MODEL_NUMBER;
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -144,10 +144,10 @@ fn skewed_servo_survives_long_frame(baud_idx: u8) {
     let mut sim = Sim::new(rate);
     sim.add_servo_with(1, 10_000, 60);
 
-    // 50 i32 words = 200 B into the rule-free calibration LUT (torque off by
+    // 55 i16 words = 110 B into the rule-free calibration LUT (torque off by
     // default -> the persistent section is writable).
-    let words: Vec<i32> = (0..50).map(|i| 0x0100_0000 + i).collect();
-    let addr = LUT.to_le_bytes();
+    let words: Vec<i16> = (0..55).map(|i| 0x0100 + i).collect();
+    let addr = LUT_CORR.to_le_bytes();
     let mut payload = vec![addr[0], addr[1]];
     for w in &words {
         payload.extend_from_slice(&w.to_le_bytes());
@@ -160,8 +160,8 @@ fn skewed_servo_survives_long_frame(baud_idx: u8) {
     assert_eq!(inst.result(), Some(ResultCode::Ok), "long write applies");
     assert!(data.is_empty(), "write ack is empty");
 
-    let stored = sim.servo_table(0, |t| t.calib.pot_lut.lut);
-    assert_eq!(&stored[..50], &words[..], "all 200 B landed under drift");
+    let stored = sim.servo_table(0, |t| t.calib.pot_lut.lut_corr);
+    assert_eq!(&stored[..], &words[..], "all 110 B landed under drift");
     assert_eq!(sim.servo_diag(0).framing_drop_count, 0);
 }
 

--- a/firmware/servo-ch32/src/cfg/board_wiring.rs
+++ b/firmware/servo-ch32/src/cfg/board_wiring.rs
@@ -80,6 +80,10 @@ pub struct Calibration {
     pub vmotor_divider: Divider,
     /// DMM-measured VDD at the chip pin; the v006 ADC reference is VDD itself.
     pub vdd_mv: u16,
+    /// Shortest drive window (TIM1 ticks) with a valid shunt sample.
+    pub i_window_min_ticks: u16,
+    /// Shortest drive window (TIM1 ticks) with a valid vmotor sample.
+    pub v_window_min_ticks: u16,
 }
 
 /// Board-tunable wiring; consumed during `Ch32ControlIo::new` and not retained.

--- a/firmware/servo-ch32/src/cfg/mod.rs
+++ b/firmware/servo-ch32/src/cfg/mod.rs
@@ -6,7 +6,9 @@ pub use board_wiring::BusWiring;
 pub use board_wiring::{AdcPins, BoardWiring, Calibration, CurrentSenseConfig, Divider, DrvEn};
 pub use chip::{AnalogChannel, DigitalPin};
 
-use osc_servo_core::ConfigDefaults;
+use osc_servo_core::estimator::bemf::RECIP_ARR_SHIFT;
+use osc_servo_core::kernel::DECIM_MED;
+use osc_servo_core::{ConfigDefaults, KernelTiming};
 
 use crate::providers::usart_baud;
 
@@ -28,15 +30,26 @@ pub struct Precomputed {
     pub pwm_psc: u16,
     pub pwm_arr: u16,
     pub usart_brr: u32,
+    pub kernel_timing: KernelTiming,
 }
 
 impl Precomputed {
     pub const fn compute(cfg: &BoardConfig) -> Self {
         let (pwm_psc, pwm_arr) = crate::hal::timer::pwm_dividers_from_hz(chip::MOTOR_PWM_FREQ_HZ);
+        // Const-eval quotients per the KernelTiming field docs; the divides
+        // fold at compile time so no soft-div symbol ever links.
+        let med_hz = chip::MOTOR_PWM_FREQ_HZ / DECIM_MED as u32;
         Self {
             pwm_psc,
             pwm_arr,
             usart_brr: usart_baud::brr_for(cfg.defaults.baud),
+            kernel_timing: KernelTiming {
+                pwm_arr,
+                recip_arr_q24: (1u32 << RECIP_ARR_SHIFT) / pwm_arr as u32,
+                tick_hz: chip::MOTOR_PWM_FREQ_HZ as u16,
+                dt_med_q32: ((1u64 << 32) / med_hz as u64) as u32,
+                med_ticks_per_ms_q16: ((med_hz as u64 * 65536) / 1000) as u32,
+            },
         }
     }
 }

--- a/firmware/servo-ch32/src/runtime/init.rs
+++ b/firmware/servo-ch32/src/runtime/init.rs
@@ -96,6 +96,10 @@ pub fn bringup(
     super::diag::dump_init_regs();
 }
 
+// tick_hz stamps from the constant that programs TIM1, so the table can
+// never disagree with silicon; the cast must stay lossless.
+const _: () = assert!(chip::MOTOR_PWM_FREQ_HZ <= u16::MAX as u32);
+
 fn calib_sense(wiring: &BoardWiring, cal: &Calibration) -> CalibSense {
     CalibSense {
         shunt_r_mohm: cal.shunt_r_mohm,
@@ -103,6 +107,9 @@ fn calib_sense(wiring: &BoardWiring, cal: &Calibration) -> CalibSense {
         vmotor_div_top: cal.vmotor_divider.top_ohm.min(u16::MAX as u32) as u16,
         vmotor_div_bot: cal.vmotor_divider.bot_ohm.min(u16::MAX as u32) as u16,
         vdd_mv: cal.vdd_mv,
+        tick_hz: chip::MOTOR_PWM_FREQ_HZ as u16,
+        i_window_min_ticks: cal.i_window_min_ticks,
+        v_window_min_ticks: cal.v_window_min_ticks,
     }
 }
 

--- a/firmware/servo-ch32/src/runtime/isr.rs
+++ b/firmware/servo-ch32/src/runtime/isr.rs
@@ -69,10 +69,7 @@ pub fn on_adc_dma_tc() {
 
     unsafe {
         // Volatile pair: load-bearing against optimizer hoisting in the pump.
-        let tick = &raw mut (*SHARED.table.region_ptr())
-            .telemetry
-            .intermediaries
-            .sample_tick;
+        let tick = &raw mut (*SHARED.table.region_ptr()).telemetry.estimates.sample_tick;
         tick.write_volatile(tick.read_volatile().wrapping_add(1));
 
         // SAFETY: PFIC unmasks DMA1_CHANNEL1 only after install_kernel writes KERNEL.

--- a/firmware/servo-ch32/src/runtime/run.rs
+++ b/firmware/servo-ch32/src/runtime/run.rs
@@ -38,7 +38,7 @@ macro_rules! run {
 #[doc(hidden)]
 pub fn __run(cfg: BoardConfig, pre: Precomputed) -> ! {
     let io = Ch32ControlIo::new(cfg, pre);
-    crate::runtime::statics::install(io);
+    crate::runtime::statics::install(io, pre.kernel_timing);
     crate::runtime::isr::install_irqs();
     // Last-published transport counters: the table gets DELTAS, so a host
     // zero-write (the rw clear contract, `TelemetryCommon`) sticks instead

--- a/firmware/servo-ch32/src/runtime/statics.rs
+++ b/firmware/servo-ch32/src/runtime/statics.rs
@@ -30,10 +30,7 @@ pub fn install(io: Ch32ControlIo) {
 /// because LLVM can't see the DMA TC ISR writing this asynchronously.
 pub fn read_sample_tick() -> u32 {
     unsafe {
-        let p = &raw const (*SHARED.table.region_ptr())
-            .telemetry
-            .intermediaries
-            .sample_tick;
+        let p = &raw const (*SHARED.table.region_ptr()).telemetry.estimates.sample_tick;
         p.read_volatile()
     }
 }

--- a/firmware/servo-ch32/src/runtime/statics.rs
+++ b/firmware/servo-ch32/src/runtime/statics.rs
@@ -1,6 +1,6 @@
 use core::cell::SyncUnsafeCell;
 use core::mem::MaybeUninit;
-use osc_servo_core::{Kernel, RegionStorageRaw, Session, Shared};
+use osc_servo_core::{Kernel, KernelTiming, RegionStorageRaw, Session, Shared};
 
 use crate::control::Ch32ControlIo;
 
@@ -18,9 +18,9 @@ pub(crate) static KERNEL: SyncUnsafeCell<MaybeUninit<Kernel<Ch32ControlIo>>> =
 pub(crate) static SESSION: SyncUnsafeCell<MaybeUninit<Session>> =
     SyncUnsafeCell::new(MaybeUninit::uninit());
 
-pub fn install(io: Ch32ControlIo) {
+pub fn install(io: Ch32ControlIo, timing: KernelTiming) {
     unsafe {
-        (*KERNEL.get()).write(Kernel::new(io));
+        (*KERNEL.get()).write(Kernel::new(io, timing));
         (*SESSION.get()).write(Session::new());
     }
     crate::log::info!("kernel + session installed");

--- a/tools/bench/tests/hardware/hold_commit.rs
+++ b/tools/bench/tests/hardware/hold_commit.rs
@@ -1,6 +1,6 @@
 use bench::osc::{build_instruction, build_read, build_write};
 use osc_protocol::wire::{Inst, Opcode};
-use osc_servo_core::regions::control::addr::streaming::STREAM_FIELD_MASK;
+use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
 use serial_test::serial;
 
 use crate::support::bench;
@@ -16,11 +16,11 @@ fn hold_then_commit_applies() {
     let mut b = bench();
     let id = b.id();
 
-    let orig = b.status_ok(&build_read(id, STREAM_FIELD_MASK, 4)).payload;
+    let orig = b.status_ok(&build_read(id, GOAL_VELOCITY, 4)).payload;
     let staged: u32 = 0x0BAD_F00D;
 
     // WRITE + HOLD: acks OK, but the live field keeps its old value.
-    let mut payload = STREAM_FIELD_MASK.to_le_bytes().to_vec();
+    let mut payload = GOAL_VELOCITY.to_le_bytes().to_vec();
     payload.extend_from_slice(&staged.to_le_bytes());
     b.status_ok(&build_instruction(
         id,
@@ -29,17 +29,17 @@ fn hold_then_commit_applies() {
         &payload,
     ));
 
-    let held = b.status_ok(&build_read(id, STREAM_FIELD_MASK, 4)).payload;
+    let held = b.status_ok(&build_read(id, GOAL_VELOCITY, 4)).payload;
     assert_eq!(held, orig, "HOLD does not touch the live field");
 
     // Broadcast COMMIT is silent and applies the staged write.
     b.expect_no_reply(&build_instruction(BROADCAST, Opcode::Commit, 0, &[]));
-    let after = b.status_ok(&build_read(id, STREAM_FIELD_MASK, 4)).payload;
+    let after = b.status_ok(&build_read(id, GOAL_VELOCITY, 4)).payload;
     assert_eq!(
         after,
         staged.to_le_bytes(),
         "COMMIT applied the staged write"
     );
 
-    b.status_ok(&build_write(id, STREAM_FIELD_MASK, &orig));
+    b.status_ok(&build_write(id, GOAL_VELOCITY, &orig));
 }

--- a/tools/bench/tests/hardware/silence.rs
+++ b/tools/bench/tests/hardware/silence.rs
@@ -1,6 +1,6 @@
 use bench::osc::{build_instruction, build_read, build_write};
 use osc_protocol::wire::{Inst, Opcode};
-use osc_servo_core::regions::control::addr::streaming::STREAM_FIELD_MASK;
+use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
 use serial_test::serial;
 
 use crate::support::bench;
@@ -14,9 +14,9 @@ const BROADCAST: u8 = 0xFE;
 fn noreply_write_is_silent() {
     let mut b = bench();
     let id = b.id();
-    let orig = b.status_ok(&build_read(id, STREAM_FIELD_MASK, 4)).payload;
+    let orig = b.status_ok(&build_read(id, GOAL_VELOCITY, 4)).payload;
 
-    let mut payload = STREAM_FIELD_MASK.to_le_bytes().to_vec();
+    let mut payload = GOAL_VELOCITY.to_le_bytes().to_vec();
     payload.extend_from_slice(&orig);
     b.expect_no_reply(&build_instruction(
         id,
@@ -32,6 +32,6 @@ fn noreply_write_is_silent() {
 fn broadcast_write_is_silent() {
     let mut b = bench();
     let id = b.id();
-    let orig = b.status_ok(&build_read(id, STREAM_FIELD_MASK, 4)).payload;
-    b.expect_no_reply(&build_write(BROADCAST, STREAM_FIELD_MASK, &orig));
+    let orig = b.status_ok(&build_read(id, GOAL_VELOCITY, 4)).payload;
+    b.expect_no_reply(&build_write(BROADCAST, GOAL_VELOCITY, &orig));
 }

--- a/tools/bench/tests/hardware/write.rs
+++ b/tools/bench/tests/hardware/write.rs
@@ -1,27 +1,27 @@
 use bench::osc::{build_read, build_write};
-use osc_servo_core::regions::control::addr::streaming::STREAM_FIELD_MASK;
+use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
 use serial_test::serial;
 
 use crate::support::bench;
 
-/// WRITE -> empty OK ack, and the value lands. stream_field_mask is a plain u32
-/// bitmask (no range rule, no motion side-effect), so an arbitrary value is a
+/// WRITE -> empty OK ack, and the value lands. goal_velocity is a plain i32
+/// with no range rule and no kernel consumer yet, so an arbitrary value is a
 /// clean round-trip probe. The original is restored (state discipline).
 #[serial]
 #[test]
-fn write_field_mask_round_trips() {
+fn write_goal_velocity_round_trips() {
     let mut b = bench();
     let id = b.id();
 
-    let orig = b.status_ok(&build_read(id, STREAM_FIELD_MASK, 4)).payload;
-    assert_eq!(orig.len(), 4, "stream_field_mask is 4 bytes");
+    let orig = b.status_ok(&build_read(id, GOAL_VELOCITY, 4)).payload;
+    assert_eq!(orig.len(), 4, "goal_velocity is 4 bytes");
 
     let probe: u32 = 0x1234_ABCD;
-    let ack = b.status_ok(&build_write(id, STREAM_FIELD_MASK, &probe.to_le_bytes()));
+    let ack = b.status_ok(&build_write(id, GOAL_VELOCITY, &probe.to_le_bytes()));
     assert!(ack.payload.is_empty(), "a write ack is empty");
 
-    let after = b.status_ok(&build_read(id, STREAM_FIELD_MASK, 4)).payload;
+    let after = b.status_ok(&build_read(id, GOAL_VELOCITY, 4)).payload;
     assert_eq!(after, probe.to_le_bytes(), "the write applied");
 
-    b.status_ok(&build_write(id, STREAM_FIELD_MASK, &orig));
+    b.status_ok(&build_write(id, GOAL_VELOCITY, &orig));
 }

--- a/tools/osc/src/descriptor.rs
+++ b/tools/osc/src/descriptor.rs
@@ -421,10 +421,10 @@ mod tests {
     fn enum_by_name_and_number() {
         let d = builtin();
         let f = field(&d, "mode");
-        assert_eq!(encode(&f, "PositionPid").unwrap(), vec![1]);
-        assert_eq!(encode(&f, "positionpid").unwrap(), vec![1]); // case-insensitive
-        assert_eq!(encode(&f, "1").unwrap(), vec![1]);
-        assert_eq!(decode(&f, &[1]).unwrap(), "PositionPid (1)");
+        assert_eq!(encode(&f, "Position").unwrap(), vec![3]);
+        assert_eq!(encode(&f, "position").unwrap(), vec![3]); // case-insensitive
+        assert_eq!(encode(&f, "3").unwrap(), vec![3]);
+        assert_eq!(decode(&f, &[3]).unwrap(), "Position (3)");
         // off-registry discriminant falls back to the raw number
         assert_eq!(decode(&f, &[7]).unwrap(), "7");
     }
@@ -445,7 +445,7 @@ mod tests {
         let d = builtin();
         let f = field(&d, "response_deadline_us"); // u16
         assert!(encode(&f, "70000").is_err());
-        let g = field(&d, "goal_effort"); // i16
+        let g = field(&d, "goal_current"); // i16
         assert!(encode(&g, "40000").is_err());
     }
 

--- a/tools/osc/src/main.rs
+++ b/tools/osc/src/main.rs
@@ -194,6 +194,7 @@ enum Cmd {
         field: String,
         /// Value: decimal/0x-hex int, on|off for bool, variant name or number
         /// for enum, hex bytes for a bytes field.
+        #[arg(allow_hyphen_values = true)]
         value: String,
         /// Stage under HOLD; applied by the next COMMIT.
         #[arg(long)]


### PR DESCRIPTION
Implements docs/control-theory.md: the current / velocity / position cascade, trajectory generator, protective limits, and the estimator layer (current sensing, back-EMF velocity, winding temperature, position/velocity/load fusion, supply voltage).

Also reworks the control table for it: raw-count units, the four control modes, gain/limit/calibration registers, estimator telemetry, and fault reporting.