### PR TITLE
osc: self-describing servo calibration, counts to real-world units

### DIFF
--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -159,36 +159,29 @@
       "kind": "uint"
     },
     {
-      "name": "hold_omega_cps",
+      "name": "velocity_limit_cps",
       "addr": 68,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "velocity_limit_cps",
+      "name": "accel_limit_q88",
       "addr": 70,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "accel_limit_q88",
+      "name": "current_limit_counts",
       "addr": 72,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "current_limit_counts",
-      "addr": 74,
-      "width": 2,
-      "access": "rw",
-      "kind": "uint"
-    },
-    {
       "name": "stall_response",
-      "addr": 76,
+      "addr": 74,
       "width": 1,
       "access": "rw",
       "kind": "enum",
@@ -205,63 +198,63 @@
     },
     {
       "name": "drive_polarity",
-      "addr": 77,
+      "addr": 75,
       "width": 1,
       "access": "rw",
       "kind": "bool"
     },
     {
       "name": "stall_omega_max_cps",
-      "addr": 78,
+      "addr": 76,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "stall_time_ms",
-      "addr": 80,
+      "addr": 78,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "stall_yield_counts",
-      "addr": 82,
+      "addr": 80,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "stall_release_counts",
-      "addr": 84,
+      "addr": 82,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "stall_tau_trip_counts",
-      "addr": 86,
+      "addr": 84,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "oc_trip_counts",
-      "addr": 88,
+      "addr": 86,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "oc_trip_ticks",
-      "addr": 90,
+      "addr": 88,
       "width": 1,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "openloop_decay",
-      "addr": 91,
+      "addr": 89,
       "width": 1,
       "access": "rw",
       "kind": "enum",
@@ -278,98 +271,98 @@
     },
     {
       "name": "derate_start_cc",
-      "addr": 92,
+      "addr": 90,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
       "name": "cutoff_cc",
-      "addr": 94,
+      "addr": 92,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
       "name": "recover_cc",
-      "addr": 96,
+      "addr": 94,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
       "name": "v_undervolt_counts",
-      "addr": 98,
+      "addr": 96,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "rtherm_i_min_counts",
-      "addr": 100,
+      "addr": 98,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "rtherm_omega_max_cps",
-      "addr": 102,
+      "addr": 100,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "l1_q016",
-      "addr": 104,
+      "addr": 102,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "l2_q88",
-      "addr": 106,
+      "addr": 104,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "l3_q88",
-      "addr": 108,
+      "addr": 106,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "l_bemf_q016",
-      "addr": 110,
+      "addr": 108,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "pos_error_counts",
-      "addr": 112,
+      "addr": 110,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "pos_error_time_ms",
-      "addr": 114,
+      "addr": 112,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "sensor_delta_max",
-      "addr": 116,
+      "addr": 114,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
       "name": "sensor_bad_count",
-      "addr": 118,
+      "addr": 116,
       "width": 1,
       "access": "rw",
       "kind": "uint"

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -501,7 +501,7 @@
       "kind": "uint"
     },
     {
-      "name": "b_i_q016",
+      "name": "b_i_q313",
       "addr": 272,
       "width": 2,
       "access": "rw",

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -536,6 +536,27 @@
       "kind": "uint"
     },
     {
+      "name": "angle_min_cdeg",
+      "addr": 282,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "angle_max_cdeg",
+      "addr": 284,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "gear_ratio_centi",
+      "addr": 286,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
       "name": "torque_enable",
       "addr": 384,
       "width": 1,

--- a/firmware/lib/core/src/estimator/fusion.rs
+++ b/firmware/lib/core/src/estimator/fusion.rs
@@ -1,9 +1,10 @@
 //! Fixed-gain 3-state fusion observer (control-theory "The Fusion Filter").
-//! Predict pushes theta/omega through the mechanical model - b_i_q016 =
-//! round(B * 65536) where B bakes Kt*Ts/J as (c/s per medium tick) per
-//! ccount, so the shift-0 product couples current counts straight into
-//! csQ16 - and correct nudges all three states against the measured pot
-//! position. The third state is the
+//! Predict pushes theta/omega through the mechanical model - b_i_q313 =
+//! round(B * 8192) where B bakes Kt*Ts/J as (c/s per medium tick) per
+//! ccount (rig-measured B runs ~3.4, so Q3.13 holds it with headroom
+//! where Q0.16 saturated), and the shift-0 product << 3 couples current
+//! counts into csQ16 - and correct nudges all three states against the
+//! measured pot position. The third state is the
 //! disturbance torque the model cannot explain, in current counts; it feeds
 //! stall/collision detection and telemetry. Gains are host-synthesized
 //! constants (no runtime matrix math on this chip).
@@ -33,14 +34,15 @@ const OMEGA_LIM_CSQ16: i32 = 32767 << 16;
 const TAU_D_LIM_CCQ16: i32 = 4095 << 16;
 
 /// Model-input clamp, 2x shunt full scale: 65535 * 8192 < 2^31 keeps the
-/// shift-0 b_i product i32-exact for any gain encoding.
+/// shift-0 b_i product i32-exact for any gain encoding; only the << 3 to
+/// csQ16 saturates (velocity.rs shift discipline).
 const ACCEL_LIM_CC: i32 = 8192;
 
 /// CALIB motor (b_i, fric_fc) + CONFIG fusion correction gains, loaded fresh
 /// each step by the kernel.
 #[derive(Copy, Clone)]
 pub struct FusionGains {
-    pub b_i_q016: u16,
+    pub b_i_q313: u16,
     pub l1_q016: u16,
     pub l2_q88: u16,
     pub l3_q88: u16,
@@ -96,9 +98,10 @@ impl FusionObs {
         dt_med_q32: u32,
         gains: &FusionGains,
     ) {
-        // Predict. b_i is Q0.16 of B (c/s per ccount per tick), so the
-        // shift-0 product lands in csQ16 directly; ACCEL_LIM_CC bounds it
-        // i32-exact. Saturating subs guard a hostile i_counts, everything
+        // Predict. b_i is Q3.13 of B (c/s per ccount per tick), so the
+        // shift-0 product lands in csQ13; the << 3 to csQ16 saturates only
+        // beyond omega full scale (ACCEL_LIM_CC keeps the product itself
+        // i32-exact). Saturating subs guard a hostile i_counts, everything
         // downstream is clamp-bounded.
         let fric = fric_c(self.omega_q16, gains.fric_fc_counts);
         let accel = i_counts
@@ -107,7 +110,7 @@ impl FusionObs {
             .clamp(-ACCEL_LIM_CC, ACCEL_LIM_CC);
         self.omega_q16 = self
             .omega_q16
-            .saturating_add(q_mul(gains.b_i_q016 as i32, accel, 0))
+            .saturating_add(q_mul(gains.b_i_q313 as i32, accel, 0).saturating_mul(1 << 3))
             .clamp(-OMEGA_LIM_CSQ16, OMEGA_LIM_CSQ16);
         // |omega| <= 2^31, dt < 2^31 -> |delta| < 2^30
         self.theta_q16 = self
@@ -164,16 +167,17 @@ mod tests {
     // 2 kHz MEDIUM rate, matching the kernel's DT_MED_Q32 derivation.
     const DT: u32 = ((1u64 << 32) / 2000) as u32;
 
-    // Hand-picked stable set for the 2 kHz discrete observer: b_i = 6554 =
-    // Q0.16 of B = 0.1 c/s per tick per ccount (mid rig-physical range),
-    // l1 = 0.25, l2 = 4.0 c/s per count, l3 = 8.0 cc per count. With the
-    // coupling live, the e -> tau_d -> omega -> theta loop gain scales as
-    // l3 * B, so l3 must shrink as b_i grows: 64.0 rails the filter at
-    // this B (integer-sim verified), 8.0 sits inside the stable region
-    // with the disturbance step still settling exactly. If a convergence
-    // test oscillates the fix is smaller gains, not more iterations.
+    // Hand-picked stable set for the 2 kHz discrete observer: b_i = 819 =
+    // Q3.13 of B = 0.1 c/s per tick per ccount (low rig-physical range;
+    // the rig measures ~3.4), l1 = 0.25, l2 = 4.0 c/s per count, l3 = 8.0
+    // cc per count. With the coupling live, the e -> tau_d -> omega ->
+    // theta loop gain scales as l3 * B, so l3 must shrink as b_i grows:
+    // 64.0 rails the filter at this B (integer-sim verified), 8.0 sits
+    // inside the stable region with the disturbance step still settling
+    // exactly. If a convergence test oscillates the fix is smaller gains,
+    // not more iterations.
     const G: FusionGains = FusionGains {
-        b_i_q016: 6554,
+        b_i_q313: 819,
         l1_q016: 16384,
         l2_q88: 1024,
         l3_q88: 2048,
@@ -204,22 +208,22 @@ mod tests {
             f.step(0, 2000, None, DT, &G);
         }
         assert_eq!(f.theta_q16(), 2000 << 16, "pin");
-        assert_eq!(f.omega_q16(), 1966, "pin");
+        assert_eq!(f.omega_q16(), 1964, "pin");
         assert_eq!(f.tau_d_counts(), 0, "pin");
     }
 
     #[test]
     fn current_couples_at_full_scale() {
         // One step from rest, e = 0 going in: predict alone moves omega by
-        // q_mul(b_i, i, 0) = 6554 * 100 = 655400 q16 (~10 c/s) - the
-        // shift-0 encoding couples whole ccounts into csQ16 directly (the
-        // old shift-16 form moved <= 1 q16 per ccount and left b_i inert).
-        // The correct step then subtracts l2*e for the 327-q16 theta
-        // advance: 655400 - (1024 * 327 >> 8) = 654092.
+        // q_mul(b_i, i, 0) << 3 = 819 * 100 * 8 = 655200 q16 (~10 c/s) -
+        // the Q3.13 encoding couples whole ccounts into csQ16 through the
+        // << 3 (the old shift-16 form moved <= 1 q16 per ccount and left
+        // b_i inert). The correct step then subtracts l2*e for the 327-q16
+        // theta advance: 655200 - (1024 * 327 >> 8) = 653892.
         let mut f = FusionObs::new();
         f.seed(2000);
         f.step(100, 2000, None, DT, &G);
-        assert_eq!(f.omega_q16(), 654092, "pin");
+        assert_eq!(f.omega_q16(), 653892, "pin");
     }
 
     #[test]
@@ -304,7 +308,7 @@ mod tests {
         // Max-encoded gains, extreme inputs: debug overflow checks are the
         // wrap detector; states must stay inside their clamps.
         let g = FusionGains {
-            b_i_q016: u16::MAX,
+            b_i_q313: u16::MAX,
             l1_q016: u16::MAX,
             l2_q88: u16::MAX,
             l3_q88: u16::MAX,

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -599,14 +599,20 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                         // the frozen loop resumes bumplessly on exit
                         self.duty_q15 = 0;
                         MotorCmd::Coast
-                    } else if self.i_ref_cc == 0 && i_meas.is_none() {
-                        // zero ref with no window: the honest-zero feed
-                        // below makes e = 0, freezing the PI at whatever
-                        // sub-floor duty it unwound to - stalled at an
-                        // endstop that grinds the gears forever (bench:
-                        // 18% duty held into the rail). Zero duty is the
-                        // honest actuation; slow decay shorts the winding,
-                        // passively braking whatever momentum remains.
+                    } else if self.i_ref_cc == 0
+                        && i_meas.is_none()
+                        && (self.i_band.hi == 0 || self.i_band.lo == 0)
+                    {
+                        // endstop-clamped ref with no window: the
+                        // honest-zero feed below makes e = 0, freezing the
+                        // PI at whatever sub-floor duty it unwound to -
+                        // stalled at an endstop that grinds the gears
+                        // forever (bench: 18% duty held into the rail).
+                        // Zero duty is the honest actuation; slow decay
+                        // shorts the winding, passively braking whatever
+                        // momentum remains. Scoped to a collapsed band so a
+                        // transient i_ref zero crossing in normal travel
+                        // can never reset the loop mid-reversal.
                         self.cur.reset();
                         self.duty_q15 = 0;
                         self.decay = DecayMode::Slow;

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -357,14 +357,12 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                         let pc = PositionCfg {
                             kp_q88: loop_pos.p_kp_q88,
                             pos_deadband_counts: loop_pos.pos_deadband_counts,
-                            hold_omega_cps: loop_pos.hold_omega_cps,
                             vel_limit_cps: loop_pos.velocity_limit_cps,
                         };
                         let out = position::step(
                             self.traj.theta_star_q16(),
                             self.traj.omega_star_q16(),
                             theta_hat,
-                            omega_hat,
                             &pc,
                         );
                         self.omega_ref_q16 = out.omega_ref_q16;
@@ -411,6 +409,17 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
 
             if run {
                 match life.mode {
+                    // Parked: the drive coasts, so the velocity loop must stop
+                    // too. omega_hat is pot-noise driven at rest (+-hundreds
+                    // c/s); left running, the PI integrates that phantom error
+                    // until i_ref pins at the current limit, and pinned + slow
+                    // false-trips the stall detector (bench: CODE_STALL a few
+                    // seconds into a clean hold). Zero the command and drain
+                    // the integrator so it never winds and resumes bumplessly.
+                    Mode::Position if self.hold => {
+                        self.i_ref_cc = 0;
+                        self.vel.reset();
+                    }
                     Mode::Velocity | Mode::Position => {
                         let vg = VelocityGains {
                             kp_q88: loop_vel.v_kp_q88,

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -590,6 +590,21 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                         // the frozen loop resumes bumplessly on exit
                         self.duty_q15 = 0;
                         MotorCmd::Coast
+                    } else if self.i_ref_cc == 0 && i_meas.is_none() {
+                        // zero ref with no window: the honest-zero feed
+                        // below makes e = 0, freezing the PI at whatever
+                        // sub-floor duty it unwound to - stalled at an
+                        // endstop that grinds the gears forever (bench:
+                        // 18% duty held into the rail). Zero duty is the
+                        // honest actuation; slow decay shorts the winding,
+                        // passively braking whatever momentum remains.
+                        self.cur.reset();
+                        self.duty_q15 = 0;
+                        self.decay = DecayMode::Slow;
+                        MotorCmd::Drive {
+                            duty: Effort(0),
+                            decay: DecayMode::Slow,
+                        }
                     } else {
                         let gains = CurrentGains {
                             kp_q88: loop_cur.i_kp_q88,

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -371,7 +371,7 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                         self.hold = out.hold;
                     }
                     Mode::Velocity => {
-                        self.traj.step_velocity(life.goal_velocity, &tc);
+                        self.traj.step_velocity(life.goal_velocity, theta_hat, &tc);
                         self.omega_ref_q16 = self.traj.omega_star_q16();
                         self.hold = false;
                     }

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -323,7 +323,7 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
             // predicts torque-free.
             let i_use = i_meas.unwrap_or(self.i_ref_cc);
             let fg = FusionGains {
-                b_i_q016: motor_cal.b_i_q016,
+                b_i_q313: motor_cal.b_i_q313,
                 l1_q016: fus_cfg.l1_q016,
                 l2_q88: fus_cfg.l2_q88,
                 l3_q88: fus_cfg.l3_q88,

--- a/firmware/lib/core/src/kernel/position.rs
+++ b/firmware/lib/core/src/kernel/position.rs
@@ -4,6 +4,14 @@
 //! position integrator over Coulomb friction limit-cycles). The anti-hunt
 //! hold predicate tells the kernel to Coast inside the deadband instead of
 //! dithering against friction.
+//!
+//! Hold gates on POSITION rest alone (profile stopped, error inside the
+//! deadband) - never on omega_hat. The fused omega is pot-noise driven at
+//! rest and the velocity loop amplifies it (bench + integer-sim: a ~3x
+//! blow-up when driving), so an omega gate that clears the coasting noise
+//! floor sits below the driving floor: hold latches from rest but can never
+//! re-catch once the loop is shaking. Position is the clean rest signal;
+//! friction and the deadband absorb any residual velocity at the crossing.
 
 use super::trajectory::VEL_CAP_CPS;
 use crate::math::q_mul;
@@ -22,7 +30,6 @@ pub struct PositionCfg {
     pub kp_q88: u16,
     /// 0 disables the hold predicate entirely.
     pub pos_deadband_counts: u16,
-    pub hold_omega_cps: u16,
     pub vel_limit_cps: u16,
 }
 
@@ -40,7 +47,6 @@ pub fn step(
     theta_star_q16: i32,
     omega_star_q16: i32,
     theta_hat_q16: i32,
-    omega_hat_q16: i32,
     cfg: &PositionCfg,
 ) -> PosOut {
     let e_raw = theta_star_q16.saturating_sub(theta_hat_q16);
@@ -54,8 +60,7 @@ pub fn step(
     // past i32
     let hold = cfg.pos_deadband_counts != 0
         && e_raw.unsigned_abs() <= (cfg.pos_deadband_counts as u32) << 16
-        && omega_star_q16 == 0
-        && omega_hat_q16.unsigned_abs() < (cfg.hold_omega_cps as u32) << 16;
+        && omega_star_q16 == 0;
     PosOut {
         omega_ref_q16: omega_ref,
         hold,
@@ -66,11 +71,10 @@ pub fn step(
 mod tests {
     use super::*;
 
-    fn c(kp: u16, db: u16, ho: u16, vl: u16) -> PositionCfg {
+    fn c(kp: u16, db: u16, vl: u16) -> PositionCfg {
         PositionCfg {
             kp_q88: kp,
             pos_deadband_counts: db,
-            hold_omega_cps: ho,
             vel_limit_cps: vl,
         }
     }
@@ -78,71 +82,61 @@ mod tests {
     #[test]
     fn p_term_sign_and_scale() {
         // kp 1.0 c/s per count: 100 counts of error -> 100 c/s
-        let cfg = c(1 << 8, 0, 0, 32767);
-        assert_eq!(step(100 << 16, 0, 0, 0, &cfg).omega_ref_q16, 100 << 16);
-        assert_eq!(step(0, 0, 100 << 16, 0, &cfg).omega_ref_q16, -(100 << 16));
+        let cfg = c(1 << 8, 0, 32767);
+        assert_eq!(step(100 << 16, 0, 0, &cfg).omega_ref_q16, 100 << 16);
+        assert_eq!(step(0, 0, 100 << 16, &cfg).omega_ref_q16, -(100 << 16));
         // kp 1/256: 100 counts -> 100/256 c/s = 100 << 8 in csQ16
-        let cfg = c(1, 0, 0, 32767);
-        assert_eq!(step(100 << 16, 0, 0, 0, &cfg).omega_ref_q16, 100 << 8);
-        assert_eq!(step(0, 0, 100 << 16, 0, &cfg).omega_ref_q16, -(100 << 8));
+        let cfg = c(1, 0, 32767);
+        assert_eq!(step(100 << 16, 0, 0, &cfg).omega_ref_q16, 100 << 8);
+        assert_eq!(step(0, 0, 100 << 16, &cfg).omega_ref_q16, -(100 << 8));
     }
 
     #[test]
     fn feedforward_adds() {
         // kp 0: pure passthrough of omega*
-        let cfg = c(0, 0, 0, 32767);
-        assert_eq!(
-            step(100 << 16, 200 << 16, 0, 0, &cfg).omega_ref_q16,
-            200 << 16
-        );
+        let cfg = c(0, 0, 32767);
+        assert_eq!(step(100 << 16, 200 << 16, 0, &cfg).omega_ref_q16, 200 << 16);
         // kp term and omega* sum
-        let cfg = c(1 << 8, 0, 0, 32767);
-        assert_eq!(
-            step(10 << 16, 200 << 16, 0, 0, &cfg).omega_ref_q16,
-            210 << 16
-        );
+        let cfg = c(1 << 8, 0, 32767);
+        assert_eq!(step(10 << 16, 200 << 16, 0, &cfg).omega_ref_q16, 210 << 16);
     }
 
     #[test]
     fn vel_limit_and_error_clamp() {
         // 1000 counts of error clamps to E_LIM's 128 first: kp 1.0 -> 128 c/s
-        let cfg = c(1 << 8, 0, 0, 32767);
-        assert_eq!(step(1000 << 16, 0, 0, 0, &cfg).omega_ref_q16, 128 << 16);
+        let cfg = c(1 << 8, 0, 32767);
+        assert_eq!(step(1000 << 16, 0, 0, &cfg).omega_ref_q16, 128 << 16);
         // vel_limit clamps the sum, both signs
-        let cfg = c(1 << 8, 0, 0, 100);
-        assert_eq!(step(1000 << 16, 0, 0, 0, &cfg).omega_ref_q16, 100 << 16);
-        assert_eq!(step(0, 0, 1000 << 16, 0, &cfg).omega_ref_q16, -(100 << 16));
+        let cfg = c(1 << 8, 0, 100);
+        assert_eq!(step(1000 << 16, 0, 0, &cfg).omega_ref_q16, 100 << 16);
+        assert_eq!(step(0, 0, 1000 << 16, &cfg).omega_ref_q16, -(100 << 16));
         // feedforward alone also cannot escape the limit
-        assert_eq!(step(0, 500 << 16, 0, 0, &cfg).omega_ref_q16, 100 << 16);
+        assert_eq!(step(0, 500 << 16, 0, &cfg).omega_ref_q16, 100 << 16);
     }
 
     #[test]
     fn hold_predicate_each_condition() {
-        let cfg = c(1 << 8, 5, 10, 32767);
-        // all four true: within deadband, profile at rest, servo near rest
-        let base = |cfg: &PositionCfg| step(5 << 16, 0, 0, (10 << 16) - 1, cfg);
-        assert!(base(&cfg).hold);
+        let cfg = c(1 << 8, 5, 32767);
+        // both hold conditions true: within deadband and profile at rest
+        assert!(step(5 << 16, 0, 0, &cfg).hold);
         // deadband 0 disables hold outright, even at perfect rest
-        assert!(!step(0, 0, 0, 0, &c(1 << 8, 0, 10, 32767)).hold);
+        assert!(!step(0, 0, 0, &c(1 << 8, 0, 32767)).hold);
         // error one cQ16 past the deadband
-        assert!(!step((5 << 16) + 1, 0, 0, 0, &cfg).hold);
+        assert!(!step((5 << 16) + 1, 0, 0, &cfg).hold);
         // omega* nonzero: profile still moving
-        assert!(!step(5 << 16, 1, 0, 0, &cfg).hold);
-        // omega_hat at the bound (strict <)
-        assert!(!step(5 << 16, 0, 0, 10 << 16, &cfg).hold);
-        assert!(step(5 << 16, 0, 0, -(10 << 16) + 1, &cfg).hold);
+        assert!(!step(5 << 16, 1, 0, &cfg).hold);
     }
 
     #[test]
     fn hold_uses_raw_error_not_clamped() {
         // 6000 counts of error is far past E_LIM's 128 but inside a 65535
         // deadband: the predicate must see the raw magnitude and hold
-        let cfg = c(1 << 8, 65535, 10, 32767);
-        let out = step(3000 << 16, 0, -(3000 << 16), 0, &cfg);
+        let cfg = c(1 << 8, 65535, 32767);
+        let out = step(3000 << 16, 0, -(3000 << 16), &cfg);
         assert!(out.hold);
         // while the drive command stays E_LIM/vel_limit-clamped
         assert_eq!(out.omega_ref_q16, 128 << 16);
         // and a small deadband rejects the same error
-        assert!(!step(3000 << 16, 0, -(3000 << 16), 0, &c(1 << 8, 5, 10, 32767)).hold);
+        assert!(!step(3000 << 16, 0, -(3000 << 16), &c(1 << 8, 5, 32767)).hold);
     }
 }

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -78,7 +78,6 @@ fn seed(shared: &Shared) {
         c.loop_velocity.j_ff_q88 = 0;
         c.loop_position.p_kp_q88 = 256;
         c.loop_position.pos_deadband_counts = 8;
-        c.loop_position.hold_omega_cps = 200;
         c.loop_position.velocity_limit_cps = 3000;
         c.loop_position.accel_limit_q88 = 50 << 8;
         c.limits.current_limit_counts = 1200;
@@ -799,6 +798,103 @@ fn hard_wall_stall_faults() {
     assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
     sh.table
         .with(|t| assert_eq!(t.telemetry.mode.fault_code, faults::CODE_STALL));
+}
+
+#[test]
+fn hold_parks_releases_and_reparks() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 2000;
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+        t.config.fusion.l3_q88 = 256;
+        t.config.loop_position.p_kp_q88 = 1024;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(1990);
+    run_plant(&mut k, &sh, &mut plant, 20_000);
+    assert!(matches!(last_cmd(&k), MotorCmd::Coast), "never parked");
+    assert_eq!(k.faults.mask(), 0);
+    // a goal write releases the park (omega_star != 0 drops hold); the whole
+    // commanded move must run without a single Coast, then it re-parks once
+    // the profile lands inside the deadband
+    sh.table
+        .with_mut(|t| t.control.lifecycle.goal_position = 2100);
+    let mut saw_move = false;
+    let mut reparked = false;
+    for _ in 0..20_000u32 {
+        run_plant(&mut k, &sh, &mut plant, 1);
+        let moving = k.traj.omega_star_q16() != 0;
+        if moving {
+            saw_move = true;
+            assert!(!matches!(last_cmd(&k), MotorCmd::Coast), "coast mid-move");
+        }
+        if saw_move && !moving && matches!(last_cmd(&k), MotorCmd::Coast) {
+            reparked = true;
+        }
+    }
+    assert!(saw_move, "goal write never started the profile");
+    assert!(reparked, "never re-parked after the move");
+    assert_eq!(k.faults.mask(), 0);
+    // an external push out of the deadband wakes the park, then it re-parks
+    plant.theta_q16 -= 60i64 << 16;
+    let mut woke = false;
+    for _ in 0..2000 {
+        run_plant(&mut k, &sh, &mut plant, 1);
+        woke |= !matches!(last_cmd(&k), MotorCmd::Coast);
+    }
+    assert!(woke, "push never woke the hold");
+    let mut coast = 0u32;
+    for _ in 0..30_000 {
+        run_plant(&mut k, &sh, &mut plant, 1);
+        if matches!(last_cmd(&k), MotorCmd::Coast) {
+            coast += 1;
+        }
+    }
+    assert!(
+        coast > 15_000,
+        "never re-parked after the push: coast {coast}"
+    );
+    assert_eq!(k.faults.mask(), 0);
+    assert!((plant.pos() - 2100).abs() <= 16, "rest {}", plant.pos());
+}
+
+#[test]
+fn hold_stays_parked_under_pot_noise() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.goal_position = 2000;
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+        t.config.fusion.l3_q88 = 256;
+        t.config.loop_position.p_kp_q88 = 1024;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(1990);
+    run_plant(&mut k, &sh, &mut plant, 20_000);
+    assert!(matches!(last_cmd(&k), MotorCmd::Coast), "never parked");
+    // parked hold under +-3 counts of pot noise: gating on position rest
+    // (not the noisy omega_hat) keeps the park engaged - a wake per blip is
+    // the shake fix2 removes
+    let mut rng: u32 = 0xdead_beef;
+    let (mut coast, mut lo, mut hi) = (0u32, i32::MAX, i32::MIN);
+    for _ in 0..40_000 {
+        let mut f = plant.step(k.duty_q15);
+        rng = rng.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let n = ((rng >> 24) as i32 % 7) - 3;
+        f.pos = (f.pos as i32 + n).clamp(0, 4095) as u16;
+        k.on_tick(f, &sh);
+        if matches!(last_cmd(&k), MotorCmd::Coast) {
+            coast += 1;
+        }
+        lo = lo.min(plant.pos());
+        hi = hi.max(plant.pos());
+    }
+    assert_eq!(k.faults.mask(), 0);
+    assert!(hi - lo <= 4, "hold limit cycle: spread {}", hi - lo);
+    assert!(coast >= 36_000, "coast ticks {coast} of 40000");
 }
 
 #[test]

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -802,6 +802,42 @@ fn hard_wall_stall_faults() {
 }
 
 #[test]
+fn current_mode_endstop_unwinds_duty_to_zero() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::Current;
+        t.control.lifecycle.goal_current = 300;
+        t.config.pos_limits.pos_max_soft_counts = 3000;
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+        t.config.limits.stall_tau_trip_counts = u16::MAX;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(1000);
+    // free flight into the soft wall with a wound-up loop
+    run_plant(&mut k, &sh, &mut plant, 20_000);
+    assert_eq!(k.faults.mask(), 0);
+    assert!(
+        plant.pos() >= 3000,
+        "never reached the wall: {}",
+        plant.pos()
+    );
+    // past the wall the endstop zeroes i_ref; the loop must unwind ALL the
+    // way to zero, not freeze at the sub-floor duty the honest-zero feed
+    // leaves behind (bench: 18% duty held grinding into the rail)
+    assert_eq!(k.duty_q15, 0, "duty froze above zero at the wall");
+    let mut zero = 0u32;
+    for _ in 0..2000 {
+        run_plant(&mut k, &sh, &mut plant, 1);
+        if k.duty_q15 == 0 {
+            zero += 1;
+        }
+    }
+    assert!(zero >= 1990, "duty kept firing at the wall: {zero} of 2000");
+}
+
+#[test]
 fn position_step_survives_tick_deletion() {
     let sh = Shared::new();
     seed(&sh);

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -838,6 +838,55 @@ fn current_mode_endstop_unwinds_duty_to_zero() {
 }
 
 #[test]
+fn velocity_mode_brakes_at_the_soft_wall() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::Velocity;
+        t.control.lifecycle.goal_velocity = 2000;
+        t.config.pos_limits.pos_max_soft_counts = 3000;
+        t.config.fault_cfg.pos_error_counts = u16::MAX;
+        t.config.limits.stall_tau_trip_counts = u16::MAX;
+    });
+    let mut k = kernel();
+    let mut plant = Plant::new(1000);
+    run_plant(&mut k, &sh, &mut plant, 30_000);
+    assert_eq!(k.faults.mask(), 0);
+    // the wall ramp shrinks the inward goal with distance: the profile
+    // decelerates INTO the wall instead of leaving momentum to coast on an
+    // open-loop current cut, and parks without a flip-flop limit cycle
+    assert!(
+        plant.pos() >= 2950 && plant.pos() <= 3020,
+        "rest pos {}",
+        plant.pos()
+    );
+    let (mut lo, mut hi) = (i32::MAX, i32::MIN);
+    let mut star_max = 0i32;
+    for _ in 0..4000 {
+        run_plant(&mut k, &sh, &mut plant, 1);
+        lo = lo.min(plant.pos());
+        hi = hi.max(plant.pos());
+        star_max = star_max.max(k.traj.omega_star_q16());
+    }
+    assert!(hi - lo <= 4, "limit cycle at the wall: spread {}", hi - lo);
+    assert!(
+        star_max <= 64 << 16,
+        "profile still commands inward speed: {}",
+        star_max >> 16
+    );
+    // the door back out stays open
+    sh.table
+        .with_mut(|t| t.control.lifecycle.goal_velocity = -500);
+    run_plant(&mut k, &sh, &mut plant, 20_000);
+    assert!(
+        plant.pos() < 2900,
+        "retreat from the wall failed: {}",
+        plant.pos()
+    );
+}
+
+#[test]
 fn position_step_survives_tick_deletion() {
     let sh = Shared::new();
     seed(&sh);

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -100,8 +100,8 @@ fn seed(shared: &Shared) {
         c.thermal.rtherm_omega_max_cps = 400;
         c.fusion.l1_q016 = 16384;
         c.fusion.l2_q88 = 1024;
-        // l3 * B is the tau_d loop gain: at the plant's B (~1.0 saturated
-        // into b_i below) 0.5 cc per count is stable, 2.0 rails the filter
+        // l3 * B is the tau_d loop gain: at the b_i-encoded B (1.0 below)
+        // 0.5 cc per count is stable, 2.0 rails the filter
         c.fusion.l3_q88 = 128;
         c.fusion.l_bemf_q016 = 0;
         c.fault_cfg.pos_error_counts = 400;
@@ -114,9 +114,10 @@ fn seed(shared: &Shared) {
         cal.motor.ke_vpc_q = 256; // 0.0625 vcounts per c/s
         cal.motor.r_q12 = 8192; // 2.0 vcounts/ccount
         cal.motor.recip_ke_q = 16 << 10; // 16 c/s per vcount
-        // plant B ~= 1.33 c/s per ccount per medium tick (200/1500 x 10),
-        // saturated to the Q0.16 ceiling; correction gains absorb the gap
-        cal.motor.b_i_q016 = 65535;
+        // plant B ~= 1.33 c/s per ccount per medium tick (200/1500 x 10);
+        // encoded 1.0 (the old Q0.16-ceiling dynamics, kept so the pinned
+        // integer sims stand); correction gains absorb the gap
+        cal.motor.b_i_q313 = 8192;
         t.telemetry.sensors.current_bias_counts = BIAS;
         t.control.lifecycle.torque_enable = false;
         t.control.lifecycle.mode = Mode::Position;

--- a/firmware/lib/core/src/kernel/trajectory.rs
+++ b/firmware/lib/core/src/kernel/trajectory.rs
@@ -27,6 +27,12 @@ pub(crate) const VEL_CAP_CPS: u16 = 32767;
 /// tick) at the 2 kHz MEDIUM rate.
 const SNAP_D_CQ16: u32 = 1 << 16;
 
+/// Velocity-mode wall ramp slope: 2^4 = 16 c/s of inward allowance per
+/// count of distance to a soft limit. Matches the decel the default limits
+/// can deliver (accel/vel = 30000/1500 = 20 /s); a hotter config just lags
+/// the ramp through the accel slew.
+const WALL_RAMP_SHIFT: u32 = 4;
+
 /// CONFIG loop_position profile fields + soft limits, loaded fresh each
 /// step by the kernel (`CurrentGains` convention). `dt_med_q32` =
 /// 2^32 / MED_HZ, the kernel's compile-time constant; MED_HZ > 2 keeps it
@@ -147,10 +153,30 @@ impl TrajGen {
     /// per tick. theta_ref keeps integrating - unused downstream in this
     /// mode, but a switch back to position mode then starts from a
     /// consistent pose.
-    pub fn step_velocity(&mut self, goal_velocity_cps: i32, cfg: &TrajCfg) {
+    ///
+    /// Soft-limit wall ramp: the goal's inward component is capped at
+    /// WALL_RAMP c/s per count of distance to the wall, reaching 0 at the
+    /// wall (and staying 0 past it - momentum only ever coasts against the
+    /// endstop's current cut, quadratic in speed on the bench). A linear
+    /// ramp converges without the limit cycle a binary at-the-wall cut
+    /// produces: the cut flips at one count and the velocity PI's brake
+    /// bounce re-arms it every swing. Retreat is never capped. The accel
+    /// slew below stays the physical enforcer when a config's accel/vel
+    /// ratio disagrees with the ramp slope - the ramp is a reference shape.
+    pub fn step_velocity(&mut self, goal_velocity_cps: i32, theta_hat_q16: i32, cfg: &TrajCfg) {
         let a = (cfg.accel_limit_q88 as i32) << 8;
         let v_cap = cfg.vel_limit_cps.min(VEL_CAP_CPS) as i32;
-        let goal = goal_velocity_cps.clamp(-v_cap, v_cap) << 16;
+        let th = theta_hat_q16 >> 16;
+        let lo = cfg.pos_min_soft_counts.min(cfg.pos_max_soft_counts);
+        let hi = cfg.pos_max_soft_counts.max(cfg.pos_min_soft_counts);
+        // distance pre-clamped so the shift cannot overflow
+        let cap = (VEL_CAP_CPS as i32) >> WALL_RAMP_SHIFT;
+        let allow_up = hi.saturating_sub(th).clamp(0, cap) << WALL_RAMP_SHIFT;
+        let allow_dn = th.saturating_sub(lo).clamp(0, cap) << WALL_RAMP_SHIFT;
+        let goal = goal_velocity_cps
+            .clamp(-v_cap, v_cap)
+            .clamp(-allow_dn, allow_up)
+            << 16;
         let prev = self.omega_ref_q16;
         // goal - prev can span 2^32; saturation past +-a is clamped away
         let omega = prev + goal.saturating_sub(prev).clamp(-a, a);
@@ -361,16 +387,16 @@ mod tests {
         let mut t = TrajGen::new();
         t.reseed(0);
         for k in 1..=10i32 {
-            t.step_velocity(500, &c);
+            t.step_velocity(500, 0, &c);
             assert_eq!(t.omega_star_q16(), (50 * k) << 16);
             assert_eq!(t.alpha_star_q16(), A);
         }
-        t.step_velocity(500, &c);
+        t.step_velocity(500, 0, &c);
         assert_eq!(t.omega_star_q16(), 500 << 16);
         assert_eq!(t.alpha_star_q16(), 0);
         // goal past vel_limit clamps at the limit
         for _ in 0..100 {
-            t.step_velocity(5000, &c);
+            t.step_velocity(5000, 0, &c);
         }
         assert_eq!(t.omega_star_q16(), 1000 << 16);
         // theta tracked the motion
@@ -378,11 +404,40 @@ mod tests {
         // reversal: exactly one accel step per tick through zero
         let mut prev = t.omega_star_q16();
         for _ in 0..40 {
-            t.step_velocity(-5000, &c);
+            t.step_velocity(-5000, 0, &c);
             assert_eq!(prev - t.omega_star_q16(), A);
             prev = t.omega_star_q16();
         }
         assert_eq!(prev, -(1000 << 16));
+    }
+
+    #[test]
+    fn velocity_wall_ramp_caps_inward_goal() {
+        let c = TrajCfg {
+            pos_min_soft_counts: 0,
+            pos_max_soft_counts: 1000,
+            ..cfg(1000, 50 << 8)
+        };
+        let run = |theta: i32, goal: i32| {
+            let mut t = TrajGen::new();
+            for _ in 0..100 {
+                t.step_velocity(goal, theta << 16, &c);
+            }
+            t.omega_star_q16() >> 16
+        };
+        // far from both walls: the vel limit binds
+        assert_eq!(run(500, 5000), 1000);
+        // 50 counts out: 50 << WALL_RAMP_SHIFT binds
+        assert_eq!(run(950, 5000), 800);
+        // at and past the wall: inward goal pinned to 0
+        assert_eq!(run(1000, 5000), 0);
+        assert_eq!(run(1100, 5000), 0);
+        // retreat is never capped, even from past the wall
+        assert_eq!(run(1100, -700), -700);
+        // mirrored at the min wall
+        assert_eq!(run(25, -5000), -400);
+        assert_eq!(run(0, -5000), 0);
+        assert_eq!(run(500, -5000), -1000);
     }
 
     #[test]
@@ -449,7 +504,7 @@ mod tests {
                                 t.step_position(goal, &c);
                                 assert!(t.omega_star_q16().unsigned_abs() <= 32767u32 << 16);
                                 assert!(t.theta_star_q16().unsigned_abs() <= 1 << 29);
-                                t.step_velocity(goal, &c);
+                                t.step_velocity(goal, seed, &c);
                                 assert!(t.omega_star_q16().unsigned_abs() <= 32767u32 << 16);
                                 assert!(t.theta_star_q16().unsigned_abs() <= 1 << 29);
                             }

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -27,11 +27,12 @@ pub use kernel::{Kernel, KernelTiming};
 pub use persist::{ConfigStore, StoreError};
 pub use regions::config::{BaudRate, ConfigDefaults};
 pub use regions::{
-    BootMode, CalibMotor, CalibRegs, CalibSense, CalibWinding, ConfigCommon, ConfigFaultCfg,
-    ConfigFusion, ConfigLimits, ConfigLoopCurrent, ConfigLoopPosition, ConfigLoopVelocity,
-    ConfigPosLimits, ConfigRegs, ConfigThermal, ControlLifecycle, ControlRegs, ControlSystem,
-    ControlTable, ControlTableCell, DecaySelect, Mode, PotLutBlock, StallResponse, TelemetryCommon,
-    TelemetryEstimates, TelemetryIdent, TelemetryMode, TelemetryRegs, TelemetrySensors,
+    BootMode, CalibKinematics, CalibMotor, CalibRegs, CalibSense, CalibWinding, ConfigCommon,
+    ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent, ConfigLoopPosition,
+    ConfigLoopVelocity, ConfigPosLimits, ConfigRegs, ConfigThermal, ControlLifecycle, ControlRegs,
+    ControlSystem, ControlTable, ControlTableCell, DecaySelect, Mode, PotLutBlock, StallResponse,
+    TelemetryCommon, TelemetryEstimates, TelemetryIdent, TelemetryMode, TelemetryRegs,
+    TelemetrySensors,
 };
 pub use sensor_frame::SensorFrame;
 pub use services::bus::{Dispatcher, Session};

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -41,7 +41,7 @@ pub const CALIB_IMAGE_LEN: usize = HEADER_LEN + CALIB_LEN;
 pub const IMAGE_MAGIC: u8 = b'C';
 /// Bump on any CONFIG/PROFILE layout change; a mismatched image is ignored
 /// (boot keeps board defaults) rather than migrated.
-pub const IMAGE_VERSION: u8 = 2;
+pub const IMAGE_VERSION: u8 = 3;
 
 pub const CALIB_IMAGE_MAGIC: u8 = b'K';
 /// Bump on any CALIB layout change; independent of [`IMAGE_VERSION`].

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -68,6 +68,18 @@ pub struct CalibMotor {
     pub ke_vpc_q: u16,
 }
 
+/// Count<->angle scale and gearing, pure host-facing metadata: firmware never
+/// reads it, the ISR stays in counts. Angles are centi-degrees at the pot LUT
+/// endpoints raw_min/raw_max (which equal pos_min/max_phys); `gear_ratio_centi`
+/// is motor revs per output rev x100. All-zero = unset.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct CalibKinematics {
+    pub angle_min_cdeg: i16,
+    pub angle_max_cdeg: i16,
+    pub gear_ratio_centi: u16,
+}
+
 /// Calibration section: always writable (normal field validation applies),
 /// volatile until persisted -- persistence is SAVE's job, not a write gate.
 #[repr(C)]
@@ -81,6 +93,7 @@ pub struct CalibRegs {
     pub sense: CalibSense,
     pub winding: CalibWinding,
     pub motor: CalibMotor,
+    pub kinematics: CalibKinematics,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 102],
+    pub _rsvd_tail: [u8; 96],
 }

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -50,7 +50,8 @@ pub struct CalibWinding {
 /// Motor identification: `ke_uvs_per_rad` is the host-facing record; the rest
 /// are firmware-shaped -- bemf subtract R (Q4.12), reciprocal Ke (c/s per
 /// vcount Q6.10, estimator::bemf convention), fusion current gain (bakes
-/// Ts/J), the friction model (Coulomb ccounts, viscous Q0.16, breakaway
+/// Ts/J, Q3.13: rig B runs ~3.4 so Q0.16 saturated), the friction model
+/// (Coulomb ccounts, viscous Q0.16, breakaway
 /// ccounts), and forward Ke (vcounts per c/s Q4.12, the current loop's bemf
 /// decoupling feedforward). Forward and reciprocal Ke are both host-written:
 /// the chip has no divide to derive one from the other. SG90 scale ~0.28
@@ -61,7 +62,7 @@ pub struct CalibMotor {
     pub ke_uvs_per_rad: u16,
     pub r_q12: u16,
     pub recip_ke_q: u16,
-    pub b_i_q016: u16,
+    pub b_i_q313: u16,
     pub fric_fc_counts: u16,
     pub fric_fv_q016: u16,
     pub fric_breakaway_counts: u16,

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -103,14 +103,13 @@ pub struct ConfigLoopVelocity {
     pub j_ff_q88: u16,
 }
 
-/// Position P gain, anti-hunt hold window, trajectory limits.
+/// Position P gain, anti-hunt hold deadband, trajectory limits.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
 pub struct ConfigLoopPosition {
     pub p_kp_q88: u16,
-    /// 0 = hold disabled.
+    /// 0 = hold disabled. Hold coasts on position rest alone (position.rs).
     pub pos_deadband_counts: u16,
-    pub hold_omega_cps: u16,
     pub velocity_limit_cps: u16,
     /// c/s per medium tick.
     pub accel_limit_q88: u16,
@@ -122,6 +121,11 @@ pub struct ConfigLoopPosition {
 // medium tick = 0 -> 1500 in 50 ms).
 pub const DEFAULT_VELOCITY_LIMIT_CPS: u16 = 1500;
 pub const DEFAULT_ACCEL_LIMIT_Q88: u16 = 3840;
+
+// Anti-hunt hold: at 0 the park never engages and the position loop chases
+// pot noise at rest (audible shake on the SG90 rig). Modest pot-noise-scale
+// backstop; identification refines it from the measured sigma_theta.
+pub const DEFAULT_POS_DEADBAND_COUNTS: u16 = 12;
 
 /// Current ceiling, stall policy, overcurrent trip window.
 #[repr(C)]
@@ -226,7 +230,7 @@ pub struct ConfigRegs {
     pub fusion: ConfigFusion,
     pub fault_cfg: ConfigFaultCfg,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 8],
+    pub _rsvd_tail: [u8; 10],
 }
 
 /// Boot-time seed for `ControlTable.config`; stamped pre-IRQ, then host-owned.

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -116,6 +116,13 @@ pub struct ConfigLoopPosition {
     pub accel_limit_q88: u16,
 }
 
+// Trajectory limits are clamps, not gains: at 0 the profile pins omega_ref
+// to 0 and velocity/position modes are inert even with live gains, so they
+// get real defaults (bench-validated on the SG90 rig: 1500 c/s, 15 c/s per
+// medium tick = 0 -> 1500 in 50 ms).
+pub const DEFAULT_VELOCITY_LIMIT_CPS: u16 = 1500;
+pub const DEFAULT_ACCEL_LIMIT_Q88: u16 = 3840;
+
 /// Current ceiling, stall policy, overcurrent trip window.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -39,9 +39,12 @@ pub struct ControlLifecycle {
     pub _rsvd_align: u8,
     #[ct_field(le = &config::addr::loop_current::DUTY_MAX_Q15, abs)]
     pub goal_duty: i16,
+    /// Phys-validated, soft-clamped: garbage outside the rails rejects; an
+    /// out-of-soft goal runs to the soft wall (trajectory clamp) instead of
+    /// bouncing the write.
     #[ct_field(
-        ge = &config::addr::pos_limits::POS_MIN_SOFT_COUNTS,
-        le = &config::addr::pos_limits::POS_MAX_SOFT_COUNTS,
+        ge = &config::addr::pos_limits::POS_MIN_PHYS_COUNTS,
+        le = &config::addr::pos_limits::POS_MAX_PHYS_COUNTS,
     )]
     pub goal_position: i32,
     pub goal_velocity: i32,

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -90,6 +90,7 @@ impl ControlTableCell {
             cfg.loop_current.duty_max_q15 = config::DEFAULT_DUTY_MAX_Q15;
             cfg.loop_position.velocity_limit_cps = config::DEFAULT_VELOCITY_LIMIT_CPS;
             cfg.loop_position.accel_limit_q88 = config::DEFAULT_ACCEL_LIMIT_Q88;
+            cfg.loop_position.pos_deadband_counts = config::DEFAULT_POS_DEADBAND_COUNTS;
             cfg.limits.current_limit_counts = config::DEFAULT_CURRENT_LIMIT_COUNTS;
             cfg.limits.drive_polarity = config::DEFAULT_DRIVE_POLARITY;
             cfg.limits.stall_omega_max_cps = config::DEFAULT_STALL_OMEGA_MAX_CPS;

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod hooks;
 pub mod profile;
 pub mod telemetry;
 
-pub use calib::{CalibMotor, CalibRegs, CalibSense, CalibWinding, PotLutBlock};
+pub use calib::{CalibKinematics, CalibMotor, CalibRegs, CalibSense, CalibWinding, PotLutBlock};
 pub use config::{
     BaudRate, ConfigCommon, ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent,
     ConfigLoopPosition, ConfigLoopVelocity, ConfigPosLimits, ConfigRegs, ConfigThermal,

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -262,7 +262,7 @@ mod tests {
             ])
         );
 
-        // goal_position's bounds are register-RHS (soft limits); they must not
+        // goal_position's bounds are register-RHS (phys limits); they must not
         // export as scalar bounds.
         let goal = by("goal_position");
         assert!(goal.writable);

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -85,7 +85,11 @@ impl ControlTableCell {
             cfg.common.response_deadline_us = defaults.response_deadline_us;
             // Core-owned safe defaults; gains stay at their zero seed so
             // every loop boots inert. Enum defaults are discriminant 0.
+            // Trajectory limits are clamps, not gains - zero would pin the
+            // profile at 0 and keep the loops inert even once gains land.
             cfg.loop_current.duty_max_q15 = config::DEFAULT_DUTY_MAX_Q15;
+            cfg.loop_position.velocity_limit_cps = config::DEFAULT_VELOCITY_LIMIT_CPS;
+            cfg.loop_position.accel_limit_q88 = config::DEFAULT_ACCEL_LIMIT_Q88;
             cfg.limits.current_limit_counts = config::DEFAULT_CURRENT_LIMIT_COUNTS;
             cfg.limits.drive_polarity = config::DEFAULT_DRIVE_POLARITY;
             cfg.limits.stall_omega_max_cps = config::DEFAULT_STALL_OMEGA_MAX_CPS;

--- a/ident/src/exp/endstop.rs
+++ b/ident/src/exp/endstop.rs
@@ -1,0 +1,256 @@
+//! End-stop finder + drive-direction check: open-loop, seek each mechanical
+//! hard-stop at modest duty, record the settled physical pot count at each
+//! end, and infer drive polarity from which rail a positive duty reached.
+//!
+//! Run with the pos guard disabled ([`super::RigParams::without_pos_guard`]):
+//! driving into the physical ends is the method. The current abort stays
+//! live so a stalled winding is not cooked; the seek duty mirrors
+//! resistance.rs's stall duty so the stall current stays well under it.
+
+use super::{Cmd, Experiment, RigParams};
+use crate::frame::TelemetrySnapshot;
+use crate::regs::control;
+
+pub struct EndstopCfg {
+    /// Seek drive toward each end, q15 (mirrors resistance's 26% seek).
+    pub seek_duty_q15: i16,
+    pub seek_poll_ms: u32,
+    /// Cool-down between the two seeks, duty 0.
+    pub rest_ms: u32,
+}
+
+impl Default for EndstopCfg {
+    fn default() -> Self {
+        Self {
+            seek_duty_q15: 8520,
+            seek_poll_ms: 30,
+            rest_ms: 300,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct EndstopResult {
+    pub pos_min_phys: i32,
+    pub pos_max_phys: i32,
+    /// true = positive duty increased position counts (matches the firmware
+    /// `ConfigLimits::drive_polarity` semantics).
+    pub drive_polarity: bool,
+    /// Larger of the two stall currents, counts - confirms the motor
+    /// actually loaded against a hard stop rather than settling idle.
+    pub i_stall_counts: i16,
+}
+
+enum Phase {
+    ModeWrite,
+    TorqueOn,
+    SeekSet,
+    SeekRead,
+    SeekEval,
+    RestOff,
+    RestPause,
+    FinishDuty,
+    FinishTorque,
+    Finished,
+}
+
+pub struct Endstop {
+    cfg: EndstopCfg,
+    phase: Phase,
+    stall_eps: u16,
+    stall_polls: u32,
+    dir_idx: u8,
+    last_pos: Option<u16>,
+    still: u32,
+    /// Settled pos + stall current recorded per seek direction: index 0 is
+    /// the positive-duty rail, index 1 the negative-duty rail.
+    rail: [Option<(u16, i16)>; 2],
+}
+
+impl Endstop {
+    pub fn new(cfg: EndstopCfg, params: &RigParams) -> Self {
+        Self {
+            cfg,
+            phase: Phase::ModeWrite,
+            stall_eps: params.stall_eps,
+            stall_polls: params.stall_polls,
+            dir_idx: 0,
+            last_pos: None,
+            still: 0,
+            rail: [None; 2],
+        }
+    }
+
+    fn dir(&self) -> i8 {
+        if self.dir_idx == 0 { 1 } else { -1 }
+    }
+
+    /// `None` until both rails have been reached (a guard abort leaves one
+    /// side unrecorded).
+    pub fn result(&self) -> Option<EndstopResult> {
+        let (p_pos, i_pos) = self.rail[0]?;
+        let (p_neg, i_neg) = self.rail[1]?;
+        let (p_pos, p_neg) = (p_pos as i32, p_neg as i32);
+        Some(EndstopResult {
+            pos_min_phys: p_pos.min(p_neg),
+            pos_max_phys: p_pos.max(p_neg),
+            drive_polarity: p_pos > p_neg,
+            i_stall_counts: i_pos.abs().max(i_neg.abs()),
+        })
+    }
+}
+
+impl Experiment for Endstop {
+    fn step(&mut self, obs: Option<&TelemetrySnapshot>) -> Cmd {
+        match self.phase {
+            Phase::ModeWrite => {
+                self.phase = Phase::TorqueOn;
+                Cmd::Write {
+                    reg: control::MODE,
+                    value: 0,
+                }
+            }
+            Phase::TorqueOn => {
+                self.phase = Phase::SeekSet;
+                Cmd::Write {
+                    reg: control::TORQUE_ENABLE,
+                    value: 1,
+                }
+            }
+            Phase::SeekSet => {
+                self.phase = Phase::SeekRead;
+                self.last_pos = None;
+                self.still = 0;
+                Cmd::Write {
+                    reg: control::GOAL_DUTY,
+                    value: self.dir() as i32 * self.cfg.seek_duty_q15 as i32,
+                }
+            }
+            Phase::SeekRead => {
+                self.phase = Phase::SeekEval;
+                Cmd::Read
+            }
+            Phase::SeekEval => {
+                if let Some(o) = obs {
+                    if let Some(last) = self.last_pos
+                        && o.pos.abs_diff(last) <= self.stall_eps
+                    {
+                        self.still += 1;
+                    } else {
+                        self.still = 0;
+                    }
+                    self.last_pos = Some(o.pos);
+                    if self.still >= self.stall_polls {
+                        self.rail[self.dir_idx as usize] = Some((o.pos, o.i_mean_counts));
+                        self.phase = Phase::RestOff;
+                        return Cmd::Pause { ms: 0 };
+                    }
+                }
+                self.phase = Phase::SeekRead;
+                Cmd::Pause {
+                    ms: self.cfg.seek_poll_ms,
+                }
+            }
+            Phase::RestOff => {
+                self.phase = Phase::RestPause;
+                Cmd::Write {
+                    reg: control::GOAL_DUTY,
+                    value: 0,
+                }
+            }
+            Phase::RestPause => {
+                if self.dir_idx == 0 {
+                    self.dir_idx = 1;
+                    self.phase = Phase::SeekSet;
+                } else {
+                    self.phase = Phase::FinishDuty;
+                }
+                Cmd::Pause {
+                    ms: self.cfg.rest_ms,
+                }
+            }
+            Phase::FinishDuty => {
+                self.phase = Phase::FinishTorque;
+                Cmd::Write {
+                    reg: control::GOAL_DUTY,
+                    value: 0,
+                }
+            }
+            Phase::FinishTorque => {
+                self.phase = Phase::Finished;
+                Cmd::Write {
+                    reg: control::TORQUE_ENABLE,
+                    value: 0,
+                }
+            }
+            Phase::Finished => Cmd::Done,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::testkit::{FakeServo, pump};
+    use super::super::{Guarded, RigParams};
+    use super::*;
+
+    fn run(servo: &mut FakeServo) -> (Endstop, Vec<String>) {
+        let params = RigParams::default().without_pos_guard();
+        let mut exp = Guarded::new(Endstop::new(EndstopCfg::default(), &params), params);
+        let log = pump(&mut exp, servo, 2_000_000);
+        assert!(exp.abort().is_none(), "abort: {:?}", exp.abort());
+        (exp.into_inner(), log)
+    }
+
+    #[test]
+    fn recovers_rails_and_polarity() {
+        let mut servo = FakeServo::new(3.37);
+        servo.ends = (321.0, 3702.0);
+        servo.pos = 2000.0;
+        let (exp, log) = run(&mut servo);
+        assert!(!log.contains(&"OVERRUN".to_string()));
+        let r = exp.result().expect("both rails found");
+        assert!((r.pos_min_phys - 321).abs() <= 3, "min {}", r.pos_min_phys);
+        assert!((r.pos_max_phys - 3702).abs() <= 3, "max {}", r.pos_max_phys);
+        assert!(r.drive_polarity, "positive duty should raise counts");
+        assert!(r.i_stall_counts > 0, "stall current {}", r.i_stall_counts);
+    }
+
+    #[test]
+    fn polarity_inference_flips_when_wiring_reversed() {
+        let mut servo = FakeServo::new(3.37);
+        servo.ends = (321.0, 3702.0);
+        servo.pos = 2000.0;
+        servo.drive_polarity = false;
+        let (exp, _) = run(&mut servo);
+        let r = exp.result().expect("both rails found");
+        assert!(!r.drive_polarity, "reversed wiring must flip inference");
+        // rails ordered regardless of which duty sign reached which end
+        assert!(r.pos_min_phys < r.pos_max_phys);
+        assert!((r.pos_min_phys - 321).abs() <= 3, "min {}", r.pos_min_phys);
+        assert!((r.pos_max_phys - 3702).abs() <= 3, "max {}", r.pos_max_phys);
+    }
+
+    #[test]
+    fn command_choreography_is_safe() {
+        let mut servo = FakeServo::new(3.37);
+        let (_, log) = run(&mut servo);
+        // torque on before any nonzero duty
+        let torque_on = log
+            .iter()
+            .position(|l| l == "write torque_enable 1")
+            .expect("torque on");
+        let first_duty = log
+            .iter()
+            .position(|l| l.starts_with("write goal_duty") && !l.ends_with(" 0"))
+            .expect("a drive command");
+        assert!(torque_on < first_duty);
+        // rest between the two seeks
+        let zeros = log.iter().filter(|l| *l == "write goal_duty 0").count();
+        assert!(zeros >= 2, "one rest plus final safety, got {zeros}");
+        // final safety pair
+        let tail: Vec<&String> = log.iter().rev().take(2).collect();
+        assert_eq!(*tail[1], "write goal_duty 0");
+        assert_eq!(*tail[0], "write torque_enable 0");
+    }
+}

--- a/ident/src/exp/ladder.rs
+++ b/ident/src/exp/ladder.rs
@@ -23,8 +23,8 @@ pub struct LadderCfg {
     pub seek_duty_q15: i16,
     /// Sweep start/stop distance from the guard edges, counts. OpenLoop
     /// cannot brake: a duty-0 at speed coasts several hundred counts, and
-    /// this absorbs it (bench: the 26% sweep-end coast breached a 600
-    /// margin by 18 counts).
+    /// this absorbs it (bench: the 64% sweep-end coast on a healthy gear
+    /// ran ~970 counts through the rest pause, breaching a 900 margin).
     pub stop_margin: u16,
     pub poll_ms: u32,
     pub seek_poll_ms: u32,
@@ -47,7 +47,7 @@ impl Default for LadderCfg {
             // 26/33/40/47/55/64% of 32767
             rungs_q15: vec![8520, 10813, 13107, 15400, 18022, 20971],
             seek_duty_q15: 8520,
-            stop_margin: 900,
+            stop_margin: 1300,
             poll_ms: 2,
             seek_poll_ms: 30,
             rest_ms: 300,
@@ -461,8 +461,11 @@ mod tests {
         let mut clean = physical_servo();
         let (exp_clean, _) = run_e3(&mut clean, RigParams::default());
         let mut glitched = physical_servo();
-        // +80-count pot artifact strictly inside the masked slip zone
-        glitched.glitch_zone = Some((1300.0, 1500.0));
+        // +80-count pot artifact strictly inside the masked slip zone:
+        // above the sweep-start threshold (band lo + stop_margin) so the
+        // seek geometry matches the clean run, and low enough that the
+        // +80 readings also stay inside the mask
+        glitched.glitch_zone = Some((1460.0, 1560.0));
         let (exp_glitch, _) = run_e3(&mut glitched, RigParams::default());
         let a = exp_clean.fit(3.37).unwrap();
         let b = exp_glitch.fit(3.37).unwrap();

--- a/ident/src/exp/mod.rs
+++ b/ident/src/exp/mod.rs
@@ -20,6 +20,7 @@
 
 pub mod bias;
 pub mod breakaway;
+pub mod endstop;
 pub mod inertia;
 pub mod ladder;
 pub mod resistance;
@@ -63,6 +64,11 @@ pub struct RigParams {
     pub settle_windows: u32,
     /// One ident aggregate window in ms: 16 fast ticks at ~20 kHz.
     pub agg_period_ms: f64,
+    /// End-stop stall detect: a seek read whose pos moved <= `stall_eps`
+    /// counts from the prior one counts as still; `stall_polls` consecutive
+    /// still reads declare the mechanical rail.
+    pub stall_eps: u16,
+    pub stall_polls: u32,
 }
 
 impl Default for RigParams {
@@ -73,6 +79,8 @@ impl Default for RigParams {
             slip: (1250, 1650),
             settle_windows: 5,
             agg_period_ms: 0.8,
+            stall_eps: 3,
+            stall_polls: 8,
         }
     }
 }

--- a/ident/src/exp/mod.rs
+++ b/ident/src/exp/mod.rs
@@ -24,6 +24,7 @@ pub mod endstop;
 pub mod inertia;
 pub mod ladder;
 pub mod resistance;
+pub mod sweep;
 pub mod verify;
 
 use crate::frame::{SeqUnwrap, TelemetrySnapshot};

--- a/ident/src/exp/sweep.rs
+++ b/ident/src/exp/sweep.rs
@@ -1,4 +1,4 @@
-//! Dedicated constant-duty ripple sweep: one clean rail-to-rail traverse
+//! Dedicated constant-duty ripple capture: one clean constant-duty traverse
 //! whose per-tick TEL current carries an uninterrupted commutation-ripple
 //! signal for the tachometer and pot LUT.
 //!
@@ -11,34 +11,34 @@
 //! so the pump drains TEL continuously and the whole traverse lands as a
 //! single long contiguous run.
 //!
+//! No positioning or speed probe here: the caller positions to the capture
+//! start rail (with TEL off, where polling is free) and sizes capture_ms from
+//! a measured speed so the traverse stays off BOTH mechanical rails - the
+//! clone can jam at either end, so the capture must never reach a stop.
+//!
 //! No safety Reads during the traverse (they would re-fragment the capture):
-//! the firmware current limit + fault protection are the winding's backstop,
-//! and the identical seek duty was just proven safe against both hard stops
-//! by [`super::endstop`]. The caller parks duty 0 + torque off on exit.
+//! the time-bounded, speed-sized duration is the backstop, and the firmware
+//! current limit + fault protection guard the winding. The caller parks duty 0
+//! + torque off on exit.
 
 use super::{Cmd, Experiment};
 use crate::frame::TelemetrySnapshot;
 use crate::regs::control;
 
 pub struct SweepCfg {
-    /// Constant sweep drive magnitude, q15 (mirrors the end-stop seek duty so
+    /// Constant capture drive magnitude, q15 (mirrors the end-stop seek duty so
     /// the winding load is the same proven-safe operating point).
     pub duty_q15: i16,
-    /// Drive to the start rail for this long before the capturing traverse, so
-    /// the sweep begins from a known end rather than mid-travel.
-    pub prime_ms: u32,
-    /// Constant-duty traverse duration. Longer than a full traverse takes: the
-    /// tail dwells stalled at the far rail and is trimmed by the moving-run
-    /// selector, so overshoot is free.
-    pub sweep_ms: u32,
+    /// Constant-duty capture duration. The caller sizes this from a measured
+    /// speed so the motion covers the count-inset span without reaching a rail.
+    pub capture_ms: u32,
 }
 
 impl Default for SweepCfg {
     fn default() -> Self {
         Self {
             duty_q15: 8520,
-            prime_ms: 500,
-            sweep_ms: 800,
+            capture_ms: 800,
         }
     }
 }
@@ -46,20 +46,18 @@ impl Default for SweepCfg {
 enum Phase {
     ModeWrite,
     TorqueOn,
-    PrimeDuty,
-    PrimePause,
-    SweepDuty,
-    SweepPause,
-    FinishDuty,
-    FinishTorque,
+    CaptureDuty,
+    CapturePause,
+    ZeroDuty,
+    TorqueOff,
     Finished,
 }
 
 pub struct Sweep {
     cfg: SweepCfg,
     phase: Phase,
-    /// Duty sign that drives pos toward the far rail (the capture direction);
-    /// the caller derives it from the measured drive polarity.
+    /// Duty sign that drives pos toward the capture end (increasing pos); the
+    /// caller derives it from the measured drive polarity.
     sweep_sign: i8,
 }
 
@@ -72,7 +70,7 @@ impl Sweep {
         }
     }
 
-    fn sweep_duty(&self) -> i32 {
+    fn capture_duty(&self) -> i32 {
         self.sweep_sign as i32 * self.cfg.duty_q15 as i32
     }
 }
@@ -88,46 +86,33 @@ impl Experiment for Sweep {
                 }
             }
             Phase::TorqueOn => {
-                self.phase = Phase::PrimeDuty;
+                self.phase = Phase::CaptureDuty;
                 Cmd::Write {
                     reg: control::TORQUE_ENABLE,
                     value: 1,
                 }
             }
-            Phase::PrimeDuty => {
-                self.phase = Phase::PrimePause;
+            Phase::CaptureDuty => {
+                self.phase = Phase::CapturePause;
                 Cmd::Write {
                     reg: control::GOAL_DUTY,
-                    value: -self.sweep_duty(),
+                    value: self.capture_duty(),
                 }
             }
-            Phase::PrimePause => {
-                self.phase = Phase::SweepDuty;
+            Phase::CapturePause => {
+                self.phase = Phase::ZeroDuty;
                 Cmd::Pause {
-                    ms: self.cfg.prime_ms,
+                    ms: self.cfg.capture_ms,
                 }
             }
-            Phase::SweepDuty => {
-                self.phase = Phase::SweepPause;
-                Cmd::Write {
-                    reg: control::GOAL_DUTY,
-                    value: self.sweep_duty(),
-                }
-            }
-            Phase::SweepPause => {
-                self.phase = Phase::FinishDuty;
-                Cmd::Pause {
-                    ms: self.cfg.sweep_ms,
-                }
-            }
-            Phase::FinishDuty => {
-                self.phase = Phase::FinishTorque;
+            Phase::ZeroDuty => {
+                self.phase = Phase::TorqueOff;
                 Cmd::Write {
                     reg: control::GOAL_DUTY,
                     value: 0,
                 }
             }
-            Phase::FinishTorque => {
+            Phase::TorqueOff => {
                 self.phase = Phase::Finished;
                 Cmd::Write {
                     reg: control::TORQUE_ENABLE,
@@ -155,7 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn choreography_is_safe_and_primes_opposite_the_sweep() {
+    fn choreography_is_safe() {
         let log = run(1);
         // mode set before anything drives
         assert_eq!(log[0], "write mode 0");
@@ -169,16 +154,12 @@ mod tests {
             .position(|l| l.starts_with("write goal_duty") && !l.ends_with(" 0"))
             .unwrap();
         assert!(torque_on < first_duty);
-        // prime drives negative (toward the start rail), sweep positive
+        // single nonzero capture duty (no prime): exactly one drive write
         let duties: Vec<&String> = log
             .iter()
             .filter(|l| l.starts_with("write goal_duty"))
             .collect();
-        assert_eq!(
-            duties[0], "write goal_duty -8520",
-            "prime toward start rail"
-        );
-        assert_eq!(duties[1], "write goal_duty 8520", "sweep toward far rail");
+        assert_eq!(duties[0], "write goal_duty 8520", "capture toward far rail");
         // ends parked: duty 0 then torque off
         let tail: Vec<&String> = log.iter().rev().take(2).collect();
         assert_eq!(*tail[1], "write goal_duty 0");
@@ -186,13 +167,18 @@ mod tests {
     }
 
     #[test]
-    fn negative_polarity_flips_prime_and_sweep() {
-        let log = run(-1);
-        let duties: Vec<&String> = log
+    fn negative_sign_flips_capture_duty() {
+        let pos = run(1);
+        let neg = run(-1);
+        let pos_duty = pos
             .iter()
-            .filter(|l| l.starts_with("write goal_duty"))
-            .collect();
-        assert_eq!(duties[0], "write goal_duty 8520");
-        assert_eq!(duties[1], "write goal_duty -8520");
+            .find(|l| l.starts_with("write goal_duty") && !l.ends_with(" 0"))
+            .unwrap();
+        let neg_duty = neg
+            .iter()
+            .find(|l| l.starts_with("write goal_duty") && !l.ends_with(" 0"))
+            .unwrap();
+        assert_eq!(pos_duty, "write goal_duty 8520");
+        assert_eq!(neg_duty, "write goal_duty -8520");
     }
 }

--- a/ident/src/exp/sweep.rs
+++ b/ident/src/exp/sweep.rs
@@ -1,0 +1,198 @@
+//! Dedicated constant-duty ripple sweep: one clean rail-to-rail traverse
+//! whose per-tick TEL current carries an uninterrupted commutation-ripple
+//! signal for the tachometer and pot LUT.
+//!
+//! Why a separate motion and not the end-stop seek: the seek must poll pos to
+//! detect each stall, and every poll is a bus read the pump cannot drain TEL
+//! through - so the seek capture is shredded into sub-millisecond seq-
+//! contiguous fragments, too short for the autocorr window, and it spends
+//! most of its time dwelling stalled at a rail (flat current, no ripple).
+//! This experiment instead drives one fixed duty and does nothing but Pause,
+//! so the pump drains TEL continuously and the whole traverse lands as a
+//! single long contiguous run.
+//!
+//! No safety Reads during the traverse (they would re-fragment the capture):
+//! the firmware current limit + fault protection are the winding's backstop,
+//! and the identical seek duty was just proven safe against both hard stops
+//! by [`super::endstop`]. The caller parks duty 0 + torque off on exit.
+
+use super::{Cmd, Experiment};
+use crate::frame::TelemetrySnapshot;
+use crate::regs::control;
+
+pub struct SweepCfg {
+    /// Constant sweep drive magnitude, q15 (mirrors the end-stop seek duty so
+    /// the winding load is the same proven-safe operating point).
+    pub duty_q15: i16,
+    /// Drive to the start rail for this long before the capturing traverse, so
+    /// the sweep begins from a known end rather than mid-travel.
+    pub prime_ms: u32,
+    /// Constant-duty traverse duration. Longer than a full traverse takes: the
+    /// tail dwells stalled at the far rail and is trimmed by the moving-run
+    /// selector, so overshoot is free.
+    pub sweep_ms: u32,
+}
+
+impl Default for SweepCfg {
+    fn default() -> Self {
+        Self {
+            duty_q15: 8520,
+            prime_ms: 500,
+            sweep_ms: 800,
+        }
+    }
+}
+
+enum Phase {
+    ModeWrite,
+    TorqueOn,
+    PrimeDuty,
+    PrimePause,
+    SweepDuty,
+    SweepPause,
+    FinishDuty,
+    FinishTorque,
+    Finished,
+}
+
+pub struct Sweep {
+    cfg: SweepCfg,
+    phase: Phase,
+    /// Duty sign that drives pos toward the far rail (the capture direction);
+    /// the caller derives it from the measured drive polarity.
+    sweep_sign: i8,
+}
+
+impl Sweep {
+    pub fn new(cfg: SweepCfg, sweep_sign: i8) -> Self {
+        Self {
+            cfg,
+            phase: Phase::ModeWrite,
+            sweep_sign: if sweep_sign < 0 { -1 } else { 1 },
+        }
+    }
+
+    fn sweep_duty(&self) -> i32 {
+        self.sweep_sign as i32 * self.cfg.duty_q15 as i32
+    }
+}
+
+impl Experiment for Sweep {
+    fn step(&mut self, _obs: Option<&TelemetrySnapshot>) -> Cmd {
+        match self.phase {
+            Phase::ModeWrite => {
+                self.phase = Phase::TorqueOn;
+                Cmd::Write {
+                    reg: control::MODE,
+                    value: 0,
+                }
+            }
+            Phase::TorqueOn => {
+                self.phase = Phase::PrimeDuty;
+                Cmd::Write {
+                    reg: control::TORQUE_ENABLE,
+                    value: 1,
+                }
+            }
+            Phase::PrimeDuty => {
+                self.phase = Phase::PrimePause;
+                Cmd::Write {
+                    reg: control::GOAL_DUTY,
+                    value: -self.sweep_duty(),
+                }
+            }
+            Phase::PrimePause => {
+                self.phase = Phase::SweepDuty;
+                Cmd::Pause {
+                    ms: self.cfg.prime_ms,
+                }
+            }
+            Phase::SweepDuty => {
+                self.phase = Phase::SweepPause;
+                Cmd::Write {
+                    reg: control::GOAL_DUTY,
+                    value: self.sweep_duty(),
+                }
+            }
+            Phase::SweepPause => {
+                self.phase = Phase::FinishDuty;
+                Cmd::Pause {
+                    ms: self.cfg.sweep_ms,
+                }
+            }
+            Phase::FinishDuty => {
+                self.phase = Phase::FinishTorque;
+                Cmd::Write {
+                    reg: control::GOAL_DUTY,
+                    value: 0,
+                }
+            }
+            Phase::FinishTorque => {
+                self.phase = Phase::Finished;
+                Cmd::Write {
+                    reg: control::TORQUE_ENABLE,
+                    value: 0,
+                }
+            }
+            Phase::Finished => Cmd::Done,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::testkit::{FakeServo, pump};
+    use super::*;
+
+    fn run(sweep_sign: i8) -> Vec<String> {
+        let mut servo = FakeServo::new(3.37);
+        servo.ends = (321.0, 3702.0);
+        servo.pos = 2000.0;
+        let mut exp = Sweep::new(SweepCfg::default(), sweep_sign);
+        let log = pump(&mut exp, &mut servo, 2_000);
+        assert!(!log.contains(&"OVERRUN".to_string()));
+        log
+    }
+
+    #[test]
+    fn choreography_is_safe_and_primes_opposite_the_sweep() {
+        let log = run(1);
+        // mode set before anything drives
+        assert_eq!(log[0], "write mode 0");
+        // torque on before any nonzero duty
+        let torque_on = log
+            .iter()
+            .position(|l| l == "write torque_enable 1")
+            .unwrap();
+        let first_duty = log
+            .iter()
+            .position(|l| l.starts_with("write goal_duty") && !l.ends_with(" 0"))
+            .unwrap();
+        assert!(torque_on < first_duty);
+        // prime drives negative (toward the start rail), sweep positive
+        let duties: Vec<&String> = log
+            .iter()
+            .filter(|l| l.starts_with("write goal_duty"))
+            .collect();
+        assert_eq!(
+            duties[0], "write goal_duty -8520",
+            "prime toward start rail"
+        );
+        assert_eq!(duties[1], "write goal_duty 8520", "sweep toward far rail");
+        // ends parked: duty 0 then torque off
+        let tail: Vec<&String> = log.iter().rev().take(2).collect();
+        assert_eq!(*tail[1], "write goal_duty 0");
+        assert_eq!(*tail[0], "write torque_enable 0");
+    }
+
+    #[test]
+    fn negative_polarity_flips_prime_and_sweep() {
+        let log = run(-1);
+        let duties: Vec<&String> = log
+            .iter()
+            .filter(|l| l.starts_with("write goal_duty"))
+            .collect();
+        assert_eq!(duties[0], "write goal_duty 8520");
+        assert_eq!(duties[1], "write goal_duty -8520");
+    }
+}

--- a/ident/src/exp/testkit.rs
+++ b/ident/src/exp/testkit.rs
@@ -34,6 +34,9 @@ pub struct FakeServo {
     pub glitch_zone: Option<(f64, f64)>,
     pub pos: f64,
     pub ends: (f64, f64),
+    /// Wiring convention: false inverts duty's effect on motion, so the
+    /// endstop experiment must infer the flipped drive_polarity.
+    pub drive_polarity: bool,
     pub pos_noise: f64,
     pub fault_at_ms: Option<f64>,
     pub torque: bool,
@@ -66,6 +69,7 @@ impl FakeServo {
             glitch_zone: None,
             pos: 2400.0,
             ends: (200.0, 4000.0),
+            drive_polarity: true,
             pos_noise: 0.0,
             fault_at_ms: None,
             torque: false,
@@ -98,17 +102,18 @@ impl FakeServo {
         if !self.torque || self.duty == 0 || self.duty.unsigned_abs() < self.breakaway_q15 as u16 {
             return 0.0;
         }
-        let stalled = (self.pos <= self.ends.0 && self.duty < 0)
-            || (self.pos >= self.ends.1 && self.duty > 0);
+        let vsign = self.duty.signum() as f64 * if self.drive_polarity { 1.0 } else { -1.0 };
+        let stalled =
+            (self.pos <= self.ends.0 && vsign < 0.0) || (self.pos >= self.ends.1 && vsign > 0.0);
         if stalled {
             return 0.0;
         }
         if self.physical_motion {
             let v = self.duty.unsigned_abs() as f64 / 32767.0 * self.vbus;
             let mag = ((v - self.r * self.fc) / (self.ke + self.r * self.fv)).max(0.0);
-            mag * self.duty.signum() as f64
+            mag * vsign
         } else {
-            self.duty as f64 / 32767.0 * self.free_speed
+            self.duty.unsigned_abs() as f64 / 32767.0 * self.free_speed * vsign
         }
     }
 

--- a/ident/src/exp/verify.rs
+++ b/ident/src/exp/verify.rs
@@ -368,8 +368,16 @@ pub struct VerifyVelocityCfg {
     pub poll_ms: u32,
     pub rest_ms: u32,
     pub seek_poll_ms: u32,
-    /// Travel margin off each guard edge where a leg turns around.
+    /// Travel margin off each guard edge where a leg turns around. Wide
+    /// enough that goal-0 braking on unproven gains stays inside the
+    /// guard through the rest pause (no envelope read until the next leg).
     pub margin: u16,
+    /// Park distance off the low guard edge for the open-loop seek.
+    /// Separate from `margin`: the seek cannot brake, and the coast after
+    /// seek-off runs through the mode-switch writes with no envelope read
+    /// in between (bench: a 26% seek parked at margin 350 coasted into
+    /// the low rail and the first leg read aborted at pos 8).
+    pub seek_margin: u16,
     /// Head trim before the slope fit (trajectory accel ramp), ms.
     pub accel_trim_ms: f64,
     pub tol: f64,
@@ -385,7 +393,8 @@ impl Default for VerifyVelocityCfg {
             poll_ms: 4,
             rest_ms: 300,
             seek_poll_ms: 30,
-            margin: 350,
+            margin: 550,
+            seek_margin: 1300,
             accel_trim_ms: 250.0,
             tol: 0.15,
             leg_cap_polls: 4000,
@@ -565,7 +574,7 @@ impl Experiment for VerifyVelocity {
             VPhase::SeekEval => {
                 let mut parked = false;
                 if let Some(o) = obs {
-                    parked = o.pos <= self.band.0 + self.cfg.margin;
+                    parked = o.pos <= self.band.0 + self.cfg.seek_margin;
                     if let Some(last) = self.last_pos
                         && o.pos.abs_diff(last) <= 3
                     {

--- a/ident/src/gains.rs
+++ b/ident/src/gains.rs
@@ -17,6 +17,14 @@
 /// `--l-henries` default.
 pub const DEFAULT_L_HENRIES: f64 = 0.5e-3;
 
+/// Anti-hunt deadband policy. The deadband must exceed pot-noise excursions
+/// or the hold chatters (bench: 16 counts held clean at sigma 6.9 = 2.3
+/// sigma). Hold coasts on position rest alone (firmware position.rs), so the
+/// only synthesized field is the deadband; the floor keeps a suspiciously
+/// quiet E0 from synthesizing a deadband too tight to engage.
+const DEADBAND_SIGMA_MULT: f64 = 2.5;
+const DEADBAND_FLOOR_COUNTS: f64 = 4.0;
+
 /// SI inductance -> count domain. vcounts and ccounts share the ADC lsb
 /// (both channels reference VDD), so it cancels and only the front-end
 /// scales remain:
@@ -103,6 +111,9 @@ pub struct GainSet {
     /// Projected omega noise from the pot, c/s: l2 * sigma_theta per
     /// correct step - report fodder, not a table field.
     pub omega_noise_cps: f64,
+    /// Anti-hunt park window, counts: noise-derived lower bound (an
+    /// application may widen it for a softer, quieter hold).
+    pub pos_deadband: f64,
 }
 
 /// Pole placement.
@@ -166,6 +177,7 @@ pub fn synthesize(p: &PlantParams, t: &BwTargets) -> GainSet {
         fric_fv: p.fv,
         fric_breakaway: 0.0,
         omega_noise_cps: l2 * p.sigma_theta,
+        pos_deadband: (DEADBAND_SIGMA_MULT * p.sigma_theta).max(DEADBAND_FLOOR_COUNTS),
     }
 }
 
@@ -216,6 +228,7 @@ pub struct EncodedGains {
     pub v_kaw_q412: Encoded,
     pub j_ff_q88: Encoded,
     pub p_kp_q88: Encoded,
+    pub pos_deadband_counts: Encoded,
     pub l1_q016: Encoded,
     pub l2_q88: Encoded,
     pub l3_q88: Encoded,
@@ -231,7 +244,7 @@ pub struct EncodedGains {
 impl EncodedGains {
     /// (name, field) pairs in table-write order - the report and the CLI
     /// write-back both iterate this.
-    pub fn fields(&self) -> [(&'static str, Encoded); 18] {
+    pub fn fields(&self) -> [(&'static str, Encoded); 19] {
         [
             ("r_q12", self.r_q12),
             ("ke_vpc_q", self.ke_vpc_q),
@@ -248,6 +261,7 @@ impl EncodedGains {
             ("v_kaw_q412", self.v_kaw_q412),
             ("j_ff_q88", self.j_ff_q88),
             ("p_kp_q88", self.p_kp_q88),
+            ("pos_deadband_counts", self.pos_deadband_counts),
             ("l1_q016", self.l1_q016),
             ("l2_q88", self.l2_q88),
             ("l3_q88", self.l3_q88),
@@ -265,6 +279,7 @@ pub fn encode(g: &GainSet) -> EncodedGains {
         v_kaw_q412: enc(g.v_kaw, 4096.0),
         j_ff_q88: enc(g.j_ff, 256.0),
         p_kp_q88: enc(g.p_kp, 256.0),
+        pos_deadband_counts: enc(g.pos_deadband, 1.0),
         l1_q016: enc(g.l1, 65536.0),
         l2_q88: enc(g.l2, 256.0),
         l3_q88: enc(g.l3, 256.0),
@@ -345,6 +360,19 @@ mod tests {
         assert!(g.l1 > 0.05 && g.l1 < 0.5, "l1={}", g.l1);
         assert!(g.l2 > 1.0 && g.l2 < 50.0, "l2={}", g.l2);
         assert!(g.l3 > 0.1 && g.l3 < 20.0, "l3={}", g.l3);
+        // sigma 1.0: the deadband sits on its floor
+        assert_eq!(g.pos_deadband, DEADBAND_FLOOR_COUNTS);
+        // rig-scale noise: the noise-derived deadband clears the floor
+        let noisy = PlantParams {
+            sigma_theta: 6.9,
+            ..rig_plant()
+        };
+        let g = synthesize(&noisy, &BwTargets::default());
+        assert!(
+            (g.pos_deadband - 2.5 * 6.9).abs() < 1e-9,
+            "deadband={}",
+            g.pos_deadband
+        );
     }
 
     /// Mirror of estimator/fusion.rs (Q3.13 b_i coupling), integer-exact.

--- a/ident/src/gains.rs
+++ b/ident/src/gains.rs
@@ -4,12 +4,13 @@
 //! updates (current.rs / velocity.rs / fusion.rs) and is the authority on
 //! stability - the placement formulas are only as good as those runs.
 //!
-//! Q formats (verified against firmware/lib/core, commit-4 fusion encoding):
+//! Q formats (verified against firmware/lib/core, Q3.13 fusion coupling):
 //! i_kp_q88 vcounts/ccount; i_ki/i_kaw_q412 per FAST tick; v_kp_q88
 //! ccounts per c/s; v_ki/v_kaw_q412 per MEDIUM tick; j_ff_q88 = 256/B;
 //! p_kp_q88 c/s per count; l1_q016; l2_q88 c/s per count; l3_q88 cc per
-//! count; b_i_q016 = round(B*65536); r_q12/ke_vpc_q Q4.12; recip_ke_q
-//! Q6.10; fric_fv_q016 Q0.16; fric_fc/breakaway whole ccounts.
+//! count; b_i_q313 = round(B*8192) (rig B runs ~3.4, Q0.16 saturated);
+//! r_q12/ke_vpc_q Q4.12; recip_ke_q Q6.10; fric_fv_q016 Q0.16;
+//! fric_fc/breakaway whole ccounts.
 
 /// Bench model-card inductance (SG90 clone donor motor), henries. L is not
 /// identifiable from the fixed-phase shunt sampling - this is the CLI
@@ -218,7 +219,7 @@ pub struct EncodedGains {
     pub l1_q016: Encoded,
     pub l2_q88: Encoded,
     pub l3_q88: Encoded,
-    pub b_i_q016: Encoded,
+    pub b_i_q313: Encoded,
     pub r_q12: Encoded,
     pub ke_vpc_q: Encoded,
     pub recip_ke_q: Encoded,
@@ -235,7 +236,7 @@ impl EncodedGains {
             ("r_q12", self.r_q12),
             ("ke_vpc_q", self.ke_vpc_q),
             ("recip_ke_q", self.recip_ke_q),
-            ("b_i_q016", self.b_i_q016),
+            ("b_i_q313", self.b_i_q313),
             ("fric_fc_counts", self.fric_fc_counts),
             ("fric_fv_q016", self.fric_fv_q016),
             ("fric_breakaway_counts", self.fric_breakaway_counts),
@@ -267,7 +268,7 @@ pub fn encode(g: &GainSet) -> EncodedGains {
         l1_q016: enc(g.l1, 65536.0),
         l2_q88: enc(g.l2, 256.0),
         l3_q88: enc(g.l3, 256.0),
-        b_i_q016: enc(g.b, 65536.0),
+        b_i_q313: enc(g.b, 8192.0),
         r_q12: enc(g.r_vpc, 4096.0),
         ke_vpc_q: enc(g.ke_vpc, 4096.0),
         recip_ke_q: enc(g.recip_ke, 1024.0),
@@ -321,11 +322,11 @@ mod tests {
             assert!(!f.saturated, "{name} saturated: {f:?}");
             assert!(f.quantization_pct < 5.0, "{name} quant {f:?}");
         }
-        // B too big for Q0.16 saturates and flags, never wraps
-        let big = GainSet { b: 1.5, ..g };
+        // B too big for Q3.13 saturates and flags, never wraps
+        let big = GainSet { b: 9.0, ..g };
         let e = encode(&big);
-        assert_eq!(e.b_i_q016.raw, u16::MAX);
-        assert!(e.b_i_q016.saturated);
+        assert_eq!(e.b_i_q313.raw, u16::MAX);
+        assert!(e.b_i_q313.saturated);
         // negative clamps to zero flagged
         let neg = GainSet { fric_fc: -3.0, ..g };
         assert!(encode(&neg).fric_fc_counts.saturated);
@@ -346,7 +347,7 @@ mod tests {
         assert!(g.l3 > 0.1 && g.l3 < 20.0, "l3={}", g.l3);
     }
 
-    /// Mirror of estimator/fusion.rs (commit-4 encoding), integer-exact.
+    /// Mirror of estimator/fusion.rs (Q3.13 b_i coupling), integer-exact.
     struct FusionMirror {
         theta: i32,
         omega: i32,
@@ -389,7 +390,7 @@ mod tests {
                 .clamp(-ACCEL_LIM, ACCEL_LIM);
             self.omega = self
                 .omega
-                .saturating_add(q_mul(g.b_i as i32, accel, 0))
+                .saturating_add(q_mul(g.b_i as i32, accel, 0).saturating_mul(1 << 3))
                 .clamp(-OMEGA_LIM, OMEGA_LIM);
             self.theta = self
                 .theta
@@ -413,7 +414,7 @@ mod tests {
 
     fn fusion_raw(e: &EncodedGains) -> FusionRaw {
         FusionRaw {
-            b_i: e.b_i_q016.raw,
+            b_i: e.b_i_q313.raw,
             l1: e.l1_q016.raw,
             l2: e.l2_q88.raw,
             l3: e.l3_q88.raw,

--- a/ident/src/kinematics.rs
+++ b/ident/src/kinematics.rs
@@ -58,6 +58,29 @@ pub fn gear_ratio_centi(motor_rev_s: f64, pot_omega_cps: f64, deg_per_count: f64
     centi.min(u16::MAX as f64) as u16
 }
 
+/// Total motor revs over a FULL rail-to-rail traverse, extrapolated from a
+/// partial (soft-bounded) sweep via the per-count rate: anchor-free geometry,
+/// so a run turning `motor_revs_run` over `pot_disp` counts scales to the whole
+/// `count_span`. 0.0 when the sweep covered no counts or the span is non-finite.
+pub fn full_span_motor_revs(motor_revs_run: f64, pot_disp: f64, count_span: f64) -> f64 {
+    if pot_disp > 0.0 && count_span.is_finite() {
+        motor_revs_run * count_span / pot_disp
+    } else {
+        0.0
+    }
+}
+
+/// Output travel (deg) implied by a counted gear ratio and the full-traverse
+/// motor revs: `motor_revs_full * 360 / gear_ratio`. The inverse of the
+/// travel-anchored gear derivation. 0.0 on a zero/non-finite gear ratio.
+pub fn travel_deg_from_gear(motor_revs_full: f64, gear_ratio: f64) -> f64 {
+    if gear_ratio > 0.0 && gear_ratio.is_finite() {
+        motor_revs_full * 360.0 / gear_ratio
+    } else {
+        0.0
+    }
+}
+
 /// Assemble the three encoded values from the endstop sweep and the
 /// human-supplied travel angles.
 pub fn resolve(
@@ -131,6 +154,38 @@ mod tests {
     #[test]
     fn gear_ratio_saturates_to_u16() {
         assert_eq!(gear_ratio_centi(1e9, 1.0, 0.05), u16::MAX);
+    }
+
+    #[test]
+    fn travel_from_gear_round_trips_through_gear_ratio_centi() {
+        // gear 150, motor_revs_full 79.1667 -> travel 190 deg over a 3900-count
+        // span; feeding count_span as pot speed and travel/count_span as dpc
+        // recovers the gear (gear_ratio_centi = motor_revs_full*360/travel).
+        let motor_revs_full = 79.166_667;
+        let gear = 150.0;
+        let count_span = 3900.0;
+        let travel = travel_deg_from_gear(motor_revs_full, gear);
+        assert!((travel - 190.0).abs() < 1e-3, "travel {travel}");
+        let dpc = travel / count_span;
+        let g = gear_ratio_centi(motor_revs_full, count_span, dpc);
+        assert!((g as f64 / 100.0 - gear).abs() < 0.02, "gear {g}");
+    }
+
+    #[test]
+    fn full_span_scales_by_count_ratio() {
+        // 20 motor revs over 1000 counts of a 4000-count span -> 80 full revs
+        assert!((full_span_motor_revs(20.0, 1000.0, 4000.0) - 80.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn full_span_and_travel_degenerate_guards() {
+        assert_eq!(full_span_motor_revs(20.0, 0.0, 4000.0), 0.0);
+        assert_eq!(full_span_motor_revs(20.0, 1000.0, f64::INFINITY), 0.0);
+        assert_eq!(full_span_motor_revs(20.0, 1000.0, f64::NAN), 0.0);
+        assert_eq!(travel_deg_from_gear(80.0, 0.0), 0.0);
+        assert_eq!(travel_deg_from_gear(80.0, -1.0), 0.0);
+        assert_eq!(travel_deg_from_gear(80.0, f64::NAN), 0.0);
+        assert_eq!(travel_deg_from_gear(80.0, f64::INFINITY), 0.0);
     }
 
     #[test]

--- a/ident/src/kinematics.rs
+++ b/ident/src/kinematics.rs
@@ -1,0 +1,146 @@
+//! Count <-> real-world-unit resolution for the calibration band. Turns the
+//! endstop sweep (pos_min/max_phys, which equal the pot LUT endpoints
+//! raw_min/raw_max) plus the human-supplied travel angles into the on-servo
+//! `CalibKinematics` values: angle endpoints in centi-degrees and the
+//! physical gear ratio. Pure math; the caller writes the encoded values to
+//! the three calib regs in a later commit.
+
+use crate::ripple;
+
+/// Encoded kinematics, ready for the three calib regs. All-zero is the
+/// firmware's "unset" sentinel.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct KinematicsResult {
+    pub angle_min_cdeg: i16,
+    pub angle_max_cdeg: i16,
+    pub gear_ratio_centi: u16,
+}
+
+/// Degrees of output travel per pot count over the phys span. 0.0 on a
+/// zero/non-finite span.
+pub fn deg_per_count(
+    angle_min_cdeg: i16,
+    angle_max_cdeg: i16,
+    pos_min_phys: i32,
+    pos_max_phys: i32,
+) -> f64 {
+    let count_span = pos_max_phys as f64 - pos_min_phys as f64;
+    if count_span == 0.0 {
+        return 0.0;
+    }
+    let angle_span_deg = (angle_max_cdeg as f64 - angle_min_cdeg as f64) / 100.0;
+    angle_span_deg / count_span
+}
+
+/// Encode the human's angle at each phys end into centi-degree endpoints.
+/// angle_at_min pairs with pos_min_phys, angle_at_max with pos_max_phys.
+pub fn angle_endpoints(angle_at_min_deg: f64, angle_at_max_deg: f64) -> (i16, i16) {
+    (
+        cdeg_saturating(angle_at_min_deg),
+        cdeg_saturating(angle_at_max_deg),
+    )
+}
+
+/// Physical gear ratio (motor revs per output rev) x100, saturating to u16.
+/// 0 on degenerate input (zero pot speed, zero/non-finite deg/count).
+pub fn gear_ratio_centi(motor_rev_s: f64, pot_omega_cps: f64, deg_per_count: f64) -> u16 {
+    if pot_omega_cps == 0.0 || deg_per_count == 0.0 || !deg_per_count.is_finite() {
+        return 0;
+    }
+    // counts per full output rev closes ripple::gear_ratio_check's relative
+    // ratio to the physical one (360 deg/rev)
+    let counts_per_output_rev = 360.0 / deg_per_count;
+    let ratio = ripple::gear_ratio_check(motor_rev_s, pot_omega_cps, counts_per_output_rev);
+    let centi = (ratio.abs() * 100.0).round();
+    if !centi.is_finite() {
+        return 0;
+    }
+    centi.min(u16::MAX as f64) as u16
+}
+
+/// Assemble the three encoded values from the endstop sweep and the
+/// human-supplied travel angles.
+pub fn resolve(
+    pos_min_phys: i32,
+    pos_max_phys: i32,
+    angle_at_min_deg: f64,
+    angle_at_max_deg: f64,
+    motor_rev_s: f64,
+    pot_omega_cps: f64,
+) -> KinematicsResult {
+    let (angle_min_cdeg, angle_max_cdeg) = angle_endpoints(angle_at_min_deg, angle_at_max_deg);
+    let dpc = deg_per_count(angle_min_cdeg, angle_max_cdeg, pos_min_phys, pos_max_phys);
+    KinematicsResult {
+        angle_min_cdeg,
+        angle_max_cdeg,
+        gear_ratio_centi: gear_ratio_centi(motor_rev_s, pot_omega_cps, dpc),
+    }
+}
+
+fn cdeg_saturating(deg: f64) -> i16 {
+    if !deg.is_finite() {
+        return 0;
+    }
+    (deg * 100.0)
+        .round()
+        .clamp(i16::MIN as f64, i16::MAX as f64) as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoints_and_deg_per_count_round_trip() {
+        // 190 deg of travel over a 3900-count phys span
+        let (lo, hi) = angle_endpoints(0.0, 190.0);
+        assert_eq!((lo, hi), (0, 19000));
+        let dpc = deg_per_count(lo, hi, 100, 4000);
+        assert!((dpc - 190.0 / 3900.0).abs() < 1e-12, "dpc {dpc}");
+    }
+
+    #[test]
+    fn cdeg_rounds_and_saturates() {
+        assert_eq!(cdeg_saturating(12.345), 1235);
+        assert_eq!(cdeg_saturating(-12.345), -1235);
+        assert_eq!(cdeg_saturating(400.0), i16::MAX);
+        assert_eq!(cdeg_saturating(-400.0), i16::MIN);
+        assert_eq!(cdeg_saturating(f64::NAN), 0);
+    }
+
+    #[test]
+    fn deg_per_count_degenerate_span_is_zero() {
+        assert_eq!(deg_per_count(0, 19000, 512, 512), 0.0);
+    }
+
+    #[test]
+    fn gear_ratio_from_synthetic_inputs() {
+        // dpc 0.05 deg/count, pot 4000 cps -> output 0.5556 rev/s;
+        // motor 83.333 rev/s implies 150:1
+        let g = gear_ratio_centi(83.333_333, 4000.0, 0.05);
+        assert!((g as i32 - 15000).abs() <= 1, "gear {g}");
+    }
+
+    #[test]
+    fn gear_ratio_degenerate_is_zero() {
+        assert_eq!(gear_ratio_centi(83.0, 0.0, 0.05), 0);
+        assert_eq!(gear_ratio_centi(83.0, 4000.0, 0.0), 0);
+        assert_eq!(gear_ratio_centi(83.0, 4000.0, f64::NAN), 0);
+    }
+
+    #[test]
+    fn gear_ratio_saturates_to_u16() {
+        assert_eq!(gear_ratio_centi(1e9, 1.0, 0.05), u16::MAX);
+    }
+
+    #[test]
+    fn resolve_assembles_all_three() {
+        let r = resolve(100, 4000, 0.0, 190.0, 83.333_333, 4000.0);
+        assert_eq!(r.angle_min_cdeg, 0);
+        assert_eq!(r.angle_max_cdeg, 19000);
+        // dpc = 190/3900 = 0.048718; output = 4000*dpc/360; gear ~ 154
+        let dpc: f64 = 190.0 / 3900.0;
+        let expect = (83.333_333 / (4000.0 * dpc / 360.0) * 100.0).round() as u16;
+        assert_eq!(r.gear_ratio_centi, expect);
+    }
+}

--- a/ident/src/lib.rs
+++ b/ident/src/lib.rs
@@ -13,6 +13,7 @@ pub mod fitmath;
 pub mod fits;
 pub mod frame;
 pub mod gains;
+pub mod kinematics;
 pub mod regs;
 pub mod report;
 pub mod ripple;

--- a/ident/src/lib.rs
+++ b/ident/src/lib.rs
@@ -14,6 +14,7 @@ pub mod fits;
 pub mod frame;
 pub mod gains;
 pub mod kinematics;
+pub mod lut;
 pub mod regs;
 pub mod report;
 pub mod ripple;

--- a/ident/src/lib.rs
+++ b/ident/src/lib.rs
@@ -17,3 +17,4 @@ pub mod kinematics;
 pub mod regs;
 pub mod report;
 pub mod ripple;
+pub mod units;

--- a/ident/src/lib.rs
+++ b/ident/src/lib.rs
@@ -18,4 +18,5 @@ pub mod lut;
 pub mod regs;
 pub mod report;
 pub mod ripple;
+pub mod slip;
 pub mod units;

--- a/ident/src/lut.rs
+++ b/ident/src/lut.rs
@@ -33,6 +33,12 @@ const MIN_SAMPLES: usize = 4;
 /// sweep SNR is too low to trust as an angle clock.
 const MIN_GOOD_FRAC: f64 = 0.5;
 
+/// A sweep covering less than this fraction of the rail span has its phase
+/// mis-scaled to [0,1] as if it spanned rail-to-rail, so `build` would fabricate
+/// large corrections in the uncovered rail regions (the ~1742-count cliff).
+/// Below this coverage `build` returns identity instead.
+pub const MIN_SPAN_COVER: f64 = 0.7;
+
 /// Host mirror of the firmware PotLutBlock (raw_min/raw_max/lut_corr).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PotLut {
@@ -134,6 +140,26 @@ pub fn cumulative_phase(current: &[f64], fs: f64, ripple_per_rev: f64) -> Option
     Some((phase, good_frac))
 }
 
+/// Fraction of the rail span [raw_min,raw_max] the sweep's raw pot samples
+/// actually covered: (observed max-min of raw_pot) / (raw_max - raw_min),
+/// clamped to [0,1]. 0.0 on empty input or a zero/degenerate denominator.
+pub fn span_coverage(raw_pot: &[u16], raw_min: u16, raw_max: u16) -> f64 {
+    if raw_pot.is_empty() {
+        return 0.0;
+    }
+    let denom = raw_max as f64 - raw_min as f64;
+    if denom <= 0.0 {
+        return 0.0;
+    }
+    let mut lo = raw_pot[0];
+    let mut hi = raw_pot[0];
+    for &r in raw_pot {
+        lo = lo.min(r);
+        hi = hi.max(r);
+    }
+    ((hi as f64 - lo as f64) / denom).clamp(0.0, 1.0)
+}
+
 /// Build the LUT from time-aligned raw pot samples and the cumulative motor
 /// phase (monotonic, from cumulative_phase). Normalizes phase to a true
 /// fraction, forms a monotone raw->fraction curve, and sets each knot's corr
@@ -148,6 +174,12 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
     let p0 = motor_phase[0];
     let pspan = motor_phase[n - 1] - p0;
     if !pspan.is_finite() || pspan == 0.0 {
+        return PotLut::identity(raw_min, raw_max);
+    }
+    // partial-coverage guard: phase is normalized to [0,1] as if the run
+    // spanned rail-to-rail, so a sweep over only part of travel mis-scales it
+    // and fabricates large rail corrections (the ~1742-count cliff).
+    if span_coverage(raw_pot, raw_min, raw_max) < MIN_SPAN_COVER {
         return PotLut::identity(raw_min, raw_max);
     }
     // (raw, true_frac) pairs. Orient frac to increase with raw: raw is
@@ -189,9 +221,10 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
     let mut corr = [0i16; N_KNOTS];
     for (k, c) in corr.iter_mut().enumerate() {
         let raw_i = raw_min as f64 + k as f64 * span_f / N_INTERVALS as f64;
-        // knots the sweep never reached (SNR gap near a rail) fall on the
-        // clamped end of the curve, so their corr stays small rather than
-        // extrapolating a wild slope past the covered range.
+        // knots past the covered range fall on the clamped end of the curve;
+        // over a thin sliver of uncovered raw that stays small, but a whole
+        // uncovered rail region would fabricate a large corr - the span_coverage
+        // gate above rejects such sweeps before reaching here.
         let frac = interp(&curve, raw_i);
         let corrected = raw_min as f64 + frac * span_f;
         *c = sat_i16((corrected - raw_i).round());
@@ -340,6 +373,41 @@ mod tests {
             build(&raw, &phase[..50], RAW_MIN, RAW_MAX),
             PotLut::identity(RAW_MIN, RAW_MAX)
         );
+    }
+
+    #[test]
+    fn span_coverage_fraction_and_degenerate() {
+        // full-span samples -> ~1.0
+        assert!((span_coverage(&[RAW_MIN, RAW_MAX], RAW_MIN, RAW_MAX) - 1.0).abs() < 1e-12);
+        // middle half of the span -> ~0.5
+        let q1 = RAW_MIN + (SPAN * 0.25) as u16;
+        let q3 = RAW_MIN + (SPAN * 0.75) as u16;
+        assert!((span_coverage(&[q1, q3], RAW_MIN, RAW_MAX) - 0.5).abs() < 0.01);
+        // empty -> 0.0
+        assert_eq!(span_coverage(&[], RAW_MIN, RAW_MAX), 0.0);
+        // degenerate raw_min == raw_max -> 0.0
+        assert_eq!(span_coverage(&[500, 600], 500, 500), 0.0);
+    }
+
+    #[test]
+    fn build_partial_coverage_is_identity() {
+        // nonlinear pot sampled over only the middle 40% of travel: phase is
+        // valid but coverage is below MIN_SPAN_COVER, so build falls back to
+        // identity rather than fabricating rail corrections.
+        let a = 0.15;
+        let m = 300;
+        let mut raw = Vec::with_capacity(m);
+        let mut phase = Vec::with_capacity(m);
+        for k in 0..m {
+            // f in [0.3, 0.7] -> ~40% of travel, centered mid-rail
+            let f = 0.3 + 0.4 * k as f64 / (m - 1) as f64;
+            raw.push(pot_raw(f, a));
+            phase.push(3.0 * f);
+        }
+        assert!(span_coverage(&raw, RAW_MIN, RAW_MAX) < MIN_SPAN_COVER);
+        let lut = build(&raw, &phase, RAW_MIN, RAW_MAX);
+        assert_eq!(lut, PotLut::identity(RAW_MIN, RAW_MAX));
+        assert!(lut.corr.iter().all(|&c| c == 0), "corr {:?}", lut.corr);
     }
 
     #[test]

--- a/ident/src/lut.rs
+++ b/ident/src/lut.rs
@@ -33,10 +33,10 @@ const MIN_SAMPLES: usize = 4;
 /// sweep SNR is too low to trust as an angle clock.
 const MIN_GOOD_FRAC: f64 = 0.5;
 
-/// A sweep covering less than this fraction of the rail span has its phase
-/// mis-scaled to [0,1] as if it spanned rail-to-rail, so `build` would fabricate
-/// large corrections in the uncovered rail regions (the ~1742-count cliff).
-/// Below this coverage `build` returns identity instead.
+/// A sweep covering less than this fraction of the rail span leaves too much of
+/// travel for `build`'s affine anchoring to extrapolate through: the anchoring
+/// assumes local linearity over the uncovered insets, which fails once whole
+/// rail regions are uncovered. Below this coverage `build` returns identity.
 pub const MIN_SPAN_COVER: f64 = 0.7;
 
 /// Host mirror of the firmware PotLutBlock (raw_min/raw_max/lut_corr).
@@ -141,8 +141,11 @@ pub fn cumulative_phase(current: &[f64], fs: f64, ripple_per_rev: f64) -> Option
 }
 
 /// Fraction of the rail span [raw_min,raw_max] the sweep's raw pot samples
-/// actually covered: (observed max-min of raw_pot) / (raw_max - raw_min),
-/// clamped to [0,1]. 0.0 on empty input or a zero/degenerate denominator.
+/// actually covered, from robust 2/98 percentiles of raw_pot rather than
+/// absolute min/max: (p98 - p2) / (raw_max - raw_min), clamped to [0,1]. The
+/// percentiles keep a couple of outlier samples near a rail from inflating a
+/// partial sweep to full coverage. 0.0 on empty input or a zero/degenerate
+/// denominator.
 pub fn span_coverage(raw_pot: &[u16], raw_min: u16, raw_max: u16) -> f64 {
     if raw_pot.is_empty() {
         return 0.0;
@@ -151,20 +154,21 @@ pub fn span_coverage(raw_pot: &[u16], raw_min: u16, raw_max: u16) -> f64 {
     if denom <= 0.0 {
         return 0.0;
     }
-    let mut lo = raw_pot[0];
-    let mut hi = raw_pot[0];
-    for &r in raw_pot {
-        lo = lo.min(r);
-        hi = hi.max(r);
-    }
-    ((hi as f64 - lo as f64) / denom).clamp(0.0, 1.0)
+    let mut sorted = raw_pot.to_vec();
+    sorted.sort_unstable();
+    let n = sorted.len();
+    let idx = |p: f64| ((n - 1) as f64 * p).round() as usize;
+    let lo = sorted[idx(0.02)] as f64;
+    let hi = sorted[idx(0.98)] as f64;
+    ((hi - lo) / denom).clamp(0.0, 1.0)
 }
 
 /// Build the LUT from time-aligned raw pot samples and the cumulative motor
-/// phase (monotonic, from cumulative_phase). Normalizes phase to a true
-/// fraction, forms a monotone raw->fraction curve, and sets each knot's corr
-/// to the count offset that lands its corrected value on the curve. Degenerate
-/// input (too few samples, length mismatch, zero raw or phase span) -> identity.
+/// phase (monotonic, from cumulative_phase). Anchors the captured phase shape
+/// into full-rail true-fraction space via the covered pot endpoints, forms a
+/// monotone raw->fraction curve, and sets each knot's corr to the count offset
+/// that lands its corrected value on the curve. Degenerate input (too few
+/// samples, length mismatch, zero raw or phase span) -> identity.
 pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -> PotLut {
     let n = raw_pot.len();
     let span = raw_max as i32 - raw_min as i32;
@@ -176,15 +180,18 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
     if !pspan.is_finite() || pspan == 0.0 {
         return PotLut::identity(raw_min, raw_max);
     }
-    // partial-coverage guard: phase is normalized to [0,1] as if the run
-    // spanned rail-to-rail, so a sweep over only part of travel mis-scales it
-    // and fabricates large rail corrections (the ~1742-count cliff).
+    // partial-coverage guard: the affine anchoring below assumes local
+    // linearity over the uncovered rail insets. That holds for the small
+    // insets of a near-full sweep, but a sweep over only part of travel leaves
+    // whole rail regions to extrapolate through, where the assumption breaks
+    // and the corrections become untrustworthy. Below MIN_SPAN_COVER, bail.
     if span_coverage(raw_pot, raw_min, raw_max) < MIN_SPAN_COVER {
         return PotLut::identity(raw_min, raw_max);
     }
-    // (raw, true_frac) pairs. Orient frac to increase with raw: raw is
-    // monotonic in true angle and so is phase, making frac monotone in raw
-    // regardless of sweep direction.
+    let span_f = span as f64;
+    // (raw, rel) pairs; rel = phase fraction over the CAPTURED range (0..1).
+    // Orient rel to increase with raw: raw is monotonic in true angle and so
+    // is phase, making rel monotone in raw regardless of sweep direction.
     let mut pts: Vec<(f64, f64)> = (0..n)
         .map(|k| (raw_pot[k] as f64, (motor_phase[k] - p0) / pspan))
         .collect();
@@ -194,6 +201,29 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
             p.1 = 1.0 - p.1;
         }
     }
+    // Anchor rel into full-rail true-fraction space. rel spans 0..1 over only
+    // the covered pot range [rp_lo,rp_hi]; map it affinely onto that range's
+    // fractions of the FULL rail span, assuming local linearity over the small
+    // uncovered insets. A full-rail sweep has rp_lo=raw_min, rp_hi=raw_max ->
+    // tf_lo=0, tf_hi=1 -> the mapping is the identity (backward compatible).
+    let rp_lo = pts[0].0;
+    let rp_hi = pts[pts.len() - 1].0;
+    let tf_lo = (rp_lo - raw_min as f64) / span_f;
+    let tf_hi = (rp_hi - raw_min as f64) / span_f;
+    if tf_hi == tf_lo {
+        return PotLut::identity(raw_min, raw_max);
+    }
+    for p in pts.iter_mut() {
+        p.1 = tf_lo + p.1 * (tf_hi - tf_lo);
+    }
+    // pin the mechanical rails to frac 0/1: raw_min/raw_max are the kinematics
+    // endpoints, so linearize must return exactly 0/1 there. interp then links
+    // each rail linearly to the nearest covered endpoint, tapering inset corr to
+    // 0 at the rail. A full-rail sweep already carries tf_lo=0/tf_hi=1 there, so
+    // the dedup pass averages the duplicate rail cleanly (behavior unchanged).
+    pts.push((raw_min as f64, 0.0));
+    pts.push((raw_max as f64, 1.0));
+    pts.sort_by(|a, b| a.0.total_cmp(&b.0));
     // average duplicate raws (pot flat spots, rounding collisions)
     let mut curve: Vec<(f64, f64)> = Vec::with_capacity(pts.len());
     let mut i = 0;
@@ -217,14 +247,13 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
             curve[j].1 = curve[j - 1].1;
         }
     }
-    let span_f = span as f64;
     let mut corr = [0i16; N_KNOTS];
     for (k, c) in corr.iter_mut().enumerate() {
         let raw_i = raw_min as f64 + k as f64 * span_f / N_INTERVALS as f64;
-        // knots past the covered range fall on the clamped end of the curve;
-        // over a thin sliver of uncovered raw that stays small, but a whole
-        // uncovered rail region would fabricate a large corr - the span_coverage
-        // gate above rejects such sweeps before reaching here.
+        // uncovered-inset knots lie on the interp segment from the rail anchor
+        // (frac 0/1) to the nearest covered endpoint, so their corr tapers to 0
+        // at the rail; the span_coverage gate above rejects sweeps whose
+        // uncovered regions would grow that taper large.
         let frac = interp(&curve, raw_i);
         let corrected = raw_min as f64 + frac * span_f;
         *c = sat_i16((corrected - raw_i).round());
@@ -408,6 +437,68 @@ mod tests {
         let lut = build(&raw, &phase, RAW_MIN, RAW_MAX);
         assert_eq!(lut, PotLut::identity(RAW_MIN, RAW_MAX));
         assert!(lut.corr.iter().all(|&c| c == 0), "corr {:?}", lut.corr);
+    }
+
+    #[test]
+    fn build_inset_sweep_no_rail_cliff() {
+        // 94%-coverage sweep: f in [0.03,0.97], nonlinear pot inset ~3% from
+        // each rail. The un-anchored normalization stretched the covered pot
+        // range onto the full rails, fabricating large rail-region corrections
+        // (hundreds+ here, unbounded as the inset grows). Affine anchoring plus
+        // rail-anchor pins tapers near-rail corr toward 0 and pins the rails to
+        // frac 0/1, while the interior keeps the measured shape.
+        let a = 0.15;
+        let m = 400;
+        let mut raw = Vec::with_capacity(m);
+        let mut phase = Vec::with_capacity(m);
+        for k in 0..m {
+            let f = 0.03 + 0.94 * k as f64 / (m - 1) as f64;
+            raw.push(pot_raw(f, a));
+            phase.push(3.0 * f);
+        }
+        // (a) coverage clears the gate, so build produces a real curve
+        assert!(
+            span_coverage(&raw, RAW_MIN, RAW_MAX) > MIN_SPAN_COVER,
+            "coverage {}",
+            span_coverage(&raw, RAW_MIN, RAW_MAX)
+        );
+        let lut = build(&raw, &phase, RAW_MIN, RAW_MAX);
+        // (b) near-rail knot corrections taper small (no fabricated cliff)
+        assert!(lut.corr[1].abs() < 30, "corr[1] {}", lut.corr[1]);
+        assert!(
+            lut.corr[N_KNOTS - 2].abs() < 30,
+            "corr[N-2] {}",
+            lut.corr[N_KNOTS - 2]
+        );
+        // rails pin to frac 0/1 (kinematics endpoints)
+        assert!((lut.linearize(RAW_MIN) - 0.0).abs() < 1e-9);
+        assert!((lut.linearize(RAW_MAX) - 1.0).abs() < 1e-9);
+        // (c) linearize tracks the true fraction to < 2% of span over the
+        // covered range (the anchor's local-linearity residual for a=0.15)
+        let mut emax = 0.0f64;
+        for (k, &r) in raw.iter().enumerate() {
+            let f = 0.03 + 0.94 * k as f64 / (m - 1) as f64;
+            emax = emax.max((lut.linearize(r) - f).abs());
+        }
+        assert!(emax < 0.02, "linearize err {emax}");
+    }
+
+    #[test]
+    fn span_coverage_ignores_outliers() {
+        // ~40%-coverage sweep (middle of travel) plus one outlier near each
+        // rail. Absolute min/max would report ~full coverage; robust 2/98
+        // percentiles reject the outliers and keep it below the 0.7 gate.
+        let m = 300;
+        let mut raw: Vec<u16> = Vec::with_capacity(m + 2);
+        for k in 0..m {
+            let f = 0.3 + 0.4 * k as f64 / (m - 1) as f64;
+            raw.push(pot_raw(f, 0.0));
+        }
+        raw.push(RAW_MIN + 1);
+        raw.push(RAW_MAX - 1);
+        let cov = span_coverage(&raw, RAW_MIN, RAW_MAX);
+        assert!(cov < MIN_SPAN_COVER, "outliers inflated coverage to {cov}");
+        assert!(cov > 0.35 && cov < 0.45, "coverage {cov}");
     }
 
     #[test]

--- a/ident/src/lut.rs
+++ b/ident/src/lut.rs
@@ -22,7 +22,6 @@
 //!   linearize equal to the plain linear fraction.
 
 use crate::ripple;
-use std::collections::BTreeMap;
 
 /// Knot count = the firmware PotLutBlock's lut_corr length.
 const N_KNOTS: usize = 55;
@@ -288,13 +287,23 @@ struct Stitch {
     coverage: f64,
 }
 
-/// Integrate a per-count motor-rev slope over the rail span from multiple
-/// clean chunks. Each chunk contributes its local rev/count slope (motor phase
-/// from cumulative_phase, distributed across the counts it traversed); the pos
-/// axis is global and monotonic in true angle, so the chunks share one count
-/// grid and bridge each other's gaps. A chunk whose ripple phase can't be
-/// recovered is skipped, not fatal. None when the span is degenerate, fewer
-/// than two bins are covered, or the integrated rev span is non-positive.
+/// Integrate a per-count motor-rev density over the rail span from multiple
+/// clean chunks. Each chunk contributes its local rev/count density (motor
+/// phase from cumulative_phase); the pos axis is global and monotonic in true
+/// angle, so the chunks share one count grid and bridge each other's gaps. A
+/// chunk whose ripple phase can't be recovered is skipped, not fatal. None when
+/// the span is degenerate, fewer than two bins are covered, or the integrated
+/// rev span is non-positive.
+///
+/// Density comes from TIME-ORDERED steps, not a pos-sorted scan: phase is the
+/// clean monotone clock while pot pos is noisy (the ADC dithers +/-several
+/// counts around a slow advance). Depositing each step's dphi into the count(s)
+/// occupied at that instant makes each bin accumulate exactly the revs turned
+/// while sitting near that count, so a chunk's deposits sum to its raw phase
+/// span with no loss. A pos-sorted dedup instead averages phase across every
+/// time a jittered pos revisits a count, which breaks phase monotonicity vs pos
+/// (spurious reversals) and, once negative windows are dropped, both loses
+/// coverage and over-counts revs.
 fn stitch_slope(
     chunks: &[(Vec<u16>, Vec<f64>)],
     fs: f64,
@@ -307,8 +316,13 @@ fn stitch_slope(
         return None;
     }
     let bins = span as usize + 1;
-    let mut slope_sum = vec![0.0; bins];
-    let mut slope_cnt = vec![0u32; bins];
+    // acc[b] = sum over covering chunks of that chunk's local rev/count density
+    // at bin b; chunk_cov[b] = how many chunks covered b. Density = acc/chunk_cov
+    // (chunks that overlap in pos measured the same physical count and average).
+    let mut acc = vec![0.0; bins];
+    let mut chunk_cov = vec![0u32; bins];
+    let mut local = vec![0.0; bins];
+    let mut touched = vec![false; bins];
     for (pos, current) in chunks {
         if pos.len() != current.len() || pos.len() < MIN_SAMPLES {
             continue;
@@ -318,62 +332,67 @@ fn stitch_slope(
         } else {
             continue;
         };
-        // Collapse oversampling+jitter first: the pot ADC lands many samples on
-        // each count (and dithers +/-1), so a raw per-step scan would split one
-        // count's dphi across many crossings and dilute the averaged slope by
-        // the oversampling factor. Reduce to one mean phase per unique pos.
-        let mut by_pos: BTreeMap<u16, (f64, u32)> = BTreeMap::new();
-        for (&p, &ph) in pos.iter().zip(phi.iter()) {
-            let e = by_pos.entry(p).or_insert((0.0, 0));
-            e.0 += ph;
-            e.1 += 1;
-        }
-        let deduped: Vec<(u16, f64)> = by_pos
-            .into_iter()
-            .map(|(p, (sum, cnt))| (p, sum / cnt as f64))
-            .collect();
-        // Distribute each pos-step's phase increment across the counts it
-        // crossed; each covered count now gets ~one full-per-count contribution
-        // per chunk (multi-chunk overlap still averages correctly).
-        for w in deduped.windows(2) {
-            let (pos_i, phi_i) = w[0];
-            let (pos_j, phi_j) = w[1];
-            let dphi = phi_j - phi_i;
-            let (a, b) = (pos_i.min(pos_j), pos_i.max(pos_j));
-            let counts = (b - a) as f64;
-            if counts > 0.0 && dphi >= 0.0 {
-                let s = dphi / counts;
-                // b maps to the next bin; the top count lands in bin b-1
+        local.iter_mut().for_each(|x| *x = 0.0);
+        touched.iter_mut().for_each(|x| *x = false);
+        for k in 0..pos.len() - 1 {
+            let dphi = (phi[k + 1] - phi[k]).max(0.0);
+            let (a, b) = (pos[k].min(pos[k + 1]), pos[k].max(pos[k + 1]));
+            if a == b {
+                // sat at one count for this step: all of dphi lands in bin a.
+                // A sample sitting exactly at raw_max folds into the top interval
+                // (bin raw_max-1) rather than being dropped, so a rail dwell
+                // keeps its revs.
+                if a >= raw_min && a <= raw_max {
+                    let idx = (a.min(raw_max - 1) - raw_min) as usize;
+                    local[idx] += dphi;
+                    touched[idx] = true;
+                }
+            } else {
+                // crossed [a,b): spread dphi evenly over the counts traversed
+                let s = dphi / (b - a) as f64;
                 for c in a..b {
                     if c >= raw_min && c < raw_max {
                         let idx = (c - raw_min) as usize;
-                        slope_sum[idx] += s;
-                        slope_cnt[idx] += 1;
+                        local[idx] += s;
+                        touched[idx] = true;
                     }
                 }
             }
         }
+        for b in 0..bins {
+            if touched[b] {
+                acc[b] += local[b];
+                chunk_cov[b] += 1;
+            }
+        }
     }
-    let covered = slope_cnt.iter().filter(|&&c| c > 0).count();
+    let covered = chunk_cov.iter().filter(|&&c| c > 0).count();
     if covered < 2 {
         return None;
     }
-    let fc = slope_cnt.iter().position(|&c| c > 0).unwrap();
-    let lc = slope_cnt.iter().rposition(|&c| c > 0).unwrap();
+    let fc = chunk_cov.iter().position(|&c| c > 0).unwrap();
+    let lc = chunk_cov.iter().rposition(|&c| c > 0).unwrap();
     let coverage = covered as f64 / bins as f64;
     let mut avg = vec![0.0; bins];
     for b in 0..bins {
-        if slope_cnt[b] > 0 {
-            avg[b] = slope_sum[b] / slope_cnt[b] as f64;
+        if chunk_cov[b] > 0 {
+            avg[b] = acc[b] / chunk_cov[b] as f64;
         }
     }
     // linearly interpolate uncovered interior bins between covered neighbours so
-    // the integrated cumulative stays continuous and monotone across gaps
+    // the integrated cumulative stays continuous and monotone across gaps. The
+    // anchors are the MEDIAN density over up to GAP_ANCHOR covered bins scanning
+    // inward from each edge, not the single boundary bin: a chunk's outermost
+    // bin is partially occupied (the chunk was cut off mid-count) and reads low,
+    // so anchoring a wide gap on it under-fills the revs the motor turned while
+    // crossing that gap. The median over a small interior neighbourhood is the
+    // representative local density.
     let mut prev = fc;
     for b in (fc + 1)..=lc {
-        if slope_cnt[b] > 0 {
+        if chunk_cov[b] > 0 {
             if b > prev + 1 {
-                let (y0, y1) = (avg[prev], avg[b]);
+                let y0 = anchor_density(&avg, &chunk_cov, prev, -1, fc, lc);
+                let y1 = anchor_density(&avg, &chunk_cov, b, 1, fc, lc);
                 let dx = (b - prev) as f64;
                 for (j, g) in avg[(prev + 1)..b].iter_mut().enumerate() {
                     *g = y0 + (y1 - y0) * ((j + 1) as f64 / dx);
@@ -449,6 +468,37 @@ pub fn stitched_motor_revs(
     let count_span = raw_max as f64 - raw_min as f64;
     let full = crate::kinematics::full_span_motor_revs(revs, pot_disp, count_span);
     (full != 0.0).then_some((full, st.coverage))
+}
+
+/// Count of covered bins scanned inward from a gap edge to form the anchor
+/// median (see stitch_slope's interpolation).
+const GAP_ANCHOR: usize = 8;
+
+/// Median density over up to GAP_ANCHOR covered bins scanning from `start` in
+/// direction `dir` (+1/-1), staying within [lo,lc]. Skips uncovered bins (gap
+/// fills), so anchors are always real measurements. 0.0 if none found.
+fn anchor_density(
+    avg: &[f64],
+    chunk_cov: &[u32],
+    start: usize,
+    dir: i32,
+    lo: usize,
+    hi: usize,
+) -> f64 {
+    let mut vals: Vec<f64> = Vec::with_capacity(GAP_ANCHOR);
+    let mut b = start as i64;
+    while vals.len() < GAP_ANCHOR && b >= lo as i64 && b <= hi as i64 {
+        let idx = b as usize;
+        if chunk_cov[idx] > 0 {
+            vals.push(avg[idx]);
+        }
+        b += dir as i64;
+    }
+    if vals.is_empty() {
+        return 0.0;
+    }
+    vals.sort_by(f64::total_cmp);
+    vals[vals.len() / 2]
 }
 
 /// Rate (rev/s) at sample index x by linear interp over window centers,

--- a/ident/src/lut.rs
+++ b/ident/src/lut.rs
@@ -1,0 +1,398 @@
+//! Ripple-referenced pot linearization LUT: builder + host-side apply.
+//!
+//! The pot is nonlinear, so a 2-point linear map (raw_min at one rail,
+//! raw_max at the other) mis-reports angle mid-travel. This module builds a
+//! 55-knot correction table from a calibration sweep and applies it on the
+//! host - the firmware only STORES the block, it never converts.
+//!
+//! Angle clock: over a constant-duty full-travel sweep the motor commutation
+//! ripple on the winding current is a motor-shaft angle clock. Its cumulative
+//! phase is a drift-resistant TRUE-angle axis (no constant-velocity
+//! assumption, unlike sampling against wall time); raw pot counts sampled
+//! against that axis reveal the pot's nonlinearity. One monotonic pot
+//! channel, so the result is a plain raw->fraction curve (no 2D search).
+//!
+//! LUT semantics (host-defined; firmware does not apply the block):
+//! - 55 knots evenly spaced in raw counts, raw_i = raw_min + i*span/54.
+//! - corrected(raw_i) = raw_i + corr[i]; linear interp between knots; raw
+//!   outside [raw_min,raw_max] clamps to the rail.
+//! - linearize(raw) = (corrected(raw) - raw_min)/span clamped to [0,1].
+//! - all-zero corr == identity == the 2-point-linear baseline: corr shifts
+//!   each knot's corrected value off the straight line, so zeros leave
+//!   linearize equal to the plain linear fraction.
+
+use crate::ripple;
+
+/// Knot count = the firmware PotLutBlock's lut_corr length.
+const N_KNOTS: usize = 55;
+/// Intervals between knots.
+const N_INTERVALS: usize = N_KNOTS - 1;
+/// Below this many aligned samples the sweep can't define a curve.
+const MIN_SAMPLES: usize = 4;
+/// cumulative_phase needs a majority of windows to find ripple, else the
+/// sweep SNR is too low to trust as an angle clock.
+const MIN_GOOD_FRAC: f64 = 0.5;
+
+/// Host mirror of the firmware PotLutBlock (raw_min/raw_max/lut_corr).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct PotLut {
+    pub raw_min: u16,
+    pub raw_max: u16,
+    pub corr: [i16; N_KNOTS],
+}
+
+impl PotLut {
+    /// All-zero corr: linearize reduces to the plain linear fraction.
+    pub fn identity(raw_min: u16, raw_max: u16) -> PotLut {
+        PotLut {
+            raw_min,
+            raw_max,
+            corr: [0; N_KNOTS],
+        }
+    }
+
+    /// Corrected raw value at knot i: on-line position plus its correction.
+    fn corrected_knot(&self, i: usize) -> f64 {
+        let span = self.raw_max as f64 - self.raw_min as f64;
+        self.raw_min as f64 + i as f64 * span / N_INTERVALS as f64 + self.corr[i] as f64
+    }
+
+    /// Normalized linearized fraction in [0,1]. Degenerate span -> 0.
+    pub fn linearize(&self, raw: u16) -> f64 {
+        let lo = self.raw_min as f64;
+        let hi = self.raw_max as f64;
+        let span = hi - lo;
+        if span <= 0.0 {
+            return 0.0;
+        }
+        let r = (raw as f64).clamp(lo, hi);
+        let pos = ((r - lo) / span * N_INTERVALS as f64).clamp(0.0, N_INTERVALS as f64);
+        let i0 = pos.floor() as usize;
+        let corrected = if i0 >= N_INTERVALS {
+            self.corrected_knot(N_INTERVALS)
+        } else {
+            let frac = pos - i0 as f64;
+            let c0 = self.corrected_knot(i0);
+            let c1 = self.corrected_knot(i0 + 1);
+            c0 + frac * (c1 - c0)
+        };
+        ((corrected - lo) / span).clamp(0.0, 1.0)
+    }
+
+    /// Angle in centi-degrees, composing the linearized fraction with the
+    /// kinematics endpoints (angle_min_cdeg at raw_min, angle_max at raw_max).
+    pub fn angle_cdeg(&self, raw: u16, angle_min_cdeg: i16, angle_max_cdeg: i16) -> f64 {
+        let f = self.linearize(raw);
+        angle_min_cdeg as f64 + f * (angle_max_cdeg as f64 - angle_min_cdeg as f64)
+    }
+}
+
+/// Cumulative motor phase (revs) per sample from a constant-duty sweep's
+/// current series. Slides ripple_speed over the series, integrates the
+/// per-window rev/s (drift-resistant: an occasional dropped window is
+/// interpolated across, not extrapolated from one global rate), and returns
+/// a monotonic phase. None when input is too short or a majority of windows
+/// fail the ripple confidence floor.
+pub fn cumulative_phase(current: &[f64], fs: f64, ripple_per_rev: f64) -> Option<Vec<f64>> {
+    let n = current.len();
+    if fs <= 0.0 || ripple_per_rev <= 0.0 {
+        return None;
+    }
+    let win = ripple::min_window(fs);
+    if win == 0 || n < win {
+        return None;
+    }
+    let hop = (win / 4).max(1);
+    // (window center sample, motor rev/s) for windows that clear the floor
+    let mut centers: Vec<(f64, f64)> = Vec::new();
+    let mut total = 0usize;
+    let mut start = 0usize;
+    while start + win <= n {
+        total += 1;
+        if let Some(e) = ripple::ripple_speed(&current[start..start + win], fs, ripple_per_rev) {
+            centers.push((start as f64 + win as f64 / 2.0, e.motor_rev_s));
+        }
+        start += hop;
+    }
+    if centers.len() < 2 || (centers.len() as f64) < MIN_GOOD_FRAC * total as f64 {
+        return None;
+    }
+    // per-sample rev/s: linear interp across window centers, clamped at the
+    // ends; cumulative-trapezoid to revs. rev/s >= 0 keeps phase monotone.
+    let mut phase = Vec::with_capacity(n);
+    let mut acc = 0.0;
+    let mut prev = rate_at(&centers, 0.0);
+    phase.push(0.0);
+    for k in 1..n {
+        let rs = rate_at(&centers, k as f64);
+        acc += 0.5 * (prev + rs) / fs;
+        phase.push(acc);
+        prev = rs;
+    }
+    Some(phase)
+}
+
+/// Build the LUT from time-aligned raw pot samples and the cumulative motor
+/// phase (monotonic, from cumulative_phase). Normalizes phase to a true
+/// fraction, forms a monotone raw->fraction curve, and sets each knot's corr
+/// to the count offset that lands its corrected value on the curve. Degenerate
+/// input (too few samples, length mismatch, zero raw or phase span) -> identity.
+pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -> PotLut {
+    let n = raw_pot.len();
+    let span = raw_max as i32 - raw_min as i32;
+    if n < MIN_SAMPLES || n != motor_phase.len() || span <= 0 {
+        return PotLut::identity(raw_min, raw_max);
+    }
+    let p0 = motor_phase[0];
+    let pspan = motor_phase[n - 1] - p0;
+    if !pspan.is_finite() || pspan == 0.0 {
+        return PotLut::identity(raw_min, raw_max);
+    }
+    // (raw, true_frac) pairs. Orient frac to increase with raw: raw is
+    // monotonic in true angle and so is phase, making frac monotone in raw
+    // regardless of sweep direction.
+    let mut pts: Vec<(f64, f64)> = (0..n)
+        .map(|k| (raw_pot[k] as f64, (motor_phase[k] - p0) / pspan))
+        .collect();
+    pts.sort_by(|a, b| a.0.total_cmp(&b.0));
+    if pts[pts.len() - 1].1 < pts[0].1 {
+        for p in pts.iter_mut() {
+            p.1 = 1.0 - p.1;
+        }
+    }
+    // average duplicate raws (pot flat spots, rounding collisions)
+    let mut curve: Vec<(f64, f64)> = Vec::with_capacity(pts.len());
+    let mut i = 0;
+    while i < pts.len() {
+        let r = pts[i].0;
+        let mut s = 0.0;
+        let mut c = 0.0;
+        while i < pts.len() && pts[i].0 == r {
+            s += pts[i].1;
+            c += 1.0;
+            i += 1;
+        }
+        curve.push((r, s / c));
+    }
+    if curve.len() < 2 {
+        return PotLut::identity(raw_min, raw_max);
+    }
+    // enforce non-decreasing frac (noise guard)
+    for j in 1..curve.len() {
+        if curve[j].1 < curve[j - 1].1 {
+            curve[j].1 = curve[j - 1].1;
+        }
+    }
+    let span_f = span as f64;
+    let mut corr = [0i16; N_KNOTS];
+    for (k, c) in corr.iter_mut().enumerate() {
+        let raw_i = raw_min as f64 + k as f64 * span_f / N_INTERVALS as f64;
+        // knots the sweep never reached (SNR gap near a rail) fall on the
+        // clamped end of the curve, so their corr stays small rather than
+        // extrapolating a wild slope past the covered range.
+        let frac = interp(&curve, raw_i);
+        let corrected = raw_min as f64 + frac * span_f;
+        *c = sat_i16((corrected - raw_i).round());
+    }
+    PotLut {
+        raw_min,
+        raw_max,
+        corr,
+    }
+}
+
+/// Rate (rev/s) at sample index x by linear interp over window centers,
+/// clamped to the first/last center outside the covered span.
+fn rate_at(centers: &[(f64, f64)], x: f64) -> f64 {
+    interp(centers, x)
+}
+
+/// Linear interpolation over an x-sorted table, clamping outside the range.
+fn interp(pts: &[(f64, f64)], x: f64) -> f64 {
+    let last = pts.len() - 1;
+    if x <= pts[0].0 {
+        return pts[0].1;
+    }
+    if x >= pts[last].0 {
+        return pts[last].1;
+    }
+    let (mut lo, mut hi) = (0usize, last);
+    while hi - lo > 1 {
+        let mid = (lo + hi) / 2;
+        if pts[mid].0 <= x {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    let (x0, y0) = pts[lo];
+    let (x1, y1) = pts[hi];
+    if x1 == x0 {
+        return y0;
+    }
+    y0 + (y1 - y0) * (x - x0) / (x1 - x0)
+}
+
+fn sat_i16(v: f64) -> i16 {
+    if !v.is_finite() {
+        return 0;
+    }
+    v.clamp(i16::MIN as f64, i16::MAX as f64) as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f64::consts::PI;
+
+    const RAW_MIN: u16 = 200;
+    const RAW_MAX: u16 = 3900;
+    const SPAN: f64 = (RAW_MAX - RAW_MIN) as f64;
+
+    // Monotonic nonlinear pot: raw = raw_min + span*(f + a*sin(pi*f)).
+    // a < 1/pi keeps it monotone; endpoints fixed (sin(0)=sin(pi)=0).
+    fn pot_raw(f: f64, a: f64) -> u16 {
+        (RAW_MIN as f64 + SPAN * (f + a * (PI * f).sin())).round() as u16
+    }
+
+    fn sweep(a: f64, m: usize) -> (Vec<u16>, Vec<f64>) {
+        let mut raw = Vec::with_capacity(m);
+        let mut phase = Vec::with_capacity(m);
+        for k in 0..m {
+            let f = k as f64 / (m - 1) as f64;
+            raw.push(pot_raw(f, a));
+            // rigid gear: motor phase proportional to true angle
+            phase.push(3.0 * f);
+        }
+        (raw, phase)
+    }
+
+    #[test]
+    fn identity_linearize_is_linear_fraction() {
+        let lut = PotLut::identity(RAW_MIN, RAW_MAX);
+        for raw in [RAW_MIN, 1000, 2048, 3000, RAW_MAX] {
+            let expect = (raw as f64 - RAW_MIN as f64) / SPAN;
+            assert!((lut.linearize(raw) - expect).abs() < 1e-12, "raw {raw}");
+        }
+        assert_eq!(lut.angle_cdeg(RAW_MIN, 0, 19000), 0.0);
+        assert!((lut.angle_cdeg(RAW_MAX, 0, 19000) - 19000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn out_of_range_raw_clamps() {
+        let lut = PotLut::identity(RAW_MIN, RAW_MAX);
+        assert_eq!(lut.linearize(0), 0.0);
+        assert_eq!(lut.linearize(u16::MAX), 1.0);
+    }
+
+    #[test]
+    fn build_linear_pot_yields_near_zero_corr() {
+        let (raw, phase) = sweep(0.0, 300);
+        let lut = build(&raw, &phase, RAW_MIN, RAW_MAX);
+        // only rounding of the u16 raw samples separates corr from zero
+        assert!(
+            lut.corr.iter().all(|&c| c.abs() <= 2),
+            "corr {:?}",
+            lut.corr
+        );
+    }
+
+    #[test]
+    fn build_recovers_nonlinear_pot_and_beats_identity() {
+        let a = 0.15;
+        let (raw, phase) = sweep(a, 400);
+        let lut = build(&raw, &phase, RAW_MIN, RAW_MAX);
+        let ident = PotLut::identity(RAW_MIN, RAW_MAX);
+        let mut lut_max = 0.0f64;
+        let mut ident_max = 0.0f64;
+        for (k, &r) in raw.iter().enumerate() {
+            let f = k as f64 / 399.0;
+            lut_max = lut_max.max((lut.linearize(r) - f).abs());
+            ident_max = ident_max.max((ident.linearize(r) - f).abs());
+        }
+        // fraction error is a fraction of span; < 1% of span required
+        assert!(lut_max < 0.01, "lut err {lut_max}");
+        // identity is off by ~a*sin(pi*f) mid-travel; LUT must trounce it
+        assert!(ident_max > 0.1, "ident err {ident_max}");
+        assert!(
+            lut_max < ident_max / 10.0,
+            "lut {lut_max} ident {ident_max}"
+        );
+    }
+
+    #[test]
+    fn build_degenerate_is_identity() {
+        assert_eq!(
+            build(&[], &[], RAW_MIN, RAW_MAX),
+            PotLut::identity(RAW_MIN, RAW_MAX)
+        );
+        assert_eq!(
+            build(&[1, 2], &[0.0, 1.0], RAW_MIN, RAW_MAX),
+            PotLut::identity(RAW_MIN, RAW_MAX)
+        );
+        // zero raw span
+        let (raw, phase) = sweep(0.1, 100);
+        assert_eq!(build(&raw, &phase, 500, 500), PotLut::identity(500, 500));
+        // length mismatch
+        assert_eq!(
+            build(&raw, &phase[..50], RAW_MIN, RAW_MAX),
+            PotLut::identity(RAW_MIN, RAW_MAX)
+        );
+    }
+
+    #[test]
+    fn linearize_zero_span_is_zero() {
+        let lut = PotLut::identity(500, 500);
+        assert_eq!(lut.linearize(500), 0.0);
+    }
+
+    // --- cumulative_phase ---
+
+    struct Lcg(u64);
+    impl Lcg {
+        fn next(&mut self, half: f64) -> f64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((self.0 >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0) * half
+        }
+    }
+
+    const FS: f64 = 20_100.0;
+
+    fn ripple_series(freq: f64, amp: f64, noise: f64, n: usize) -> Vec<f64> {
+        let mut lcg = Lcg(41);
+        (0..n)
+            .map(|k| {
+                let t = k as f64 / FS;
+                60.0 + amp * (2.0 * PI * freq * t).sin() + lcg.next(noise)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn cumulative_phase_recovers_total_revs() {
+        let n = 4000;
+        let i = ripple_series(1800.0, 4.0, 3.0, n);
+        let phase = cumulative_phase(&i, FS, 6.0).expect("phase found");
+        assert_eq!(phase.len(), n);
+        // monotone non-decreasing
+        assert!(phase.windows(2).all(|w| w[1] >= w[0]));
+        // 1800 Hz / 6 = 300 rev/s over (n-1)/fs s
+        let expect = 300.0 * (n - 1) as f64 / FS;
+        let got = phase[n - 1];
+        assert!(
+            (got - expect).abs() / expect < 0.03,
+            "revs {got} vs {expect}"
+        );
+    }
+
+    #[test]
+    fn cumulative_phase_rejects_noise_and_short() {
+        let mut lcg = Lcg(9);
+        let noise: Vec<f64> = (0..4000).map(|_| 512.0 + lcg.next(3.0)).collect();
+        assert!(cumulative_phase(&noise, FS, 6.0).is_none(), "pure noise");
+        assert!(cumulative_phase(&[1.0; 10], FS, 6.0).is_none(), "too short");
+    }
+}

--- a/ident/src/lut.rs
+++ b/ident/src/lut.rs
@@ -188,7 +188,6 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
     if span_coverage(raw_pot, raw_min, raw_max) < MIN_SPAN_COVER {
         return PotLut::identity(raw_min, raw_max);
     }
-    let span_f = span as f64;
     // (raw, rel) pairs; rel = phase fraction over the CAPTURED range (0..1).
     // Orient rel to increase with raw: raw is monotonic in true angle and so
     // is phase, making rel monotone in raw regardless of sweep direction.
@@ -201,6 +200,18 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
             p.1 = 1.0 - p.1;
         }
     }
+    fit_knots(pts, raw_min, raw_max)
+}
+
+/// Fit the 55-knot correction table from `pts` = (raw, rel), where rel is in
+/// [0,1] and ALREADY oriented to increase with raw. Anchors the covered pot
+/// endpoints affinely into full-rail true-fraction space, pins the rails to
+/// frac 0/1, forms a monotone raw->fraction curve, and sets each knot's corr
+/// to the count offset landing its corrected value on the curve. Degenerate
+/// input (single raw value, <2 curve points) -> identity.
+fn fit_knots(mut pts: Vec<(f64, f64)>, raw_min: u16, raw_max: u16) -> PotLut {
+    pts.sort_by(|a, b| a.0.total_cmp(&b.0));
+    let span_f = raw_max as f64 - raw_min as f64;
     // Anchor rel into full-rail true-fraction space. rel spans 0..1 over only
     // the covered pot range [rp_lo,rp_hi]; map it affinely onto that range's
     // fractions of the FULL rail span, assuming local linearity over the small
@@ -263,6 +274,169 @@ pub fn build(raw_pot: &[u16], motor_phase: &[f64], raw_min: u16, raw_max: u16) -
         raw_max,
         corr,
     }
+}
+
+/// Per-count cumulative motor revs stitched from several chunks over the
+/// shared pos axis. `cum` is indexed by bin (bin b = count raw_min+b); `fc`/
+/// `lc` bracket the covered bins; `coverage` is the covered fraction of the
+/// rail span.
+struct Stitch {
+    cum: Vec<f64>,
+    fc: usize,
+    lc: usize,
+    coverage: f64,
+}
+
+/// Integrate a per-count motor-rev slope over the rail span from multiple
+/// clean chunks. Each chunk contributes its local rev/count slope (motor phase
+/// from cumulative_phase, distributed across the counts it traversed); the pos
+/// axis is global and monotonic in true angle, so the chunks share one count
+/// grid and bridge each other's gaps. A chunk whose ripple phase can't be
+/// recovered is skipped, not fatal. None when the span is degenerate, fewer
+/// than two bins are covered, or the integrated rev span is non-positive.
+fn stitch_slope(
+    chunks: &[(Vec<u16>, Vec<f64>)],
+    fs: f64,
+    ripple_per_rev: f64,
+    raw_min: u16,
+    raw_max: u16,
+) -> Option<Stitch> {
+    let span = raw_max as i32 - raw_min as i32;
+    if span <= 0 {
+        return None;
+    }
+    let bins = span as usize + 1;
+    let mut slope_sum = vec![0.0; bins];
+    let mut slope_cnt = vec![0u32; bins];
+    for (pos, current) in chunks {
+        if pos.len() != current.len() || pos.len() < MIN_SAMPLES {
+            continue;
+        }
+        let phi = if let Some((phi, _)) = cumulative_phase(current, fs, ripple_per_rev) {
+            phi
+        } else {
+            continue;
+        };
+        // Distribute each pos-change's phase increment across the counts it
+        // crossed (pos is quantized: it steps only every several samples).
+        let mut prev_pos = pos[0];
+        let mut prev_phi = phi[0];
+        for i in 1..pos.len() {
+            if pos[i] != prev_pos {
+                let dphi = phi[i] - prev_phi;
+                let (a, b) = (prev_pos.min(pos[i]), prev_pos.max(pos[i]));
+                let counts = (b - a) as f64;
+                if counts > 0.0 && dphi >= 0.0 {
+                    let s = dphi / counts;
+                    // b maps to the next bin; the top count lands in bin b-1
+                    for c in a..b {
+                        if c >= raw_min && c < raw_max {
+                            let idx = (c - raw_min) as usize;
+                            slope_sum[idx] += s;
+                            slope_cnt[idx] += 1;
+                        }
+                    }
+                }
+                prev_pos = pos[i];
+                prev_phi = phi[i];
+            }
+        }
+    }
+    let covered = slope_cnt.iter().filter(|&&c| c > 0).count();
+    if covered < 2 {
+        return None;
+    }
+    let fc = slope_cnt.iter().position(|&c| c > 0).unwrap();
+    let lc = slope_cnt.iter().rposition(|&c| c > 0).unwrap();
+    let coverage = covered as f64 / bins as f64;
+    let mut avg = vec![0.0; bins];
+    for b in 0..bins {
+        if slope_cnt[b] > 0 {
+            avg[b] = slope_sum[b] / slope_cnt[b] as f64;
+        }
+    }
+    // linearly interpolate uncovered interior bins between covered neighbours so
+    // the integrated cumulative stays continuous and monotone across gaps
+    let mut prev = fc;
+    for b in (fc + 1)..=lc {
+        if slope_cnt[b] > 0 {
+            if b > prev + 1 {
+                let (y0, y1) = (avg[prev], avg[b]);
+                let dx = (b - prev) as f64;
+                for (j, g) in avg[(prev + 1)..b].iter_mut().enumerate() {
+                    *g = y0 + (y1 - y0) * ((j + 1) as f64 / dx);
+                }
+            }
+            prev = b;
+        }
+    }
+    let mut cum = vec![0.0; bins];
+    for b in (fc + 1)..=lc {
+        cum[b] = cum[b - 1] + avg[b];
+    }
+    for b in (lc + 1)..bins {
+        cum[b] = cum[lc];
+    }
+    if cum[lc] - cum[fc] <= 0.0 {
+        return None;
+    }
+    Some(Stitch {
+        cum,
+        fc,
+        lc,
+        coverage,
+    })
+}
+
+/// Build the pot LUT from MULTIPLE clean sweep chunks (each (pos, current)),
+/// stitched over the shared pos axis. Chunks may cover overlapping or disjoint
+/// pos ranges with gaps between them; the per-count slope integration bridges
+/// the gaps. Identity when coverage < MIN_SPAN_COVER or the stitch is degenerate.
+pub fn build_multi(
+    chunks: &[(Vec<u16>, Vec<f64>)],
+    fs: f64,
+    ripple_per_rev: f64,
+    raw_min: u16,
+    raw_max: u16,
+) -> PotLut {
+    let st = match stitch_slope(chunks, fs, ripple_per_rev, raw_min, raw_max) {
+        Some(s) => s,
+        None => return PotLut::identity(raw_min, raw_max),
+    };
+    if st.coverage < MIN_SPAN_COVER {
+        return PotLut::identity(raw_min, raw_max);
+    }
+    let total = st.cum[st.lc] - st.cum[st.fc];
+    if total <= 0.0 {
+        return PotLut::identity(raw_min, raw_max);
+    }
+    // (pos, rel), rel in [0,1] ascending with pos (no flip needed)
+    let pts: Vec<(f64, f64)> = (st.fc..=st.lc)
+        .map(|b| {
+            (
+                raw_min as f64 + b as f64,
+                (st.cum[b] - st.cum[st.fc]) / total,
+            )
+        })
+        .collect();
+    fit_knots(pts, raw_min, raw_max)
+}
+
+/// Full-travel motor revs + coverage from the stitched chunks, for the gear/
+/// travel anchor. Extrapolates the covered-span revs to the full rail span.
+pub fn stitched_motor_revs(
+    chunks: &[(Vec<u16>, Vec<f64>)],
+    fs: f64,
+    ripple_per_rev: f64,
+    raw_min: u16,
+    raw_max: u16,
+) -> Option<(f64, f64)> {
+    let st = stitch_slope(chunks, fs, ripple_per_rev, raw_min, raw_max)?;
+    let revs = st.cum[st.lc] - st.cum[st.fc];
+    let pot_disp = (st.lc - st.fc) as f64;
+    let count_span = raw_max as f64 - raw_min as f64;
+    let full = crate::kinematics::full_span_motor_revs(revs, pot_disp, count_span);
+    (full != 0.0).then_some((full, st.coverage))
 }
 
 /// Rate (rev/s) at sample index x by linear interp over window centers,
@@ -556,5 +730,126 @@ mod tests {
         let noise: Vec<f64> = (0..4000).map(|_| 512.0 + lcg.next(3.0)).collect();
         assert!(cumulative_phase(&noise, FS, 6.0).is_none(), "pure noise");
         assert!(cumulative_phase(&[1.0; 10], FS, 6.0).is_none(), "too short");
+    }
+
+    // --- build_multi / stitched_motor_revs ---
+
+    // Full nonlinear sweep with a CONSTANT-frequency ripple current: constant
+    // duty => constant motor speed => true fraction f linear in sample index.
+    fn ripple_sweep(a: f64, freq: f64, n: usize) -> (Vec<u16>, Vec<f64>) {
+        let pos: Vec<u16> = (0..n)
+            .map(|k| pot_raw(k as f64 / (n - 1) as f64, a))
+            .collect();
+        let cur = ripple_series(freq, 4.0, 3.0, n);
+        (pos, cur)
+    }
+
+    fn chunkify(pos: &[u16], cur: &[f64], ranges: &[(usize, usize)]) -> Vec<(Vec<u16>, Vec<f64>)> {
+        ranges
+            .iter()
+            .map(|&(lo, hi)| (pos[lo..hi].to_vec(), cur[lo..hi].to_vec()))
+            .collect()
+    }
+
+    #[test]
+    fn build_multi_recovers_full_sweep_from_chunks() {
+        let a = 0.15;
+        let n = 4500;
+        let (pos, cur) = ripple_sweep(a, 1800.0, n);
+        // 5 seq-contiguous chunks with ~100-sample gaps dropped between them
+        let ranges = [
+            (0, 850),
+            (950, 1750),
+            (1850, 2700),
+            (2800, 3600),
+            (3700, 4500),
+        ];
+        let chunks = chunkify(&pos, &cur, &ranges);
+        let lut = build_multi(&chunks, FS, 6.0, RAW_MIN, RAW_MAX);
+        let ident = PotLut::identity(RAW_MIN, RAW_MAX);
+        // (a) not identity
+        assert!(
+            lut.corr.iter().any(|&c| c != 0),
+            "corr all zero {:?}",
+            lut.corr
+        );
+        // (b)/(c) error over the covered chunk samples
+        let mut lut_max = 0.0f64;
+        let mut ident_max = 0.0f64;
+        for &(lo, hi) in ranges.iter() {
+            for (j, &r) in pos[lo..hi].iter().enumerate() {
+                let f = (lo + j) as f64 / (n - 1) as f64;
+                lut_max = lut_max.max((lut.linearize(r) - f).abs());
+                ident_max = ident_max.max((ident.linearize(r) - f).abs());
+            }
+        }
+        assert!(lut_max < 0.025, "lut err {lut_max}");
+        assert!(lut_max < ident_max / 5.0, "lut {lut_max} ident {ident_max}");
+    }
+
+    #[test]
+    fn build_multi_coverage_gate_is_identity() {
+        // chunks covering only the middle ~40% of travel -> below the gate
+        let a = 0.15;
+        let n = 4500;
+        let (pos, cur) = ripple_sweep(a, 1800.0, n);
+        let lo = (0.30 * (n - 1) as f64) as usize;
+        let mid = (0.50 * (n - 1) as f64) as usize;
+        let hi = (0.70 * (n - 1) as f64) as usize;
+        let chunks = chunkify(&pos, &cur, &[(lo, mid), (mid, hi)]);
+        let lut = build_multi(&chunks, FS, 6.0, RAW_MIN, RAW_MAX);
+        assert_eq!(lut, PotLut::identity(RAW_MIN, RAW_MAX));
+    }
+
+    #[test]
+    fn build_multi_single_chunk_reasonable() {
+        let a = 0.15;
+        let n = 4500;
+        let (pos, cur) = ripple_sweep(a, 1800.0, n);
+        let chunks = chunkify(&pos, &cur, &[(0, n)]);
+        let lut = build_multi(&chunks, FS, 6.0, RAW_MIN, RAW_MAX);
+        assert!(
+            lut.corr.iter().any(|&c| c != 0),
+            "corr all zero {:?}",
+            lut.corr
+        );
+        let mut emax = 0.0f64;
+        for (k, &r) in pos.iter().enumerate() {
+            let f = k as f64 / (n - 1) as f64;
+            emax = emax.max((lut.linearize(r) - f).abs());
+        }
+        assert!(emax < 0.025, "linearize err {emax}");
+    }
+
+    #[test]
+    fn stitched_motor_revs_recovers_total() {
+        let a = 0.15;
+        let n = 4500;
+        let (pos, cur) = ripple_sweep(a, 1800.0, n);
+        let ranges = [
+            (0, 850),
+            (950, 1750),
+            (1850, 2700),
+            (2800, 3600),
+            (3700, 4500),
+        ];
+        let chunks = chunkify(&pos, &cur, &ranges);
+        let (full, cov) = stitched_motor_revs(&chunks, FS, 6.0, RAW_MIN, RAW_MAX).expect("revs");
+        // 1800 Hz / 6 = 300 rev/s over N/FS s
+        let total = 300.0 * n as f64 / FS;
+        assert!(
+            (full - total).abs() / total < 0.05,
+            "revs {full} vs {total}"
+        );
+        assert!(cov > MIN_SPAN_COVER && cov <= 1.0, "coverage {cov}");
+    }
+
+    #[test]
+    fn build_multi_and_revs_degenerate() {
+        assert_eq!(
+            build_multi(&[], FS, 6.0, RAW_MIN, RAW_MAX),
+            PotLut::identity(RAW_MIN, RAW_MAX)
+        );
+        assert!(stitched_motor_revs(&[], FS, 6.0, RAW_MIN, RAW_MAX).is_none());
     }
 }

--- a/ident/src/lut.rs
+++ b/ident/src/lut.rs
@@ -88,12 +88,13 @@ impl PotLut {
 }
 
 /// Cumulative motor phase (revs) per sample from a constant-duty sweep's
-/// current series. Slides ripple_speed over the series, integrates the
-/// per-window rev/s (drift-resistant: an occasional dropped window is
-/// interpolated across, not extrapolated from one global rate), and returns
-/// a monotonic phase. None when input is too short or a majority of windows
-/// fail the ripple confidence floor.
-pub fn cumulative_phase(current: &[f64], fs: f64, ripple_per_rev: f64) -> Option<Vec<f64>> {
+/// current series, paired with the fraction of windows that found ripple (a
+/// coverage/confidence metric in `MIN_GOOD_FRAC..=1.0`). Slides ripple_speed
+/// over the series, integrates the per-window rev/s (drift-resistant: an
+/// occasional dropped window is interpolated across, not extrapolated from one
+/// global rate), and returns a monotonic phase. None when input is too short
+/// or a majority of windows fail the ripple confidence floor.
+pub fn cumulative_phase(current: &[f64], fs: f64, ripple_per_rev: f64) -> Option<(Vec<f64>, f64)> {
     let n = current.len();
     if fs <= 0.0 || ripple_per_rev <= 0.0 {
         return None;
@@ -117,6 +118,7 @@ pub fn cumulative_phase(current: &[f64], fs: f64, ripple_per_rev: f64) -> Option
     if centers.len() < 2 || (centers.len() as f64) < MIN_GOOD_FRAC * total as f64 {
         return None;
     }
+    let good_frac = centers.len() as f64 / total as f64;
     // per-sample rev/s: linear interp across window centers, clamped at the
     // ends; cumulative-trapezoid to revs. rev/s >= 0 keeps phase monotone.
     let mut phase = Vec::with_capacity(n);
@@ -129,7 +131,7 @@ pub fn cumulative_phase(current: &[f64], fs: f64, ripple_per_rev: f64) -> Option
         phase.push(acc);
         prev = rs;
     }
-    Some(phase)
+    Some((phase, good_frac))
 }
 
 /// Build the LUT from time-aligned raw pot samples and the cumulative motor
@@ -375,8 +377,9 @@ mod tests {
     fn cumulative_phase_recovers_total_revs() {
         let n = 4000;
         let i = ripple_series(1800.0, 4.0, 3.0, n);
-        let phase = cumulative_phase(&i, FS, 6.0).expect("phase found");
+        let (phase, good) = cumulative_phase(&i, FS, 6.0).expect("phase found");
         assert_eq!(phase.len(), n);
+        assert!((MIN_GOOD_FRAC..=1.0).contains(&good), "coverage {good}");
         // monotone non-decreasing
         assert!(phase.windows(2).all(|w| w[1] >= w[0]));
         // 1800 Hz / 6 = 300 rev/s over (n-1)/fs s

--- a/ident/src/lut.rs
+++ b/ident/src/lut.rs
@@ -22,6 +22,7 @@
 //!   linearize equal to the plain linear fraction.
 
 use crate::ripple;
+use std::collections::BTreeMap;
 
 /// Knot count = the firmware PotLutBlock's lut_corr length.
 const N_KNOTS: usize = 55;
@@ -317,28 +318,39 @@ fn stitch_slope(
         } else {
             continue;
         };
-        // Distribute each pos-change's phase increment across the counts it
-        // crossed (pos is quantized: it steps only every several samples).
-        let mut prev_pos = pos[0];
-        let mut prev_phi = phi[0];
-        for i in 1..pos.len() {
-            if pos[i] != prev_pos {
-                let dphi = phi[i] - prev_phi;
-                let (a, b) = (prev_pos.min(pos[i]), prev_pos.max(pos[i]));
-                let counts = (b - a) as f64;
-                if counts > 0.0 && dphi >= 0.0 {
-                    let s = dphi / counts;
-                    // b maps to the next bin; the top count lands in bin b-1
-                    for c in a..b {
-                        if c >= raw_min && c < raw_max {
-                            let idx = (c - raw_min) as usize;
-                            slope_sum[idx] += s;
-                            slope_cnt[idx] += 1;
-                        }
+        // Collapse oversampling+jitter first: the pot ADC lands many samples on
+        // each count (and dithers +/-1), so a raw per-step scan would split one
+        // count's dphi across many crossings and dilute the averaged slope by
+        // the oversampling factor. Reduce to one mean phase per unique pos.
+        let mut by_pos: BTreeMap<u16, (f64, u32)> = BTreeMap::new();
+        for (&p, &ph) in pos.iter().zip(phi.iter()) {
+            let e = by_pos.entry(p).or_insert((0.0, 0));
+            e.0 += ph;
+            e.1 += 1;
+        }
+        let deduped: Vec<(u16, f64)> = by_pos
+            .into_iter()
+            .map(|(p, (sum, cnt))| (p, sum / cnt as f64))
+            .collect();
+        // Distribute each pos-step's phase increment across the counts it
+        // crossed; each covered count now gets ~one full-per-count contribution
+        // per chunk (multi-chunk overlap still averages correctly).
+        for w in deduped.windows(2) {
+            let (pos_i, phi_i) = w[0];
+            let (pos_j, phi_j) = w[1];
+            let dphi = phi_j - phi_i;
+            let (a, b) = (pos_i.min(pos_j), pos_i.max(pos_j));
+            let counts = (b - a) as f64;
+            if counts > 0.0 && dphi >= 0.0 {
+                let s = dphi / counts;
+                // b maps to the next bin; the top count lands in bin b-1
+                for c in a..b {
+                    if c >= raw_min && c < raw_max {
+                        let idx = (c - raw_min) as usize;
+                        slope_sum[idx] += s;
+                        slope_cnt[idx] += 1;
                     }
                 }
-                prev_pos = pos[i];
-                prev_phi = phi[i];
             }
         }
     }
@@ -851,5 +863,65 @@ mod tests {
             PotLut::identity(RAW_MIN, RAW_MAX)
         );
         assert!(stitched_motor_revs(&[], FS, 6.0, RAW_MIN, RAW_MAX).is_none());
+    }
+
+    // Oversampled + jittered sweep: pos advances well under 1 count/sample (the
+    // pot ADC lands many samples on each count) and dithers +/-1 count. Mirrors
+    // the real capture that undercounted revs ~oversampling-fold before the
+    // per-chunk pos dedup in stitch_slope.
+    fn jitter_ripple_sweep(a: f64, freq: f64, n: usize) -> (Vec<u16>, Vec<f64>) {
+        let mut lcg = Lcg(7);
+        let pos: Vec<u16> = (0..n)
+            .map(|k| {
+                let f = k as f64 / (n - 1) as f64;
+                let j = lcg.next(1.5).round() as i32; // -1, 0, or +1 count
+                (pot_raw(f, a) as i32 + j).clamp(RAW_MIN as i32, RAW_MAX as i32) as u16
+            })
+            .collect();
+        let cur = ripple_series(freq, 4.0, 3.0, n);
+        (pos, cur)
+    }
+
+    #[test]
+    fn stitched_motor_revs_survives_oversampling_and_jitter() {
+        let a = 0.15;
+        // ~8 samples per count over the 3700-count span
+        let n = 30_000;
+        let (pos, cur) = jitter_ripple_sweep(a, 1800.0, n);
+        // 1800 Hz / 6 = 300 rev/s over N/FS s
+        let total = 300.0 * n as f64 / FS;
+        // single oversampled chunk: dedup must recover the full rev count, not
+        // an oversampling-diluted fraction of it
+        let single = vec![(pos.clone(), cur.clone())];
+        let (full1, cov1) = stitched_motor_revs(&single, FS, 6.0, RAW_MIN, RAW_MAX).expect("revs");
+        assert!(
+            (full1 - total).abs() / total < 0.05,
+            "single {full1} vs {total}"
+        );
+        assert!(cov1 > MIN_SPAN_COVER && cov1 <= 1.0, "coverage {cov1}");
+        // same data split into gapped chunks
+        let ranges = [
+            (0, 6000),
+            (6500, 12000),
+            (12500, 18000),
+            (18500, 24000),
+            (24500, 30000),
+        ];
+        let chunks = chunkify(&pos, &cur, &ranges);
+        let (fullc, _) = stitched_motor_revs(&chunks, FS, 6.0, RAW_MIN, RAW_MAX).expect("revs");
+        assert!(
+            (fullc - total).abs() / total < 0.05,
+            "chunked {fullc} vs {total}"
+        );
+        // build_multi's normalized shape still tracks true fraction on jitter
+        let lut = build_multi(&chunks, FS, 6.0, RAW_MIN, RAW_MAX);
+        let mut emax = 0.0f64;
+        for &(lo, hi) in ranges.iter() {
+            for (j, &r) in pos[lo..hi].iter().enumerate() {
+                let f = (lo + j) as f64 / (n - 1) as f64;
+                emax = emax.max((lut.linearize(r) - f).abs());
+            }
+        }
+        assert!(emax < 0.03, "linearize err {emax}");
     }
 }

--- a/ident/src/regs.rs
+++ b/ident/src/regs.rs
@@ -28,13 +28,14 @@ pub mod config {
     pub const V_KAW_Q412: Reg = reg(0x003c, 2);
     pub const J_FF_Q88: Reg = reg(0x003e, 2);
     pub const P_KP_Q88: Reg = reg(0x0040, 2);
-    pub const CURRENT_LIMIT_COUNTS: Reg = reg(0x004a, 2);
-    pub const DRIVE_POLARITY: Reg = reg(0x004d, 1);
-    pub const V_UNDERVOLT_COUNTS: Reg = reg(0x0062, 2);
-    pub const L1_Q016: Reg = reg(0x0068, 2);
-    pub const L2_Q88: Reg = reg(0x006a, 2);
-    pub const L3_Q88: Reg = reg(0x006c, 2);
-    pub const L_BEMF_Q016: Reg = reg(0x006e, 2);
+    pub const POS_DEADBAND_COUNTS: Reg = reg(0x0042, 2);
+    pub const CURRENT_LIMIT_COUNTS: Reg = reg(0x0048, 2);
+    pub const DRIVE_POLARITY: Reg = reg(0x004b, 1);
+    pub const V_UNDERVOLT_COUNTS: Reg = reg(0x0060, 2);
+    pub const L1_Q016: Reg = reg(0x0066, 2);
+    pub const L2_Q88: Reg = reg(0x0068, 2);
+    pub const L3_Q88: Reg = reg(0x006a, 2);
+    pub const L_BEMF_Q016: Reg = reg(0x006c, 2);
 }
 
 pub mod calib {
@@ -127,6 +128,7 @@ pub const ALL: &[(&str, Reg)] = &[
     ("v_kaw_q412", config::V_KAW_Q412),
     ("j_ff_q88", config::J_FF_Q88),
     ("p_kp_q88", config::P_KP_Q88),
+    ("pos_deadband_counts", config::POS_DEADBAND_COUNTS),
     ("current_limit_counts", config::CURRENT_LIMIT_COUNTS),
     ("drive_polarity", config::DRIVE_POLARITY),
     ("v_undervolt_counts", config::V_UNDERVOLT_COUNTS),

--- a/ident/src/regs.rs
+++ b/ident/src/regs.rs
@@ -58,7 +58,7 @@ pub mod calib {
     pub const T0_CC: Reg = reg(0x0104, 2);
     pub const R_Q12: Reg = reg(0x010c, 2);
     pub const RECIP_KE_Q: Reg = reg(0x010e, 2);
-    pub const B_I_Q016: Reg = reg(0x0110, 2);
+    pub const B_I_Q313: Reg = reg(0x0110, 2);
     pub const FRIC_FC_COUNTS: Reg = reg(0x0112, 2);
     pub const FRIC_FV_Q016: Reg = reg(0x0114, 2);
     pub const FRIC_BREAKAWAY_COUNTS: Reg = reg(0x0116, 2);
@@ -150,7 +150,7 @@ pub const ALL: &[(&str, Reg)] = &[
     ("t0_cc", calib::T0_CC),
     ("r_q12", calib::R_Q12),
     ("recip_ke_q", calib::RECIP_KE_Q),
-    ("b_i_q016", calib::B_I_Q016),
+    ("b_i_q313", calib::B_I_Q313),
     ("fric_fc_counts", calib::FRIC_FC_COUNTS),
     ("fric_fv_q016", calib::FRIC_FV_Q016),
     ("fric_breakaway_counts", calib::FRIC_BREAKAWAY_COUNTS),

--- a/ident/src/regs.rs
+++ b/ident/src/regs.rs
@@ -15,6 +15,10 @@ const fn reg(addr: u16, width: u8) -> Reg {
 pub mod config {
     use super::{Reg, reg};
 
+    pub const POS_MIN_PHYS_COUNTS: Reg = reg(0x0020, 4);
+    pub const POS_MAX_PHYS_COUNTS: Reg = reg(0x0024, 4);
+    pub const POS_MIN_SOFT_COUNTS: Reg = reg(0x0028, 4);
+    pub const POS_MAX_SOFT_COUNTS: Reg = reg(0x002c, 4);
     pub const I_KP_Q88: Reg = reg(0x0030, 2);
     pub const I_KI_Q412: Reg = reg(0x0032, 2);
     pub const I_KAW_Q412: Reg = reg(0x0034, 2);
@@ -25,6 +29,7 @@ pub mod config {
     pub const J_FF_Q88: Reg = reg(0x003e, 2);
     pub const P_KP_Q88: Reg = reg(0x0040, 2);
     pub const CURRENT_LIMIT_COUNTS: Reg = reg(0x004a, 2);
+    pub const DRIVE_POLARITY: Reg = reg(0x004d, 1);
     pub const V_UNDERVOLT_COUNTS: Reg = reg(0x0062, 2);
     pub const L1_Q016: Reg = reg(0x0068, 2);
     pub const L2_Q88: Reg = reg(0x006a, 2);
@@ -103,6 +108,10 @@ pub mod telemetry {
 /// Every const above with its descriptor field name - the cross-check
 /// test's worklist, and a name lookup for reports.
 pub const ALL: &[(&str, Reg)] = &[
+    ("pos_min_phys_counts", config::POS_MIN_PHYS_COUNTS),
+    ("pos_max_phys_counts", config::POS_MAX_PHYS_COUNTS),
+    ("pos_min_soft_counts", config::POS_MIN_SOFT_COUNTS),
+    ("pos_max_soft_counts", config::POS_MAX_SOFT_COUNTS),
     ("i_kp_q88", config::I_KP_Q88),
     ("i_ki_q412", config::I_KI_Q412),
     ("i_kaw_q412", config::I_KAW_Q412),
@@ -113,6 +122,7 @@ pub const ALL: &[(&str, Reg)] = &[
     ("j_ff_q88", config::J_FF_Q88),
     ("p_kp_q88", config::P_KP_Q88),
     ("current_limit_counts", config::CURRENT_LIMIT_COUNTS),
+    ("drive_polarity", config::DRIVE_POLARITY),
     ("v_undervolt_counts", config::V_UNDERVOLT_COUNTS),
     ("l1_q016", config::L1_Q016),
     ("l2_q88", config::L2_Q88),

--- a/ident/src/regs.rs
+++ b/ident/src/regs.rs
@@ -40,6 +40,12 @@ pub mod config {
 pub mod calib {
     use super::{Reg, reg};
 
+    // PotLutBlock: the first CALIB block. lut_corr is a 110-byte Bytes field
+    // written as one blob, so it stays out of the scalar ALL cross-check.
+    pub const POT_LUT_RAW_MIN: Reg = reg(0x0080, 2);
+    pub const POT_LUT_RAW_MAX: Reg = reg(0x0082, 2);
+    pub const POT_LUT_CORR: Reg = reg(0x0084, 110);
+
     pub const SHUNT_R_MOHM: Reg = reg(0x00f2, 2);
     pub const GAIN_MILLI: Reg = reg(0x00f4, 2);
     pub const VMOTOR_DIV_TOP: Reg = reg(0x00f6, 2);
@@ -128,6 +134,10 @@ pub const ALL: &[(&str, Reg)] = &[
     ("l2_q88", config::L2_Q88),
     ("l3_q88", config::L3_Q88),
     ("l_bemf_q016", config::L_BEMF_Q016),
+    // lut_corr omitted: a 110-byte Bytes field, not a scalar reg (write_reg
+    // and reg_by_name assume width <= 4); raw_min/raw_max are plain u16.
+    ("raw_min", calib::POT_LUT_RAW_MIN),
+    ("raw_max", calib::POT_LUT_RAW_MAX),
     ("shunt_r_mohm", calib::SHUNT_R_MOHM),
     ("gain_milli", calib::GAIN_MILLI),
     ("vmotor_div_top", calib::VMOTOR_DIV_TOP),

--- a/ident/src/regs.rs
+++ b/ident/src/regs.rs
@@ -52,6 +52,9 @@ pub mod calib {
     pub const FRIC_FV_Q016: Reg = reg(0x0114, 2);
     pub const FRIC_BREAKAWAY_COUNTS: Reg = reg(0x0116, 2);
     pub const KE_VPC_Q: Reg = reg(0x0118, 2);
+    pub const ANGLE_MIN_CDEG: Reg = reg(0x011a, 2);
+    pub const ANGLE_MAX_CDEG: Reg = reg(0x011c, 2);
+    pub const GEAR_RATIO_CENTI: Reg = reg(0x011e, 2);
 }
 
 pub mod control {
@@ -132,6 +135,9 @@ pub const ALL: &[(&str, Reg)] = &[
     ("fric_fv_q016", calib::FRIC_FV_Q016),
     ("fric_breakaway_counts", calib::FRIC_BREAKAWAY_COUNTS),
     ("ke_vpc_q", calib::KE_VPC_Q),
+    ("angle_min_cdeg", calib::ANGLE_MIN_CDEG),
+    ("angle_max_cdeg", calib::ANGLE_MAX_CDEG),
+    ("gear_ratio_centi", calib::GEAR_RATIO_CENTI),
     ("torque_enable", control::TORQUE_ENABLE),
     ("tel_enable", control::TEL_ENABLE),
     ("tel_mask", control::TEL_MASK),

--- a/ident/src/report.rs
+++ b/ident/src/report.rs
@@ -13,14 +13,14 @@ use crate::exp::resistance::ResistanceResult;
 use crate::gains::{EncodedGains, GainSet};
 
 /// The board-D rig's hand-eyeballed seeds (kernel band), for the comparison
-/// column. b_i 655 predates the commit-4 rescale (it was inert under the
-/// old shift-16 coupling) and i_ki was eyeballed ~40x low - the rendered
+/// column. b_i 655 predates both coupling rescales (it was inert under the
+/// original shift-16 form) and i_ki was eyeballed ~40x low - the rendered
 /// note says so instead of bending any formula toward them.
 const HAND_SEEDS: [(&str, u16); 8] = [
     ("r_q12", 13800),
     ("recip_ke_q", 5184),
     ("ke_vpc_q", 809),
-    ("b_i_q016", 655),
+    ("b_i_q313", 655),
     ("i_kp_q88", 863),
     ("i_ki_q412", 205),
     ("fric_fc_counts", 20),
@@ -236,7 +236,7 @@ mod tests {
             gains: Some((&g, &e)),
             ..Default::default()
         });
-        assert!(s.contains("b_i_q016"));
+        assert!(s.contains("b_i_q313"));
         assert!(s.contains("x of 13800"), "hand-seed column missing:\n{s}");
         assert!(s.contains("eyeballed ~40x low"));
     }

--- a/ident/src/ripple.rs
+++ b/ident/src/ripple.rs
@@ -70,23 +70,27 @@ pub fn ripple_speed(i: &[f64], fs: f64, ripple_per_rev: f64) -> Option<RippleEst
         .enumerate()
         .max_by(|a, b| a.1.total_cmp(b.1))
         .map(|(k, _)| k)?;
+    // Reject a peak at either band edge: at lag_min it is short-range sample
+    // correlation (the acceleration/reversal transient locks here), at lag_max
+    // it is the detrend tail - neither is a real ripple period, and only an
+    // interior peak has the two neighbors parabolic interpolation needs.
+    if k == 0 || k + 1 == ac.len() {
+        return None;
+    }
     let strength = ac[k];
     if strength < MIN_STRENGTH {
         return None;
     }
-    // parabolic interpolation around the peak lag (interior peaks only)
-    let lag = (lag_min + k) as f64
-        + if k > 0 && k + 1 < ac.len() {
-            let (a, b, c) = (ac[k - 1], ac[k], ac[k + 1]);
-            let den = a - 2.0 * b + c;
-            if den.abs() > 1e-12 {
-                (0.5 * (a - c) / den).clamp(-0.5, 0.5)
-            } else {
-                0.0
-            }
+    // parabolic interpolation around the peak lag (guaranteed interior above)
+    let lag = (lag_min + k) as f64 + {
+        let (a, b, c) = (ac[k - 1], ac[k], ac[k + 1]);
+        let den = a - 2.0 * b + c;
+        if den.abs() > 1e-12 {
+            (0.5 * (a - c) / den).clamp(-0.5, 0.5)
         } else {
             0.0
-        };
+        }
+    };
     let freq_hz = fs / lag;
     Some(RippleEstimate {
         freq_hz,

--- a/ident/src/ripple.rs
+++ b/ident/src/ripple.rs
@@ -26,12 +26,21 @@ pub struct RippleEstimate {
     pub strength: f64,
 }
 
+/// Lowest ripple frequency the autocorr band tracks; also fixes the max lag
+/// (fs/F_LO samples) and thus ripple_speed's minimum input length.
+const F_LO: f64 = 500.0;
+
+/// Minimum sample count ripple_speed needs at `fs`: 4 periods of the slowest
+/// tracked ripple. cumulative_phase in [`crate::lut`] sizes its window off it.
+pub fn min_window(fs: f64) -> usize {
+    4 * (fs / F_LO).round() as usize
+}
+
 /// Estimate ripple frequency in `i` sampled at `fs` Hz. `ripple_per_rev`
 /// = commutation events per rotor rev (6 for a 3-slot brushed motor).
 /// Searches 500 Hz..fs/5; None when the series is too short, flat, or no
 /// autocorrelation peak clears the confidence floor.
 pub fn ripple_speed(i: &[f64], fs: f64, ripple_per_rev: f64) -> Option<RippleEstimate> {
-    const F_LO: f64 = 500.0;
     const MIN_STRENGTH: f64 = 0.15;
     // band = F_LO .. fs/5: below 5 samples per period the parabolic
     // interpolation has nothing to stand on

--- a/ident/src/slip.rs
+++ b/ident/src/slip.rs
@@ -1,0 +1,187 @@
+//! Gear-slip / stripped-teeth metric from a constant-duty ripple sweep.
+//!
+//! Over a constant-duty full-travel traverse the pot must advance in fixed
+//! proportion to motor rotation: pot counts per motor rev is ~constant for a
+//! sound train. A slipping or stripped mesh makes a segment spike or drop
+//! toward zero (motor spins, pot frozen). Splitting the run into equal-index
+//! segments and measuring per-segment counts/motor-rev exposes that - a high
+//! coefficient of variation, or any core segment near zero, flags the mesh.
+//!
+//! Rail-adjacent segments are excluded: mechanical stiffness or a jam near a
+//! hard stop mimics slip. The metric is RIPPLE_PER_REV-independent (a ratio of
+//! ratios), pure, and wasm-safe. Single sweep is advisory only - a stripped
+//! gear whose slip zone is missed can read healthy, and a bad capture can
+//! false-positive, so the caller must say so.
+
+/// CoV of rail-excluded per-segment counts/motor-rev above this flags slip.
+pub const SLIP_COV_MAX: f64 = 0.20;
+/// A core segment below this fraction of the median counts as stuck.
+pub const STUCK_FRAC: f64 = 0.40;
+
+/// Slip metrics over a rail-excluded constant-duty sweep (see [`slip_metrics`]).
+pub struct SlipReport {
+    /// CoV (pstdev/mean) of rail-excluded per-segment counts/motor-rev.
+    pub slip_cov: f64,
+    /// Min core segment / median positive core segment (stuck -> ~0).
+    pub min_over_median: f64,
+    /// Core segments below STUCK_FRAC * median.
+    pub stuck_count: usize,
+    /// Core segments evaluated (after edge exclusion).
+    pub core_segments: usize,
+    /// slip_cov > SLIP_COV_MAX || stuck_count >= 1.
+    pub flagged: bool,
+}
+
+/// Slip metrics from a constant-duty sweep: time-aligned raw pot samples and
+/// the cumulative motor phase (revs) from lut::cumulative_phase. Splits into
+/// `segments` equal-index chunks, drops `edge_exclude` chunks at each end
+/// (rail stiffness mimics slip), and measures per-segment counts/motor-rev.
+/// RIPPLE_PER_REV-independent (a ratio of ratios). None when input is too
+/// short/mismatched or the run never moved (no positive segment).
+pub fn slip_metrics(
+    pos: &[u16],
+    motor_phase: &[f64],
+    segments: usize,
+    edge_exclude: usize,
+) -> Option<SlipReport> {
+    let n = pos.len();
+    if n != motor_phase.len() || segments < 3 || 2 * edge_exclude >= segments || n < 2 * segments {
+        return None;
+    }
+    // per-segment counts/motor-rev over equal-index chunks; near-zero phase
+    // advance is a stall -> 0 (not a divide-by-tiny spike).
+    let mut locals = Vec::with_capacity(segments);
+    for i in 0..segments {
+        let a = i * n / segments;
+        let z = (i + 1) * n / segments;
+        let dph = motor_phase[z - 1] - motor_phase[a];
+        let dpos = (pos[z - 1] as i32 - pos[a] as i32).unsigned_abs() as f64;
+        locals.push(if dph > 1e-3 { dpos / dph } else { 0.0 });
+    }
+    let core = &locals[edge_exclude..segments - edge_exclude];
+    if core.len() < 3 {
+        return None;
+    }
+    let mut positives: Vec<f64> = core.iter().copied().filter(|&x| x > 0.0).collect();
+    if positives.is_empty() {
+        return None;
+    }
+    let med = median(&mut positives);
+    // mean over ALL core (zeros included), so a stuck segment rightly inflates
+    // the CoV rather than being averaged out of the denominator.
+    let mean = core.iter().sum::<f64>() / core.len() as f64;
+    if mean <= 0.0 {
+        return None;
+    }
+    let var = core.iter().map(|&x| (x - mean) * (x - mean)).sum::<f64>() / core.len() as f64;
+    let slip_cov = var.sqrt() / mean;
+    let min = core.iter().copied().fold(f64::INFINITY, f64::min);
+    let stuck_count = core.iter().filter(|&&x| x < STUCK_FRAC * med).count();
+    let flagged = slip_cov > SLIP_COV_MAX || stuck_count >= 1;
+    Some(SlipReport {
+        slip_cov,
+        min_over_median: min / med,
+        stuck_count,
+        core_segments: core.len(),
+        flagged,
+    })
+}
+
+/// Median of a non-empty slice; sorts in place.
+fn median(v: &mut [f64]) -> f64 {
+    v.sort_by(f64::total_cmp);
+    let m = v.len() / 2;
+    if v.len() % 2 == 1 {
+        v[m]
+    } else {
+        (v[m - 1] + v[m]) / 2.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const N: usize = 800;
+    const SEG: usize = N / 10; // 80 samples/segment at segments=10
+
+    /// Build a sweep: phase advances uniformly (+0.01/sample); pos advances by
+    /// `step(chunk)` counts/sample. Chunk index is `k / SEG`.
+    fn build(step: impl Fn(usize) -> i32) -> (Vec<u16>, Vec<f64>) {
+        let mut pos = Vec::with_capacity(N);
+        let mut phase = Vec::with_capacity(N);
+        let mut val = 0i32;
+        for k in 0..N {
+            pos.push(val as u16);
+            phase.push(0.01 * k as f64);
+            val += step(k / SEG);
+        }
+        (pos, phase)
+    }
+
+    #[test]
+    fn healthy_uniform_is_clean() {
+        let (pos, phase) = build(|_| 2);
+        let r = slip_metrics(&pos, &phase, 10, 1).expect("report");
+        assert_eq!(r.core_segments, 8);
+        assert!(r.slip_cov < 1e-9, "cov {}", r.slip_cov);
+        assert_eq!(r.stuck_count, 0);
+        assert!(
+            (r.min_over_median - 1.0).abs() < 1e-9,
+            "mom {}",
+            r.min_over_median
+        );
+        assert!(!r.flagged);
+    }
+
+    #[test]
+    fn stripped_stuck_core_segment_flags() {
+        // core chunk 5 frozen (motor spins via phase, pot flat) -> local 0
+        let (pos, phase) = build(|c| if c == 5 { 0 } else { 2 });
+        let r = slip_metrics(&pos, &phase, 10, 1).expect("report");
+        assert!(r.stuck_count >= 1, "stuck {}", r.stuck_count);
+        assert!(r.min_over_median < 0.01, "mom {}", r.min_over_median);
+        assert!(r.flagged);
+    }
+
+    #[test]
+    fn high_variance_no_stuck_flags_on_cov() {
+        // core chunks alternate 2/4 counts/sample -> locals 200/400, spread
+        // wide enough to cross the CoV gate with no single stuck segment.
+        let (pos, phase) = build(|c| {
+            if (1..=8).contains(&c) && c % 2 == 0 {
+                4
+            } else {
+                2
+            }
+        });
+        let r = slip_metrics(&pos, &phase, 10, 1).expect("report");
+        assert_eq!(r.stuck_count, 0, "no segment should be stuck");
+        assert!(r.slip_cov > 0.20, "cov {}", r.slip_cov);
+        assert!(r.flagged);
+    }
+
+    #[test]
+    fn rail_edge_stuck_is_excluded() {
+        // edge chunk 0 frozen but every core chunk clean -> not flagged,
+        // proving the first/last edge_exclude chunks are dropped.
+        let (pos, phase) = build(|c| if c == 0 { 0 } else { 2 });
+        let r = slip_metrics(&pos, &phase, 10, 1).expect("report");
+        assert_eq!(r.stuck_count, 0);
+        assert!(r.slip_cov < 1e-9, "cov {}", r.slip_cov);
+        assert!(!r.flagged);
+    }
+
+    #[test]
+    fn degenerate_inputs_are_none() {
+        let (pos, phase) = build(|_| 2);
+        // length mismatch
+        assert!(slip_metrics(&pos, &phase[..N / 2], 10, 1).is_none());
+        // too few samples for the segment count
+        assert!(slip_metrics(&pos[..10], &phase[..10], 10, 1).is_none());
+        // too few segments
+        assert!(slip_metrics(&pos, &phase, 2, 0).is_none());
+        // edge exclusion consumes every segment
+        assert!(slip_metrics(&pos, &phase, 10, 5).is_none());
+    }
+}

--- a/ident/src/units.rs
+++ b/ident/src/units.rs
@@ -1,0 +1,304 @@
+//! Count -> real-world-unit conversion factors and a text report. Derives
+//! amps/volts/degrees per count and the torque constants from the CalibSense
+//! constants the earlier bands pinned plus the calibration outputs
+//! (kinematics + motor Ke). Pure math; matches gains.rs's sense-scale
+//! reasoning (both current and vmotor channels reference VDD as the ADC ref).
+
+use core::f64::consts::PI;
+use core::fmt::Write as _;
+
+use crate::kinematics::{self, KinematicsResult};
+
+/// Wire-readable CalibSense fields (mirrors regs::calib). tick_hz is carried
+/// for completeness but no factor here needs it: firmware reports velocity in
+/// counts/second, so per-tick conversion never enters (see [`derive`]).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SenseParams {
+    pub shunt_r_mohm: u16,
+    pub gain_milli: u16,
+    pub vmotor_div_top: u16,
+    pub vmotor_div_bot: u16,
+    pub vdd_mv: u16,
+    pub tick_hz: u16,
+}
+
+/// Real-unit conversion factors. Non-optional factors are 0.0 on a degenerate
+/// input (zero denominator) rather than an error. The velocity factor is
+/// deg_per_count itself: firmware's omega_hat is counts/second, so
+/// (deg/s per c/s) == deg/count with no tick_hz term - hence no separate field.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct UnitFactors {
+    pub amps_per_count: f64,
+    pub volts_per_count: f64,
+    pub deg_per_count: f64,
+    pub kt_output_ideal_nm_per_a: Option<f64>,
+    pub kt_motor_nm_per_a: Option<f64>,
+}
+
+/// Derive every conversion factor. 4096 = 12-bit ADC full scale (ref = VDD),
+/// 1000 = milli scaling, 100 = centi, 180/PI = deg<->rad.
+pub fn derive(
+    sense: &SenseParams,
+    kin: &KinematicsResult,
+    pos_min_phys: i32,
+    pos_max_phys: i32,
+    ke_vpc_q: u16,
+) -> UnitFactors {
+    let adc_lsb_v = sense.vdd_mv as f64 / 1000.0 / 4096.0;
+    let shunt_ohm = sense.shunt_r_mohm as f64 / 1000.0;
+    let gain = sense.gain_milli as f64 / 1000.0;
+
+    let sense_denom = gain * shunt_ohm;
+    let amps_per_count = if sense_denom > 0.0 {
+        adc_lsb_v / sense_denom
+    } else {
+        0.0
+    };
+
+    let volts_per_count = if sense.vmotor_div_bot != 0 {
+        let vdiv = (sense.vmotor_div_top as f64 + sense.vmotor_div_bot as f64)
+            / sense.vmotor_div_bot as f64;
+        adc_lsb_v * vdiv
+    } else {
+        0.0
+    };
+
+    let deg_per_count = kinematics::deg_per_count(
+        kin.angle_min_cdeg,
+        kin.angle_max_cdeg,
+        pos_min_phys,
+        pos_max_phys,
+    );
+
+    // ke_vpc_q is Q4.12 vcounts per OUTPUT c/s: it was fit against pot (output)
+    // speed, so the gear ratio is already baked in and the OUTPUT torque
+    // constant needs no explicit ratio. This is the lossless upper bound - real
+    // output torque is lower by the unknown gear efficiency.
+    let ke_vpc_phys = ke_vpc_q as f64 / 4096.0;
+    let ke_out_v_per_cps = ke_vpc_phys * volts_per_count;
+    let out_rad_per_cps = deg_per_count.abs() * PI / 180.0;
+    let kt_output_ideal_nm_per_a = if out_rad_per_cps > 0.0 && ke_out_v_per_cps.is_finite() {
+        let kt = ke_out_v_per_cps / out_rad_per_cps;
+        kt.is_finite().then_some(kt)
+    } else {
+        None
+    };
+
+    // Motor-side torque constant divides the output constant back down by the
+    // measured gear ratio. gear_ratio_centi == 0 is the "unset" sentinel.
+    let kt_motor_nm_per_a = match kt_output_ideal_nm_per_a {
+        Some(kt) if kin.gear_ratio_centi != 0 => {
+            let gear_ratio = kin.gear_ratio_centi as f64 / 100.0;
+            Some(kt / gear_ratio)
+        }
+        _ => None,
+    };
+
+    UnitFactors {
+        amps_per_count,
+        volts_per_count,
+        deg_per_count,
+        kt_output_ideal_nm_per_a,
+        kt_motor_nm_per_a,
+    }
+}
+
+fn opt(v: Option<f64>) -> String {
+    match v {
+        Some(v) => format!("{v:.6}"),
+        None => "unset".into(),
+    }
+}
+
+/// Render the `[units]` report section: each factor with its real unit, plus a
+/// caveat that output torque is a lossless upper bound and that angle/torque
+/// accuracy ride on the pot LUT and the measured gear ratio.
+pub fn render(f: &UnitFactors) -> String {
+    let mut s = String::new();
+    render_into(&mut s, f);
+    s
+}
+
+/// [`render`] appending into a caller-owned buffer.
+pub fn render_into(s: &mut String, f: &UnitFactors) {
+    let _ = writeln!(s, "[units]");
+    let _ = writeln!(s, "  amps_per_count   {:.9} A/count", f.amps_per_count);
+    let _ = writeln!(s, "  volts_per_count  {:.9} V/count", f.volts_per_count);
+    let _ = writeln!(
+        s,
+        "  deg_per_count    {:.6} deg/count (also deg/s per c/s)",
+        f.deg_per_count
+    );
+    let _ = writeln!(
+        s,
+        "  kt_output_ideal  {} N.m/A (lossless upper bound)",
+        opt(f.kt_output_ideal_nm_per_a)
+    );
+    let _ = writeln!(s, "  kt_motor         {} N.m/A", opt(f.kt_motor_nm_per_a));
+    let _ = writeln!(
+        s,
+        "  note: output torque is a lossless upper bound - real is lower by the\n  \
+         unknown gear efficiency; angle and torque accuracy depend on the pot\n  \
+         LUT and the measured gear ratio."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kin(gear_ratio_centi: u16) -> KinematicsResult {
+        // 190 deg over a 3800-count span -> deg_per_count = 0.05
+        KinematicsResult {
+            angle_min_cdeg: 0,
+            angle_max_cdeg: 19000,
+            gear_ratio_centi,
+        }
+    }
+
+    #[test]
+    fn amps_and_volts_per_count_hand_computed() {
+        // vdd 3300 mV -> lsb = 3.3/4096 = 805.664 uV; shunt 0.033 ohm, G 15.0
+        let sense = SenseParams {
+            shunt_r_mohm: 33,
+            gain_milli: 15_000,
+            vmotor_div_top: 18_200,
+            vmotor_div_bot: 10_000,
+            vdd_mv: 3300,
+            tick_hz: 20_100,
+        };
+        let f = derive(&sense, &kin(0), 100, 3900, 0);
+        let lsb = 3.3 / 4096.0;
+        assert!((f.amps_per_count - lsb / (15.0 * 0.033)).abs() < 1e-12);
+        let vdiv = 28_200.0 / 10_000.0;
+        assert!((f.volts_per_count - lsb * vdiv).abs() < 1e-12);
+    }
+
+    #[test]
+    fn deg_per_count_passthrough_and_torque_derivation() {
+        // Choose values so kt_output_ideal is a round number.
+        // deg_per_count = 0.05 -> out_rad_per_cps = 0.05*PI/180.
+        // volts_per_count = lsb*vdiv, ke_vpc_q/4096 * volts_per_count = ke_out_v.
+        let sense = SenseParams {
+            shunt_r_mohm: 33,
+            gain_milli: 15_000,
+            vmotor_div_top: 18_200,
+            vmotor_div_bot: 10_000,
+            vdd_mv: 3300,
+            tick_hz: 20_100,
+        };
+        let ke_vpc_q = 4096; // ke_vpc_phys = 1.0
+        let f = derive(&sense, &kin(15000), 100, 3900, ke_vpc_q);
+        assert!((f.deg_per_count - 0.05).abs() < 1e-12);
+
+        let lsb = 3.3 / 4096.0;
+        let vpc = lsb * 28_200.0 / 10_000.0;
+        let out_rad = 0.05 * PI / 180.0;
+        let expect_out = vpc / out_rad;
+        assert!((f.kt_output_ideal_nm_per_a.unwrap() - expect_out).abs() < 1e-9);
+
+        // kt_motor = kt_output_ideal / (gear_ratio_centi/100)
+        let gear = 15000.0 / 100.0;
+        assert!((f.kt_motor_nm_per_a.unwrap() - expect_out / gear).abs() < 1e-9);
+        assert!(
+            (f.kt_motor_nm_per_a.unwrap() - f.kt_output_ideal_nm_per_a.unwrap() / gear).abs()
+                < 1e-12
+        );
+    }
+
+    #[test]
+    fn kt_motor_none_when_gear_unset() {
+        let sense = SenseParams {
+            shunt_r_mohm: 33,
+            gain_milli: 15_000,
+            vmotor_div_top: 18_200,
+            vmotor_div_bot: 10_000,
+            vdd_mv: 3300,
+            tick_hz: 20_100,
+        };
+        let f = derive(&sense, &kin(0), 100, 3900, 4096);
+        assert!(f.kt_output_ideal_nm_per_a.is_some());
+        assert!(f.kt_motor_nm_per_a.is_none());
+    }
+
+    #[test]
+    fn degenerate_guards_no_panic() {
+        let base = SenseParams {
+            shunt_r_mohm: 33,
+            gain_milli: 15_000,
+            vmotor_div_top: 18_200,
+            vmotor_div_bot: 10_000,
+            vdd_mv: 3300,
+            tick_hz: 20_100,
+        };
+
+        // zero shunt -> amps_per_count 0
+        let f = derive(
+            &SenseParams {
+                shunt_r_mohm: 0,
+                ..base
+            },
+            &kin(15000),
+            100,
+            3900,
+            4096,
+        );
+        assert_eq!(f.amps_per_count, 0.0);
+
+        // zero gain -> amps_per_count 0
+        let f = derive(
+            &SenseParams {
+                gain_milli: 0,
+                ..base
+            },
+            &kin(15000),
+            100,
+            3900,
+            4096,
+        );
+        assert_eq!(f.amps_per_count, 0.0);
+
+        // zero divider bottom -> volts_per_count 0 and torque None (no volts)
+        let f = derive(
+            &SenseParams {
+                vmotor_div_bot: 0,
+                ..base
+            },
+            &kin(15000),
+            100,
+            3900,
+            4096,
+        );
+        // zero volts scale propagates to a zero torque constant (the division
+        // denominator out_rad is still finite, so it is Some(0.0), not None)
+        assert_eq!(f.volts_per_count, 0.0);
+        assert_eq!(f.kt_output_ideal_nm_per_a, Some(0.0));
+        assert_eq!(f.kt_motor_nm_per_a, Some(0.0));
+
+        // zero deg_per_count (zero phys span) -> torque None
+        let f = derive(&base, &kin(15000), 512, 512, 4096);
+        assert_eq!(f.deg_per_count, 0.0);
+        assert!(f.kt_output_ideal_nm_per_a.is_none());
+        assert!(f.kt_motor_nm_per_a.is_none());
+    }
+
+    #[test]
+    fn render_shows_section_and_unset() {
+        let f = UnitFactors {
+            amps_per_count: 1.6e-3,
+            volts_per_count: 2.27e-3,
+            deg_per_count: 0.05,
+            kt_output_ideal_nm_per_a: Some(0.5),
+            kt_motor_nm_per_a: None,
+        };
+        let s = render(&f);
+        assert!(s.contains("[units]"));
+        assert!(s.contains("amps_per_count"));
+        assert!(s.contains("kt_motor"));
+        assert!(
+            s.contains("unset"),
+            "kt_motor None should render unset:\n{s}"
+        );
+        assert!(s.contains("lossless upper bound"));
+    }
+}

--- a/tools/osc/Cargo.lock
+++ b/tools/osc/Cargo.lock
@@ -138,6 +138,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +178,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +201,12 @@ dependencies = [
  "libc",
  "objc2",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "errno"
@@ -224,6 +256,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +305,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -310,7 +359,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "windows-sys 0.48.0",
 ]
@@ -349,6 +398,7 @@ dependencies = [
  "anyhow",
  "clap",
  "ctrlc",
+ "dialoguer",
  "libc",
  "osc-client",
  "osc-ident",
@@ -414,6 +464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,8 +478,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -470,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,10 +568,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -657,6 +771,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/tools/osc/Cargo.toml
+++ b/tools/osc/Cargo.toml
@@ -12,6 +12,7 @@ license     = "MIT OR Apache-2.0"
 anyhow       = "1"
 clap         = { version = "4", features = ["derive"] }
 ctrlc        = "3"
+dialoguer    = "0.11"
 libc         = "0.2"
 osc-client   = { path = "../../client" }
 osc-ident    = { path = "../../ident" }

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -164,20 +164,29 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     // pot LUT from the same sweep; identity when the ripple SNR is too low to
     // clock true angle. No sweep at all -> None, LUT left untouched below.
     let lut = sweep.as_ref().map(|(pos, current)| {
+        let (raw_min, raw_max) = (pos_min_phys as u16, pos_max_phys as u16);
         let phase = lut::cumulative_phase(current, fs, RIPPLE_PER_REV);
-        let populated = phase.is_some();
+        let phase_found = phase.is_some();
         let l = match phase {
-            Some((p, _)) => lut::build(pos, &p, pos_min_phys as u16, pos_max_phys as u16),
-            None => PotLut::identity(pos_min_phys as u16, pos_max_phys as u16),
+            Some((p, _)) => lut::build(pos, &p, raw_min, raw_max),
+            None => PotLut::identity(raw_min, raw_max),
         };
-        (l, populated)
+        // build may return identity even with a phase (low span coverage), so
+        // read populated off the result, not phase.is_some().
+        let populated = l.corr.iter().any(|&c| c != 0);
+        let coverage = lut::span_coverage(pos, raw_min, raw_max);
+        (l, phase_found, populated, coverage)
     });
     match &lut {
-        Some((l, true)) => {
+        Some((l, _, true, _)) => {
             let maxc = l.corr.iter().map(|&c| c.unsigned_abs()).max().unwrap_or(0);
             println!("pot LUT: populated, max |corr| {maxc} counts");
         }
-        Some((_, false)) => println!("pot LUT: identity (ripple SNR too low)"),
+        Some((_, false, _, _)) => println!("pot LUT: identity (ripple SNR too low)"),
+        Some((_, true, false, coverage)) => println!(
+            "pot LUT: identity (sweep covered only {:.0}% of travel)",
+            coverage * 100.0
+        ),
         None => {}
     }
 
@@ -218,7 +227,7 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     write_reg(&mut c, id, calib::ANGLE_MAX_CDEG, angle_max_cdeg as i32)?;
     write_reg(&mut c, id, calib::GEAR_RATIO_CENTI, gear_ratio_centi as i32)?;
 
-    if let Some((l, _)) = &lut {
+    if let Some((l, ..)) = &lut {
         write_pot_lut(&mut c, id, l)?;
     }
 

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -1,11 +1,14 @@
 //! `osc cal` -- the calibration orchestrator: find the mechanical end-stops,
 //! confirm the real-world angle range with the operator, print the
 //! count->unit report, then write the limits + drive polarity + angle
-//! endpoints and persist with MGMT SAVE. Interactive by default; flags make
-//! it headless. Gear ratio here is an operator input only - measuring it (a
-//! TEL ripple sweep) is a later commit. The endstop state machine and the
-//! kinematics/units math live in osc-ident; this wrapper owns USB, prompts,
-//! and files.
+//! endpoints + gear + pot LUT and persist with MGMT SAVE. Interactive by
+//! default; flags make it headless. With `--tel-port` the rail-to-rail seek
+//! streams a TEL current+pos sweep: its commutation ripple gives a MEASURED
+//! gear ratio (the gear prompt's default) and fills the pot linearization
+//! LUT. Both are gear-2-dependent and degrade gracefully (identity LUT /
+//! operator-input gear) when ripple SNR is low. The endstop state machine and
+//! the kinematics/units/lut math live in osc-ident; this wrapper owns USB,
+//! the TEL port, prompts, and files.
 
 use std::path::Path;
 use std::sync::atomic::Ordering;
@@ -17,14 +20,25 @@ use osc_client::Id;
 use osc_client::blocking::Client;
 use osc_client::nusb::NusbPipe;
 use osc_ident::exp::endstop::{Endstop, EndstopCfg, EndstopResult};
-use osc_ident::exp::{Guarded, RigParams};
+use osc_ident::exp::{Cmd, Experiment, Guarded, RigParams};
+use osc_ident::frame::{TelFrame, TelemetrySnapshot};
 use osc_ident::kinematics::{self, KinematicsResult, angle_endpoints};
+use osc_ident::lut::{self, PotLut};
 use osc_ident::regs::{calib, config, control};
+use osc_ident::ripple;
 use osc_ident::units::{self, SenseParams};
 
 use crate::rig::csvio::{OutDir, SnapshotLog};
 use crate::rig::pump::{self, Pump, read_snapshot, write_reg};
 use crate::rig::snapshot::{self, read_u16};
+
+/// Commutation events per rotor rev for the brushed 3-slot motor: the ripple
+/// tach and the LUT angle clock both count 6 per revolution.
+const RIPPLE_PER_REV: f64 = 6.0;
+
+/// Autocorr strength below this flags the ripple gear estimate as
+/// low-confidence in the printout (still used - expected on a stripped gear).
+const RIPPLE_CONF_MIN: f64 = 0.3;
 
 /// Assumed total rated travel when the operator gives no phys angle: a 0..180
 /// deg span. Only a default; every real servo overrides it.
@@ -52,6 +66,10 @@ pub struct Args {
     /// Known gear ratio (motor rev per output rev); unset leaves it 0.
     #[arg(long)]
     gear_ratio: Option<f64>,
+    /// TEL stream serial device (the LinkE CDC); empty disables the ripple
+    /// sweep (no measured gear, LUT left untouched).
+    #[arg(long, default_value = "")]
+    tel_port: String,
     /// Assume yes: never prompt. Required values must come from flags.
     #[arg(long)]
     yes: bool,
@@ -64,6 +82,8 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     let id = Id::new(id);
 
     let sense = read_sense(&mut c, id)?;
+    // TEL frames arrive one per fast tick, so tick_hz is the sweep sample rate.
+    let fs = sense.tick_hz as f64;
     let ke_vpc_q = read_u16(&mut c, id, calib::KE_VPC_Q)?;
     if ke_vpc_q == 0 {
         eprintln!("warning: ke_vpc_q is 0 - run `osc ident` first for the torque report");
@@ -78,8 +98,9 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
         }
     }
 
+    let tel_port = (!args.tel_port.is_empty()).then(|| args.tel_port.clone());
     let out = OutDir::create(args.out.as_deref().unwrap_or(Path::new("./cal-out")))?;
-    let r = run_endstop(&mut c, id, &out)?;
+    let (r, tel) = run_endstop(&mut c, id, &out, tel_port)?;
     let EndstopResult {
         pos_min_phys,
         pos_max_phys,
@@ -92,11 +113,60 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
         if drive_polarity { "normal" } else { "reversed" },
     );
 
+    // The clean full-travel traverse = the longest monotonic-pos run of the
+    // captured frames; the pure lut/ripple fns then take it from here.
+    let sweep = build_sweep(&tel);
+    if let Some((pos, _)) = &sweep {
+        println!(
+            "[sweep] {} tel frames, monotonic run {} (fs {fs:.0} Hz from tick_hz)",
+            tel.len(),
+            pos.len()
+        );
+    }
+
     recenter(&mut c, id, pos_min_phys, pos_max_phys, drive_polarity)?;
 
     let (phys_min, phys_max) = phys_angles(args)?;
     let (soft_min_deg, soft_max_deg) = soft_angles(args, phys_min, phys_max)?;
-    let gear_ratio_centi = gear_ratio(args)?;
+    let (angle_min_cdeg, angle_max_cdeg) = angle_endpoints(phys_min, phys_max);
+    let dpc = kinematics::deg_per_count(angle_min_cdeg, angle_max_cdeg, pos_min_phys, pos_max_phys);
+
+    // measure-first: the ripple-derived gear ratio is the prompt's default,
+    // the operator overrides. None (no sweep / low SNR / 0) keeps commit 6's
+    // plain-input behavior.
+    let measured = sweep.as_ref().and_then(|s| measure_gear(s, fs, dpc));
+    if let Some((centi, strength)) = measured {
+        let conf = if strength < RIPPLE_CONF_MIN {
+            " (low confidence)"
+        } else {
+            ""
+        };
+        println!(
+            "measured gear ratio {:.2}, ripple-derived{conf}",
+            centi as f64 / 100.0
+        );
+    }
+    let gear_ratio_centi = gear_ratio(args, measured.map(|(c, _)| c))?;
+
+    // pot LUT from the same sweep; identity when the ripple SNR is too low to
+    // clock true angle. No sweep at all -> None, LUT left untouched below.
+    let lut = sweep.as_ref().map(|(pos, current)| {
+        let phase = lut::cumulative_phase(current, fs, RIPPLE_PER_REV);
+        let populated = phase.is_some();
+        let l = match phase {
+            Some(p) => lut::build(pos, &p, pos_min_phys as u16, pos_max_phys as u16),
+            None => PotLut::identity(pos_min_phys as u16, pos_max_phys as u16),
+        };
+        (l, populated)
+    });
+    match &lut {
+        Some((l, true)) => {
+            let maxc = l.corr.iter().map(|&c| c.unsigned_abs()).max().unwrap_or(0);
+            println!("pot LUT: populated, max |corr| {maxc} counts");
+        }
+        Some((_, false)) => println!("pot LUT: identity (ripple SNR too low)"),
+        None => {}
+    }
 
     // soft angle -> phys count via the linear phys map, clamped to the rails
     let soft_min_count =
@@ -104,7 +174,6 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     let soft_max_count =
         soft_to_count(soft_max_deg, phys_min, phys_max, pos_min_phys, pos_max_phys);
 
-    let (angle_min_cdeg, angle_max_cdeg) = angle_endpoints(phys_min, phys_max);
     let kin = KinematicsResult {
         angle_min_cdeg,
         angle_max_cdeg,
@@ -113,7 +182,6 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     let factors = units::derive(&sense, &kin, pos_min_phys, pos_max_phys, ke_vpc_q);
     print!("{}", units::render(&factors));
 
-    let dpc = kinematics::deg_per_count(angle_min_cdeg, angle_max_cdeg, pos_min_phys, pos_max_phys);
     println!("deg/count {dpc:.6}");
     println!(
         "phys angle {phys_min:.2}..{phys_max:.2} deg, soft angle {soft_min_deg:.2}..{soft_max_deg:.2} deg"
@@ -137,10 +205,96 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     write_reg(&mut c, id, calib::ANGLE_MAX_CDEG, angle_max_cdeg as i32)?;
     write_reg(&mut c, id, calib::GEAR_RATIO_CENTI, gear_ratio_centi as i32)?;
 
+    if let Some((l, _)) = &lut {
+        write_pot_lut(&mut c, id, l)?;
+    }
+
     // SAVE needs torque off (protocol sec 9.4); park was already torque-off.
     write_reg(&mut c, id, control::TORQUE_ENABLE, 0)?;
     c.save(id).context("MGMT SAVE")?;
     println!("saved");
+    Ok(())
+}
+
+/// Time-aligned (pos, current) sweep from the captured frames: the longest
+/// monotonic-pos run is the clean constant-duty full-travel traverse. None
+/// when no frames were captured or the run is too short to fit anything.
+fn build_sweep(tel: &[TelFrame]) -> Option<(Vec<u16>, Vec<f64>)> {
+    if tel.is_empty() {
+        return None;
+    }
+    let samples: Vec<(u16, f64)> = tel
+        .iter()
+        .filter_map(|f| Some((f.pos?, f.current? as f64)))
+        .collect();
+    let (pos, current) = longest_monotonic_run(&samples);
+    (pos.len() >= 2).then_some((pos, current))
+}
+
+/// Longest run of consecutive samples whose pos is monotonic (non-decreasing
+/// OR non-increasing); equal steps keep both directions alive.
+fn longest_monotonic_run(samples: &[(u16, f64)]) -> (Vec<u16>, Vec<f64>) {
+    if samples.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+    let (mut best_lo, mut best_hi) = (0usize, 1usize);
+    let (mut inc_start, mut dec_start) = (0usize, 0usize);
+    for i in 1..samples.len() {
+        let (prev, cur) = (samples[i - 1].0, samples[i].0);
+        if cur < prev {
+            inc_start = i;
+        }
+        if cur > prev {
+            dec_start = i;
+        }
+        let inc_len = i + 1 - inc_start;
+        let dec_len = i + 1 - dec_start;
+        let (start, len) = if inc_len >= dec_len {
+            (inc_start, inc_len)
+        } else {
+            (dec_start, dec_len)
+        };
+        if len > best_hi - best_lo {
+            best_lo = start;
+            best_hi = i + 1;
+        }
+    }
+    let run = &samples[best_lo..best_hi];
+    (
+        run.iter().map(|s| s.0).collect(),
+        run.iter().map(|s| s.1).collect(),
+    )
+}
+
+/// Ripple-derived gear ratio (centi) + autocorr strength from a monotonic
+/// sweep. None when the ripple SNR is too low to clock motor speed or the
+/// result degenerates to the 0 sentinel.
+fn measure_gear(sweep: &(Vec<u16>, Vec<f64>), fs: f64, dpc: f64) -> Option<(u16, f64)> {
+    let (pos, current) = sweep;
+    let n = pos.len();
+    if n < 2 || fs <= 0.0 {
+        return None;
+    }
+    let est = ripple::ripple_speed(current, fs, RIPPLE_PER_REV)?;
+    let dt = (n - 1) as f64 / fs;
+    // endpoint slope of pos vs time = output shaft speed in counts/s
+    let pot_omega_cps = ((pos[n - 1] as f64 - pos[0] as f64) / dt).abs();
+    let centi = kinematics::gear_ratio_centi(est.motor_rev_s, pot_omega_cps, dpc);
+    (centi != 0).then_some((centi, est.strength))
+}
+
+/// Write the PotLutBlock: raw_min/raw_max as scalars, then the 55 corr knots
+/// as one 110-byte blob (lut_corr is a single Bytes field, so a bulk write
+/// beats 55 round-trips and matches the on-servo layout exactly).
+fn write_pot_lut(c: &mut Client<NusbPipe>, id: Id, lut: &PotLut) -> Result<()> {
+    write_reg(c, id, calib::POT_LUT_RAW_MIN, lut.raw_min as i32)?;
+    write_reg(c, id, calib::POT_LUT_RAW_MAX, lut.raw_max as i32)?;
+    let mut bytes = [0u8; 110];
+    for (i, &k) in lut.corr.iter().enumerate() {
+        bytes[2 * i..2 * i + 2].copy_from_slice(&k.to_le_bytes());
+    }
+    c.write(id, calib::POT_LUT_CORR.addr, &bytes)
+        .context("write pot lut corr")?;
     Ok(())
 }
 
@@ -155,20 +309,47 @@ fn read_sense(c: &mut Client<NusbPipe>, id: Id) -> Result<SenseParams> {
     })
 }
 
-fn run_endstop(c: &mut Client<NusbPipe>, id: Id, out: &OutDir) -> Result<EndstopResult> {
+fn run_endstop(
+    c: &mut Client<NusbPipe>,
+    id: Id,
+    out: &OutDir,
+    tel_port: Option<String>,
+) -> Result<(EndstopResult, Vec<TelFrame>)> {
     println!("[endstop] seeking both rails (pos guard off)");
     // pos guard off: driving into the physical ends IS the method
     let params = RigParams::default().without_pos_guard();
     let mut log = SnapshotLog::create(out, "endstop_snapshots.csv")?;
     let mut exp = Guarded::new(Endstop::new(EndstopCfg::default(), &params), params);
-    let ran = Pump {
-        client: c,
-        id,
-        tel_port: None,
-        tel_mask: 0,
-        log: Some(&mut log),
-    }
-    .run(&mut exp, |_| {});
+    let mut tel: Vec<TelFrame> = Vec::new();
+    // 0x1B = pos|current|duty|vdiff (same TEL mask as ident inertia)
+    let tel_mask: u16 = 0x1B;
+    let ran = if let Some(port) = tel_port {
+        // Endstop itself never enables TEL; wrap it so the pump streams the
+        // side-channel around the rail-to-rail seek (the second seek is a
+        // constant-duty full-travel sweep - the LUT/gear source).
+        let mut wrap = TelWrap {
+            inner: &mut exp,
+            phase: TelInject::MaskOn,
+            mask: tel_mask,
+        };
+        Pump {
+            client: c,
+            id,
+            tel_port: Some(port),
+            tel_mask,
+            log: Some(&mut log),
+        }
+        .run(&mut wrap, |frames| tel.extend_from_slice(frames))
+    } else {
+        Pump {
+            client: c,
+            id,
+            tel_port: None,
+            tel_mask: 0,
+            log: Some(&mut log),
+        }
+        .run(&mut exp, |_| {})
+    };
     // park safe whether the run finished, errored, or was ctrl-c'd
     let _ = write_reg(c, id, control::GOAL_DUTY, 0);
     let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
@@ -176,9 +357,75 @@ fn run_endstop(c: &mut Client<NusbPipe>, id: Id, out: &OutDir) -> Result<Endstop
     if let Some(reason) = exp.abort() {
         bail!("endstop aborted by the safety envelope: {reason:?}");
     }
-    exp.into_inner()
+    let r = exp
+        .into_inner()
         .result()
-        .context("endstop did not reach both rails - no writes")
+        .context("endstop did not reach both rails - no writes")?;
+    Ok((r, tel))
+}
+
+/// Injects the TEL enable/mask writes around an inner experiment so the pump
+/// opens the side-channel for a run that would not enable TEL on its own
+/// (Endstop). Prepends mask+enable, delegates the body, appends enable=0 +
+/// mask=0 when the inner run reports Done.
+enum TelInject {
+    MaskOn,
+    EnaOn,
+    Body,
+    EnaOff,
+    MaskOff,
+    Done,
+}
+
+struct TelWrap<'a, E> {
+    inner: &'a mut E,
+    phase: TelInject,
+    mask: u16,
+}
+
+impl<E: Experiment> Experiment for TelWrap<'_, E> {
+    fn step(&mut self, obs: Option<&TelemetrySnapshot>) -> Cmd {
+        match self.phase {
+            TelInject::MaskOn => {
+                self.phase = TelInject::EnaOn;
+                Cmd::Write {
+                    reg: control::TEL_MASK,
+                    value: self.mask as i32,
+                }
+            }
+            TelInject::EnaOn => {
+                self.phase = TelInject::Body;
+                Cmd::Write {
+                    reg: control::TEL_ENABLE,
+                    value: 1,
+                }
+            }
+            TelInject::Body => {
+                let cmd = self.inner.step(obs);
+                if matches!(cmd, Cmd::Done) {
+                    self.phase = TelInject::EnaOff;
+                    Cmd::Write {
+                        reg: control::TEL_ENABLE,
+                        value: 0,
+                    }
+                } else {
+                    cmd
+                }
+            }
+            TelInject::EnaOff => {
+                self.phase = TelInject::MaskOff;
+                Cmd::Write {
+                    reg: control::TEL_MASK,
+                    value: 0,
+                }
+            }
+            TelInject::MaskOff => {
+                self.phase = TelInject::Done;
+                Cmd::Done
+            }
+            TelInject::Done => Cmd::Done,
+        }
+    }
 }
 
 /// Drive to the rail midpoint so the servo does not rest on a hard stop.
@@ -270,10 +517,19 @@ fn soft_angles(args: &Args, phys_min: f64, phys_max: f64) -> Result<(f64, f64)> 
     Ok((min, max))
 }
 
-/// Gear ratio as centi (x100); 0 is the firmware "unset" sentinel.
-fn gear_ratio(args: &Args) -> Result<u16> {
-    let ratio = if args.yes {
-        args.gear_ratio
+/// Gear ratio as centi (x100); 0 is the firmware "unset" sentinel. `measured`
+/// (ripple-derived) is the measure-first default: under `--yes` it becomes the
+/// value with no prompt; interactively it is the prompt's default the operator
+/// can override. None keeps commit 6's plain-input behavior.
+fn gear_ratio(args: &Args, measured: Option<u16>) -> Result<u16> {
+    if args.yes {
+        return Ok(measured.unwrap_or_else(|| ratio_to_centi(args.gear_ratio)));
+    }
+    let ratio = if let Some(m) = measured {
+        Some(input_f64(
+            "gear ratio (motor rev per output rev)",
+            m as f64 / 100.0,
+        )?)
     } else if let Some(g) = args.gear_ratio {
         Some(input_f64("gear ratio (motor rev per output rev)", g)?)
     } else if confirm("enter a known gear ratio", false)? {
@@ -337,6 +593,36 @@ mod tests {
     #[test]
     fn soft_degenerate_phys_span_is_min_rail() {
         assert_eq!(soft_to_count(50.0, 90.0, 90.0, 100, 4000), 100);
+    }
+
+    #[test]
+    fn monotonic_run_picks_longest_clean_traverse() {
+        // rising 5, a bump, then a longer falling run of 6 -> the fall wins
+        let s: Vec<(u16, f64)> = [10u16, 20, 30, 40, 50, 45, 60, 55, 44, 33, 22, 11]
+            .iter()
+            .map(|&p| (p, p as f64))
+            .collect();
+        let (pos, cur) = longest_monotonic_run(&s);
+        assert_eq!(pos, vec![60, 55, 44, 33, 22, 11]);
+        assert_eq!(cur.len(), pos.len());
+    }
+
+    #[test]
+    fn monotonic_run_allows_equal_steps() {
+        let s: Vec<(u16, f64)> = [1u16, 1, 2, 2, 3, 3].iter().map(|&p| (p, 0.0)).collect();
+        let (pos, _) = longest_monotonic_run(&s);
+        assert_eq!(pos, vec![1, 1, 2, 2, 3, 3]);
+    }
+
+    #[test]
+    fn monotonic_run_empty_and_single() {
+        assert_eq!(longest_monotonic_run(&[]), (Vec::new(), Vec::new()));
+        assert_eq!(longest_monotonic_run(&[(7, 1.0)]), (vec![7], vec![1.0]));
+    }
+
+    #[test]
+    fn build_sweep_none_without_frames() {
+        assert!(build_sweep(&[]).is_none());
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -324,6 +324,13 @@ fn build_sweep(tel: &[TelFrame]) -> Option<(Vec<u16>, Vec<f64>)> {
 /// certainly a corruption fragment, so it is dropped from the stitch.
 const MIN_CHUNK_SAMPLES: usize = 200;
 
+/// A chunk whose pos span is below this is a STALL, not a sweep segment: the
+/// open-loop constant-duty traverse can overshoot into a rail and buzz there
+/// with pos frozen while commutation ripple keeps accruing revs. Such a chunk
+/// has many samples but ~0 pos travel, so its revs/count is nonsense (spikes
+/// the stitched anchor and dumps a bogus rail correction); drop it by span.
+const MIN_CHUNK_SPAN: u16 = 50;
+
 /// ALL clean sweep chunks (not just the longest): each maximal run of
 /// seq-contiguous, in-range (pos<=4095) frames, as (pos, current). Chunks
 /// shorter than MIN_CHUNK_SAMPLES are dropped as corruption fragments. The
@@ -354,9 +361,18 @@ pub(super) fn build_sweep_chunks(tel: &[TelFrame]) -> Vec<(Vec<u16>, Vec<f64>)> 
 }
 
 /// Push one maximal seq-contiguous run as a (pos, current) chunk, dropping it
-/// when shorter than MIN_CHUNK_SAMPLES.
+/// when shorter than MIN_CHUNK_SAMPLES or when its pos span is below
+/// MIN_CHUNK_SPAN (a rail stall, not a sweep segment).
 fn emit_chunk(run: &[(u8, u16, f64)], chunks: &mut Vec<(Vec<u16>, Vec<f64>)>) {
-    if run.len() >= MIN_CHUNK_SAMPLES {
+    if run.len() < MIN_CHUNK_SAMPLES {
+        return;
+    }
+    let (mut lo, mut hi) = (run[0].1, run[0].1);
+    for x in run {
+        lo = lo.min(x.1);
+        hi = hi.max(x.1);
+    }
+    if hi - lo >= MIN_CHUNK_SPAN {
         chunks.push((
             run.iter().map(|x| x.1).collect(),
             run.iter().map(|x| x.2).collect(),
@@ -1027,27 +1043,40 @@ mod tests {
     }
 
     #[test]
-    fn build_sweep_chunks_keeps_big_runs_drops_fragments() {
-        // seq = index (u8, wraps cleanly), pos in-range except at two split
-        // points. Run A = 250, run B = 300 (both >= MIN_CHUNK_SAMPLES), and a
-        // trailing 50-sample fragment (< MIN_CHUNK_SAMPLES) is dropped.
-        let mut frames: Vec<TelFrame> = (0..602u32)
-            .map(|i| TelFrame {
-                seq: i as u8,
-                pos: Some(1000 + (i % 3) as u16),
-                current: Some(50),
-                ..Default::default()
-            })
-            .collect();
-        frames[250].pos = Some(9999); // splits run A | run B
-        frames[551].pos = Some(9999); // splits run B | tiny fragment
+    fn build_sweep_chunks_keeps_big_runs_drops_fragments_and_stalls() {
+        // seq = index (u8, wraps cleanly). Three moving runs (pos sweeps a real
+        // span) split by out-of-range pos, plus a trailing short fragment and a
+        // long STALL run (pos frozen at a rail). Kept: the two big MOVING runs.
+        // Dropped: the <MIN_CHUNK_SAMPLES fragment AND the stall (span 0).
+        let mut frames: Vec<TelFrame> = Vec::new();
+        let mut push = |base: u16, count: u32, moving: bool| {
+            for j in 0..count {
+                let seq = frames.len() as u8;
+                let pos = if moving { base + j as u16 } else { base };
+                frames.push(TelFrame {
+                    seq,
+                    pos: Some(pos),
+                    current: Some(50),
+                    ..Default::default()
+                });
+            }
+        };
+        push(1000, 250, true); // run A: span 249, kept
+        push(9999, 1, true); // split (out-of-range)
+        push(2000, 300, true); // run B: span 299, kept
+        push(9999, 1, true); // split
+        push(3000, 50, true); // fragment: < MIN_CHUNK_SAMPLES, dropped
+        push(9999, 1, true); // split
+        push(4095, 250, false); // stall: >= samples but span 0, dropped
+
         let chunks = build_sweep_chunks(&frames);
-        assert_eq!(chunks.len(), 2, "exactly the two big chunks survive");
+        assert_eq!(chunks.len(), 2, "only the two moving runs survive");
         assert_eq!(chunks[0].0.len(), 250);
         assert_eq!(chunks[1].0.len(), 300);
-        // current vec length tracks pos in each chunk
         assert_eq!(chunks[0].1.len(), 250);
         assert_eq!(chunks[1].1.len(), 300);
+        // the stall run (span 0) is gone despite having >= MIN_CHUNK_SAMPLES
+        assert!(chunks.iter().all(|(p, _)| p.iter().max() != Some(&4095)));
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -529,27 +529,54 @@ fn soft_angles(args: &Args, phys_min: f64, phys_max: f64) -> Result<(f64, f64)> 
     Ok((min, max))
 }
 
-/// Gear ratio as centi (x100); 0 is the firmware "unset" sentinel. `measured`
-/// (ripple-derived) is the measure-first default: under `--yes` it becomes the
-/// value with no prompt; interactively it is the prompt's default the operator
-/// can override. None keeps commit 6's plain-input behavior.
+/// Gear ratio as centi (x100); 0 is the firmware "unset" sentinel. Precedence:
+/// an explicit `--gear-ratio` flag wins, else the ripple-`measured` value, else
+/// the interactive prompt / unset(0). The flag wins because the bench ratio is
+/// a known counted constant; the ripple value is only a cross-check. Under
+/// `--yes` the winner is stored with no prompt; interactively it seeds the
+/// prompt's default, which the operator can still override. Whenever a flag and
+/// a measured value are both present and diverge by >10%, warn (the flag still
+/// wins) - divergence flags a wrong travel angle, gear slip, or wrong
+/// ripple-per-rev.
 fn gear_ratio(args: &Args, measured: Option<u16>) -> Result<u16> {
-    if args.yes {
-        return Ok(measured.unwrap_or_else(|| ratio_to_centi(args.gear_ratio)));
+    if let (Some(g), Some(m)) = (args.gear_ratio, measured) {
+        let entered_centi = ratio_to_centi(Some(g));
+        if gear_divergent(entered_centi, m, 0.1) {
+            eprintln!(
+                "warning: entered gear ratio {:.2} diverges from ripple-measured {:.2} by >10% - can indicate a wrong travel angle, gear slip, or wrong ripple-per-rev",
+                entered_centi as f64 / 100.0,
+                m as f64 / 100.0,
+            );
+        }
     }
-    let ratio = if let Some(m) = measured {
-        Some(input_f64(
-            "gear ratio (motor rev per output rev)",
-            m as f64 / 100.0,
-        )?)
-    } else if let Some(g) = args.gear_ratio {
-        Some(input_f64("gear ratio (motor rev per output rev)", g)?)
+    if args.yes {
+        return Ok(match args.gear_ratio {
+            Some(_) => ratio_to_centi(args.gear_ratio),
+            None => measured.unwrap_or(0),
+        });
+    }
+    // interactive default: flag > measured > known-ratio prompt path
+    let default = args
+        .gear_ratio
+        .or_else(|| measured.map(|m| m as f64 / 100.0));
+    let ratio = if let Some(d) = default {
+        Some(input_f64("gear ratio (motor rev per output rev)", d)?)
     } else if confirm("enter a known gear ratio", false)? {
         Some(input_f64("gear ratio (motor rev per output rev)", 1.0)?)
     } else {
         None
     };
     Ok(ratio_to_centi(ratio))
+}
+
+/// True when the ripple-`measured_centi` gear ratio diverges from the operator-
+/// entered `entered_centi` by more than `frac` (relative). entered_centi==0
+/// (flag unset or invalid) can never diverge.
+fn gear_divergent(entered_centi: u16, measured_centi: u16, frac: f64) -> bool {
+    if entered_centi == 0 {
+        return false;
+    }
+    ((measured_centi as f64 / entered_centi as f64) - 1.0).abs() > frac
 }
 
 fn ratio_to_centi(ratio: Option<f64>) -> u16 {
@@ -645,6 +672,45 @@ mod tests {
     #[test]
     fn build_sweep_none_without_frames() {
         assert!(build_sweep(&[]).is_none());
+    }
+
+    /// `--yes` Args with the given gear-ratio flag; other fields unset.
+    fn yes_args(gear_ratio: Option<f64>) -> Args {
+        Args {
+            out: None,
+            phys_angle_min: None,
+            phys_angle_max: None,
+            soft_angle_min: None,
+            soft_angle_max: None,
+            gear_ratio,
+            tel_port: String::new(),
+            yes: true,
+        }
+    }
+
+    #[test]
+    fn gear_divergent_relative_threshold_and_zero_safe() {
+        // 234.73 counted vs a >10% off ripple value -> divergent
+        assert!(gear_divergent(23473, 30000, 0.1));
+        // within 10% -> not divergent
+        assert!(!gear_divergent(23473, 24000, 0.1));
+        assert!(!gear_divergent(10000, 10500, 0.1));
+        assert!(gear_divergent(10000, 11500, 0.1));
+        // entered unset -> never diverges (no divide by zero)
+        assert!(!gear_divergent(0, 30000, 0.1));
+    }
+
+    #[test]
+    fn gear_ratio_yes_flag_wins_over_measured() {
+        // flag present -> flag wins even when measured is Some and different
+        assert_eq!(
+            gear_ratio(&yes_args(Some(234.73)), Some(30000)).unwrap(),
+            23473
+        );
+        // flag absent -> measured used
+        assert_eq!(gear_ratio(&yes_args(None), Some(30000)).unwrap(), 30000);
+        // neither -> 0 sentinel
+        assert_eq!(gear_ratio(&yes_args(None), None).unwrap(), 0);
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -120,7 +120,15 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     // build_sweep takes the longest moving run. Skipped without --tel-port.
     let sweep = match &tel_port {
         Some(port) => {
-            let tel = run_sweep(&mut c, id, port, pos_min_phys, pos_max_phys, drive_polarity)?;
+            let tel = run_sweep(
+                &mut c,
+                id,
+                port,
+                pos_min_phys,
+                pos_max_phys,
+                drive_polarity,
+                &out,
+            )?;
             let s = build_sweep(&tel);
             match &s {
                 Some((pos, _)) => println!(
@@ -363,6 +371,7 @@ fn run_endstop(c: &mut Client<NusbPipe>, id: Id, out: &OutDir) -> Result<Endstop
         tel_port: None,
         tel_mask: 0,
         log: Some(&mut log),
+        tel_raw_path: None,
     }
     .run(&mut exp, |_| {});
     // park safe whether the run finished, errored, or was ctrl-c'd
@@ -391,6 +400,7 @@ fn run_sweep(
     pos_min_phys: i32,
     pos_max_phys: i32,
     drive_polarity: bool,
+    out: &OutDir,
 ) -> Result<Vec<TelFrame>> {
     const DUTY: i16 = 8520;
     let span = (pos_max_phys - pos_min_phys) as f64;
@@ -440,12 +450,17 @@ fn run_sweep(
         tel_port: Some(port.to_string()),
         tel_mask,
         log: None,
+        tel_raw_path: Some(out.0.join("tel-raw.bin")),
     }
     .run(&mut wrap, |frames| tel.extend_from_slice(frames));
     // park safe whether the run finished, errored, or was ctrl-c'd
     let _ = write_reg(c, id, control::GOAL_DUTY, 0);
     let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
     ran?;
+    println!(
+        "[sweep] raw bytes -> {}",
+        out.0.join("tel-raw.bin").display()
+    );
     Ok(tel)
 }
 

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -10,6 +10,8 @@
 //! the kinematics/units/lut math live in osc-ident; this wrapper owns USB,
 //! the TEL port, prompts, and files.
 
+pub mod replay;
+
 use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -272,6 +274,12 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     Ok(())
 }
 
+/// A plausible pot reading: the ADC is 12-bit, so a valid pos is 0..=4095.
+/// Anything larger is bit-corrupted.
+fn pos_plausible(pos: u16) -> bool {
+    pos <= 4095
+}
+
 /// Time-aligned (pos, current) sweep from the captured frames: the longest
 /// seq-contiguous run. Splitting on seq gaps is the ONLY selection - it keeps
 /// the sample spacing uniform, which the ripple autocorr assumes. Pos is NOT
@@ -281,9 +289,17 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
 /// flat stall segment self-rejects downstream (no ripple -> None). None when
 /// nothing was captured.
 fn build_sweep(tel: &[TelFrame]) -> Option<(Vec<u16>, Vec<f64>)> {
+    // Drop value-domain corruption: pos > 4095 is impossible from a 12-bit ADC,
+    // so a set bit above b11 is a bit error. Dropping the frame removes its seq,
+    // which splits the contiguous run at that point and isolates the corruption.
+    // Catches pos corruption only; a current(ripple)-domain bit-error is not
+    // caught here - that needs a firmware frame CRC (deferred).
     let s: Vec<(u8, u16, f64)> = tel
         .iter()
-        .filter_map(|f| Some((f.seq, f.pos?, f.current? as f64)))
+        .filter_map(|f| {
+            let pos = f.pos?;
+            pos_plausible(pos).then_some((f.seq, pos, f.current? as f64))
+        })
         .collect();
     let (lo, hi) = longest_contiguous_run(&s)?;
     Some((
@@ -939,6 +955,37 @@ mod tests {
     #[test]
     fn build_sweep_none_without_frames() {
         assert!(build_sweep(&[]).is_none());
+    }
+
+    #[test]
+    fn pos_plausible_rejects_above_12bit() {
+        assert!(pos_plausible(0));
+        assert!(pos_plausible(4095));
+        assert!(!pos_plausible(4096));
+        assert!(!pos_plausible(9999));
+    }
+
+    #[test]
+    fn build_sweep_drops_out_of_range_pos() {
+        // seqs 0..10, all pos in-range except seq 5 which is bit-corrupt (>4095).
+        // Dropping it removes its seq, so the contiguous run splits there: the
+        // longer half is seqs 0..=4 (5 samples) and the corrupt pos is excluded.
+        let frames: Vec<TelFrame> = (0..10u8)
+            .map(|k| TelFrame {
+                seq: k,
+                pos: Some(if k == 5 { 9999 } else { 1000 + k as u16 }),
+                current: Some(50),
+                ..Default::default()
+            })
+            .collect();
+        let (pos, current) = build_sweep(&frames).expect("a run survives");
+        assert!(
+            pos.iter().all(|&p| p <= 4095),
+            "corrupt pos leaked: {pos:?}"
+        );
+        assert!(!pos.contains(&9999));
+        assert_eq!(pos, vec![1000, 1001, 1002, 1003, 1004]);
+        assert_eq!(current.len(), pos.len());
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -26,6 +26,7 @@ use osc_ident::frame::{TelFrame, TelemetrySnapshot};
 use osc_ident::kinematics::{self, KinematicsResult, angle_endpoints};
 use osc_ident::lut::{self, PotLut};
 use osc_ident::regs::{calib, config, control};
+use osc_ident::slip;
 use osc_ident::units::{self, SenseParams};
 
 use crate::rig::csvio::{OutDir, SnapshotLog};
@@ -188,6 +189,25 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
             coverage * 100.0
         ),
         None => {}
+    }
+
+    // gear-mesh slip check on the SAME sweep: pot must advance in fixed
+    // proportion to motor rotation; a slipping/stripped tooth spikes or zeros
+    // a segment. Advisory - one sweep can miss a localized slip zone.
+    if let Some((pos, current)) = &sweep
+        && let Some((phase, _)) = lut::cumulative_phase(current, fs, RIPPLE_PER_REV)
+        && let Some(rep) = slip::slip_metrics(pos, &phase, 10, 1)
+    {
+        println!(
+            "gear mesh: slip CoV {:.2} ({} core segments)",
+            rep.slip_cov, rep.core_segments
+        );
+        if rep.flagged {
+            eprintln!(
+                "warning: possible worn/stripped gear teeth - gear-slip signature (slip CoV {:.2}, {} stuck segment(s)); a single sweep is not conclusive, re-run cal to confirm",
+                rep.slip_cov, rep.stuck_count
+            );
+        }
     }
 
     // soft angle -> phys count via the linear phys map, clamped to the rails

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -48,6 +48,10 @@ const RIPPLE_CONF_MIN: f64 = 0.7;
 /// deg span. Only a default; every real servo overrides it.
 const DEFAULT_TRAVEL_DEG: f64 = 180.0;
 
+/// Default soft-limit span, centered in the phys range (or the full phys
+/// range when it is narrower).
+const DEFAULT_SOFT_TRAVEL_DEG: f64 = 180.0;
+
 /// `osc cal` args: output dir plus the headless overrides. `--baud`/`--id`
 /// come from the top-level osc globals.
 #[derive(clap::Args, Debug)]
@@ -61,10 +65,12 @@ pub struct Args {
     /// Real angle (deg) at the max-count rail.
     #[arg(long)]
     phys_angle_max: Option<f64>,
-    /// App-facing working-range min (deg); defaults to the phys min.
+    /// App-facing working-range min (deg); defaults to the low edge of a
+    /// 180 deg window centered in the phys range.
     #[arg(long)]
     soft_angle_min: Option<f64>,
-    /// App-facing working-range max (deg); defaults to the phys max.
+    /// App-facing working-range max (deg); defaults to the high edge of a
+    /// 180 deg window centered in the phys range.
     #[arg(long)]
     soft_angle_max: Option<f64>,
     /// Known gear ratio (motor rev per output rev); unset leaves it 0.
@@ -816,20 +822,19 @@ fn phys_angles(args: &Args) -> Result<(f64, f64)> {
 /// Soft (working-range) angle: flags under `--yes` (defaulting to phys), else
 /// prompted with the flags or the phys angles as defaults.
 fn soft_angles(args: &Args, phys_min: f64, phys_max: f64) -> Result<(f64, f64)> {
+    // default = DEFAULT_SOFT_TRAVEL_DEG centered in the phys range: soft
+    // limits set to the rails hand every mode's endstop zero coast margin
+    let span = (phys_max - phys_min).min(DEFAULT_SOFT_TRAVEL_DEG);
+    let mid = (phys_min + phys_max) / 2.0;
+    let (dmin, dmax) = (mid - span / 2.0, mid + span / 2.0);
     if args.yes {
         return Ok((
-            args.soft_angle_min.unwrap_or(phys_min),
-            args.soft_angle_max.unwrap_or(phys_max),
+            args.soft_angle_min.unwrap_or(dmin),
+            args.soft_angle_max.unwrap_or(dmax),
         ));
     }
-    let min = input_f64(
-        "soft angle min (deg)",
-        args.soft_angle_min.unwrap_or(phys_min),
-    )?;
-    let max = input_f64(
-        "soft angle max (deg)",
-        args.soft_angle_max.unwrap_or(phys_max),
-    )?;
+    let min = input_f64("soft angle min (deg)", args.soft_angle_min.unwrap_or(dmin))?;
+    let max = input_f64("soft angle max (deg)", args.soft_angle_max.unwrap_or(dmax))?;
     Ok((min, max))
 }
 

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -139,28 +139,36 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
 
     recenter(&mut c, id, pos_min_phys, pos_max_phys, drive_polarity)?;
 
-    let (phys_min, phys_max) = phys_angles(args)?;
+    // Full-traverse motor revs from the ripple sweep: anchor-free geometry,
+    // extrapolated from the moving run's phase span to the whole count span.
+    // Paired with a gear ratio it yields travel; paired with a travel angle it
+    // yields the gear. Both anchors consume this same ripple half.
+    let count_span = pos_max_phys as f64 - pos_min_phys as f64;
+    let motor_revs_full = sweep
+        .as_ref()
+        .and_then(|s| full_motor_revs(s, fs, count_span));
+    let mrf = motor_revs_full.map(|(m, _)| m);
+    let coverage = motor_revs_full.map(|(_, c)| c);
+
+    // Resolve the anchor: gear is preferred, travel is the fallback. --yes stays
+    // headless through the pure resolve_anchor; interactively the operator
+    // anchors on the gear first (enter 0 to switch to a travel angle instead).
+    let (phys_min, phys_max, gear_ratio_centi) = if args.yes {
+        let (lo, hi, gear) = resolve_anchor(
+            mrf,
+            args.gear_ratio,
+            args.phys_angle_min,
+            args.phys_angle_max,
+        );
+        report_yes_anchor(args, mrf, coverage, lo, hi, gear);
+        (lo, hi, gear)
+    } else {
+        resolve_anchor_interactive(args, mrf, coverage)?
+    };
+
     let (soft_min_deg, soft_max_deg) = soft_angles(args, phys_min, phys_max)?;
     let (angle_min_cdeg, angle_max_cdeg) = angle_endpoints(phys_min, phys_max);
     let dpc = kinematics::deg_per_count(angle_min_cdeg, angle_max_cdeg, pos_min_phys, pos_max_phys);
-
-    // measure-first: the ripple-derived gear ratio is the prompt's default,
-    // the operator overrides. None (no sweep / low SNR / 0) keeps commit 6's
-    // plain-input behavior.
-    let measured = sweep.as_ref().and_then(|s| measure_gear(s, fs, dpc));
-    if let Some((centi, coverage)) = measured {
-        let conf = if coverage < RIPPLE_CONF_MIN {
-            " (low confidence)"
-        } else {
-            ""
-        };
-        println!(
-            "measured gear ratio {:.2}, ripple-derived ({:.0}% coverage){conf}",
-            centi as f64 / 100.0,
-            coverage * 100.0,
-        );
-    }
-    let gear_ratio_centi = gear_ratio(args, measured.map(|(c, _)| c))?;
 
     // pot LUT from the same sweep; identity when the ripple SNR is too low to
     // clock true angle. No sweep at all -> None, LUT left untouched below.
@@ -301,13 +309,13 @@ fn longest_contiguous_run(s: &[(u8, u16, f64)]) -> Option<(usize, usize)> {
     (best_hi - best_lo >= 2).then_some((best_lo, best_hi))
 }
 
-/// Ripple-derived gear ratio (centi) + ripple coverage (0..1) from a sweep.
-/// Counts total motor revs by integrating the windowed ripple speed over the
-/// whole traverse (drift-resistant, no constant-velocity assumption) and
-/// divides by the output revs the pot turned through. dt cancels, so total
-/// motor revs and total pot displacement feed gear_ratio_centi directly. None
-/// when the ripple coverage is too low or the result hits the 0 sentinel.
-fn measure_gear(sweep: &(Vec<u16>, Vec<f64>), fs: f64, dpc: f64) -> Option<(u16, f64)> {
+/// Full-traverse motor revs + ripple coverage (0..1) from a sweep. Counts motor
+/// revs over the moving run by integrating the windowed ripple speed (drift-
+/// resistant, no constant-velocity assumption), then extrapolates to the whole
+/// rail-to-rail count span. This is the ripple half shared by both anchors: a
+/// gear ratio turns it into travel, a travel angle turns it into the gear. None
+/// when the ripple coverage is too low or the extrapolation hits the 0 sentinel.
+fn full_motor_revs(sweep: &(Vec<u16>, Vec<f64>), fs: f64, count_span: f64) -> Option<(f64, f64)> {
     let (pos, current) = sweep;
     if pos.len() < 2 || fs <= 0.0 {
         return None;
@@ -315,8 +323,8 @@ fn measure_gear(sweep: &(Vec<u16>, Vec<f64>), fs: f64, dpc: f64) -> Option<(u16,
     let (phase, coverage) = lut::cumulative_phase(current, fs, RIPPLE_PER_REV)?;
     let motor_revs = phase[phase.len() - 1] - phase[0];
     let pot_disp = (pos[pos.len() - 1] as f64 - pos[0] as f64).abs();
-    let centi = kinematics::gear_ratio_centi(motor_revs, pot_disp, dpc);
-    (centi != 0).then_some((centi, coverage))
+    let full = kinematics::full_span_motor_revs(motor_revs, pot_disp, count_span);
+    (full != 0.0).then_some((full, coverage))
 }
 
 /// Write the PotLutBlock: raw_min/raw_max as scalars, then the 55 corr knots
@@ -558,44 +566,135 @@ fn soft_angles(args: &Args, phys_min: f64, phys_max: f64) -> Result<(f64, f64)> 
     Ok((min, max))
 }
 
-/// Gear ratio as centi (x100); 0 is the firmware "unset" sentinel. Precedence:
-/// an explicit `--gear-ratio` flag wins, else the ripple-`measured` value, else
-/// the interactive prompt / unset(0). The flag wins because the bench ratio is
-/// a known counted constant; the ripple value is only a cross-check. Under
-/// `--yes` the winner is stored with no prompt; interactively it seeds the
-/// prompt's default, which the operator can still override. Whenever a flag and
-/// a measured value are both present and diverge by >10%, warn (the flag still
-/// wins) - divergence flags a wrong travel angle, gear slip, or wrong
-/// ripple-per-rev.
-fn gear_ratio(args: &Args, measured: Option<u16>) -> Result<u16> {
-    if let (Some(g), Some(m)) = (args.gear_ratio, measured) {
-        let entered_centi = ratio_to_centi(Some(g));
-        if gear_divergent(entered_centi, m, 0.1) {
-            eprintln!(
-                "warning: entered gear ratio {:.2} diverges from ripple-measured {:.2} by >10% - can indicate a wrong travel angle, gear slip, or wrong ripple-per-rev",
-                entered_centi as f64 / 100.0,
-                m as f64 / 100.0,
-            );
+/// Resolve the headless (`--yes`) anchor to (angle_at_min, angle_at_max,
+/// gear_centi). GEAR is the preferred anchor: given a `--gear-ratio` flag and a
+/// ripple-derived `motor_revs_full`, the physical travel is derived from the
+/// gear (pure geometry, protocol-free) and the counted gear stored as-is;
+/// angle_at_min comes from `--phys-angle-min` (0 default), angle_at_max is that
+/// plus the derived travel. Falling back: explicit `--phys-angle-min/max` flags
+/// anchor on travel and the gear is derived from ripple (the inverse) - though a
+/// counted `--gear-ratio` flag, when present, still wins for storage (matching
+/// the pre-inverse precedence). Neither anchor -> the 0/0/0 unset sentinels.
+fn resolve_anchor(
+    motor_revs_full: Option<f64>,
+    gear_flag: Option<f64>,
+    phys_min_flag: Option<f64>,
+    phys_max_flag: Option<f64>,
+) -> (f64, f64, u16) {
+    if let (Some(g), Some(m)) = (gear_flag, motor_revs_full)
+        && g > 0.0
+    {
+        let travel = kinematics::travel_deg_from_gear(m, g);
+        let angle_min = phys_min_flag.unwrap_or(0.0);
+        return (angle_min, angle_min + travel, ratio_to_centi(Some(g)));
+    }
+    if let (Some(lo), Some(hi)) = (phys_min_flag, phys_max_flag) {
+        let ripple_centi = motor_revs_full
+            .map(|m| ratio_to_centi(travel_to_gear(m, hi - lo)))
+            .unwrap_or(0);
+        let gear_centi = match gear_flag {
+            Some(g) if g > 0.0 => ratio_to_centi(Some(g)),
+            _ => ripple_centi,
+        };
+        return (lo, hi, gear_centi);
+    }
+    (0.0, 0.0, 0)
+}
+
+/// Print the headless anchor outcome. Gear anchor -> the derived travel (and,
+/// when an explicit travel is also given, a divergence warning; gear still wins
+/// for storage). Travel anchor with a ripple-derived gear -> the ripple info
+/// line. Divergence flags a wrong travel angle, gear slip, or wrong ripple-per-rev.
+fn report_yes_anchor(
+    args: &Args,
+    mrf: Option<f64>,
+    coverage: Option<f64>,
+    angle_min: f64,
+    angle_max: f64,
+    gear_centi: u16,
+) {
+    let gear_flag = args.gear_ratio.filter(|&g| g > 0.0);
+    if let (Some(_), Some(m)) = (gear_flag, mrf) {
+        println!(
+            "derived travel {:.1} deg from gear {:.2}",
+            angle_max - angle_min,
+            gear_centi as f64 / 100.0,
+        );
+        if let (Some(lo), Some(hi)) = (args.phys_angle_min, args.phys_angle_max) {
+            let ripple_centi = ratio_to_centi(travel_to_gear(m, hi - lo));
+            if gear_divergent(gear_centi, ripple_centi, 0.1) {
+                eprintln!(
+                    "warning: entered gear ratio {:.2} diverges from ripple-measured {:.2} by >10% - can indicate a wrong travel angle, gear slip, or wrong ripple-per-rev",
+                    gear_centi as f64 / 100.0,
+                    ripple_centi as f64 / 100.0,
+                );
+            }
         }
+    } else if gear_flag.is_none() && gear_centi != 0 {
+        print_ripple_gear(gear_centi, coverage.unwrap_or(0.0));
     }
-    if args.yes {
-        return Ok(match args.gear_ratio {
-            Some(_) => ratio_to_centi(args.gear_ratio),
-            None => measured.unwrap_or(0),
-        });
+}
+
+/// Interactive anchor resolution, nudged toward the gear. Prompts the gear ratio
+/// first: a positive gear with a ripple-derived `motor_revs_full` derives travel
+/// (gear anchor); entering 0, or having no ripple, falls back to the travel-angle
+/// prompts and derives the gear from ripple (the inverse). With no ripple at all,
+/// an entered gear still stands so a known ratio can be stored without a sweep.
+fn resolve_anchor_interactive(
+    args: &Args,
+    mrf: Option<f64>,
+    coverage: Option<f64>,
+) -> Result<(f64, f64, u16)> {
+    let gear = input_f64(
+        "gear ratio (motor rev per output rev) - most accurate if you counted the teeth; 0 to enter travel angle instead",
+        args.gear_ratio.unwrap_or(1.0),
+    )?;
+    if gear > 0.0
+        && let Some(m) = mrf
+    {
+        let travel = kinematics::travel_deg_from_gear(m, gear);
+        let angle_min = input_f64(
+            "phys angle at min rail (deg)",
+            args.phys_angle_min.unwrap_or(0.0),
+        )?;
+        println!("derived travel {travel:.1} deg from gear {gear:.2}");
+        return Ok((angle_min, angle_min + travel, ratio_to_centi(Some(gear))));
     }
-    // interactive default: flag > measured > known-ratio prompt path
-    let default = args
-        .gear_ratio
-        .or_else(|| measured.map(|m| m as f64 / 100.0));
-    let ratio = if let Some(d) = default {
-        Some(input_f64("gear ratio (motor rev per output rev)", d)?)
-    } else if confirm("enter a known gear ratio", false)? {
-        Some(input_f64("gear ratio (motor rev per output rev)", 1.0)?)
-    } else {
-        None
+    let (lo, hi) = phys_angles(args)?;
+    let gear_centi = match mrf {
+        Some(m) => {
+            let centi = ratio_to_centi(travel_to_gear(m, hi - lo));
+            if centi != 0 {
+                print_ripple_gear(centi, coverage.unwrap_or(0.0));
+            }
+            centi
+        }
+        None => ratio_to_centi((gear > 0.0).then_some(gear)),
     };
-    Ok(ratio_to_centi(ratio))
+    Ok((lo, hi, gear_centi))
+}
+
+/// Ripple gear ratio (motor rev per output rev) implied by the full-traverse
+/// motor revs and an operator travel angle - the inverse of
+/// kinematics::travel_deg_from_gear. None on a zero/non-finite travel, so
+/// ratio_to_centi then stores the 0 sentinel.
+fn travel_to_gear(motor_revs_full: f64, travel_deg: f64) -> Option<f64> {
+    (travel_deg.is_finite() && travel_deg > 0.0).then_some(motor_revs_full * 360.0 / travel_deg)
+}
+
+/// The ripple-derived gear info line (the historical "measured gear ratio ..."
+/// print), shown when the travel anchor is used.
+fn print_ripple_gear(gear_centi: u16, coverage: f64) {
+    let conf = if coverage < RIPPLE_CONF_MIN {
+        " (low confidence)"
+    } else {
+        ""
+    };
+    println!(
+        "measured gear ratio {:.2}, ripple-derived ({:.0}% coverage){conf}",
+        gear_centi as f64 / 100.0,
+        coverage * 100.0,
+    );
 }
 
 /// True when the ripple-`measured_centi` gear ratio diverges from the operator-
@@ -703,20 +802,6 @@ mod tests {
         assert!(build_sweep(&[]).is_none());
     }
 
-    /// `--yes` Args with the given gear-ratio flag; other fields unset.
-    fn yes_args(gear_ratio: Option<f64>) -> Args {
-        Args {
-            out: None,
-            phys_angle_min: None,
-            phys_angle_max: None,
-            soft_angle_min: None,
-            soft_angle_max: None,
-            gear_ratio,
-            tel_port: String::new(),
-            yes: true,
-        }
-    }
-
     #[test]
     fn gear_divergent_relative_threshold_and_zero_safe() {
         // 234.73 counted vs a >10% off ripple value -> divergent
@@ -730,16 +815,61 @@ mod tests {
     }
 
     #[test]
-    fn gear_ratio_yes_flag_wins_over_measured() {
-        // flag present -> flag wins even when measured is Some and different
+    fn resolve_anchor_gear_flag_derives_travel() {
+        // gear 150 + motor_revs_full 79.1667 -> travel ~190 deg; endpoints 0..190
+        let (lo, hi, gear) = resolve_anchor(Some(79.166_667), Some(150.0), None, None);
+        assert_eq!(lo, 0.0);
+        assert!((hi - 190.0).abs() < 0.01, "hi {hi}");
+        assert_eq!(gear, 15000);
+    }
+
+    #[test]
+    fn resolve_anchor_gear_flag_honors_min_offset() {
+        // angle_at_min from --phys-angle-min, angle_at_max = min + derived travel
+        let (lo, hi, gear) = resolve_anchor(Some(79.166_667), Some(150.0), Some(-95.0), None);
+        assert_eq!(lo, -95.0);
+        assert!((hi - 95.0).abs() < 0.01, "hi {hi}");
+        assert_eq!(gear, 15000);
+    }
+
+    #[test]
+    fn resolve_anchor_travel_flags_derive_gear() {
+        // travel 0..190 deg + motor_revs_full 79.1667 -> ripple gear ~150
+        let (lo, hi, gear) = resolve_anchor(Some(79.166_667), None, Some(0.0), Some(190.0));
+        assert_eq!((lo, hi), (0.0, 190.0));
+        assert!((gear as i32 - 15000).abs() <= 2, "gear {gear}");
+    }
+
+    #[test]
+    fn resolve_anchor_gear_flag_wins_when_both_given() {
+        // both a gear flag and travel flags: gear anchor wins, travel derived
+        // from the gear (max ignores --phys-angle-max as an endpoint)
+        let (lo, hi, gear) = resolve_anchor(Some(79.166_667), Some(150.0), Some(0.0), Some(999.0));
+        assert_eq!(lo, 0.0);
+        assert!((hi - 190.0).abs() < 0.01, "hi {hi}");
+        assert_eq!(gear, 15000);
+    }
+
+    #[test]
+    fn resolve_anchor_flag_stored_without_ripple() {
+        // travel flags but no ripple: endpoints kept, counted gear flag stored
         assert_eq!(
-            gear_ratio(&yes_args(Some(234.73)), Some(30000)).unwrap(),
-            23473
+            resolve_anchor(None, Some(234.73), Some(0.0), Some(190.0)),
+            (0.0, 190.0, 23473)
         );
-        // flag absent -> measured used
-        assert_eq!(gear_ratio(&yes_args(None), Some(30000)).unwrap(), 30000);
-        // neither -> 0 sentinel
-        assert_eq!(gear_ratio(&yes_args(None), None).unwrap(), 0);
+    }
+
+    #[test]
+    fn resolve_anchor_unset_sentinels() {
+        // neither anchor -> all-zero sentinel
+        assert_eq!(resolve_anchor(Some(79.0), None, None, None), (0.0, 0.0, 0));
+        // travel flags, no ripple, no gear flag -> gear unset
+        assert_eq!(
+            resolve_anchor(None, None, Some(0.0), Some(190.0)),
+            (0.0, 190.0, 0)
+        );
+        // gear flag but no ripple and no travel -> nothing to anchor on
+        assert_eq!(resolve_anchor(None, Some(150.0), None, None), (0.0, 0.0, 0));
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -20,12 +20,12 @@ use osc_client::Id;
 use osc_client::blocking::Client;
 use osc_client::nusb::NusbPipe;
 use osc_ident::exp::endstop::{Endstop, EndstopCfg, EndstopResult};
+use osc_ident::exp::sweep::{Sweep, SweepCfg};
 use osc_ident::exp::{Cmd, Experiment, Guarded, RigParams};
 use osc_ident::frame::{TelFrame, TelemetrySnapshot};
 use osc_ident::kinematics::{self, KinematicsResult, angle_endpoints};
 use osc_ident::lut::{self, PotLut};
 use osc_ident::regs::{calib, config, control};
-use osc_ident::ripple;
 use osc_ident::units::{self, SenseParams};
 
 use crate::rig::csvio::{OutDir, SnapshotLog};
@@ -36,9 +36,10 @@ use crate::rig::snapshot::{self, read_u16};
 /// tach and the LUT angle clock both count 6 per revolution.
 const RIPPLE_PER_REV: f64 = 6.0;
 
-/// Autocorr strength below this flags the ripple gear estimate as
-/// low-confidence in the printout (still used - expected on a stripped gear).
-const RIPPLE_CONF_MIN: f64 = 0.3;
+/// Ripple coverage (fraction of sweep windows that found ripple) below this
+/// flags the gear estimate as low-confidence in the printout - still used, as
+/// expected on a stripped gear where slip corrupts the pot displacement.
+const RIPPLE_CONF_MIN: f64 = 0.7;
 
 /// Assumed total rated travel when the operator gives no phys angle: a 0..180
 /// deg span. Only a default; every real servo overrides it.
@@ -100,7 +101,7 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
 
     let tel_port = (!args.tel_port.is_empty()).then(|| args.tel_port.clone());
     let out = OutDir::create(args.out.as_deref().unwrap_or(Path::new("./cal-out")))?;
-    let (r, tel) = run_endstop(&mut c, id, &out, tel_port)?;
+    let r = run_endstop(&mut c, id, &out)?;
     let EndstopResult {
         pos_min_phys,
         pos_max_phys,
@@ -113,16 +114,27 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
         if drive_polarity { "normal" } else { "reversed" },
     );
 
-    // The clean full-travel traverse = the longest monotonic-pos run of the
-    // captured frames; the pure lut/ripple fns then take it from here.
-    let sweep = build_sweep(&tel);
-    if let Some((pos, _)) = &sweep {
-        println!(
-            "[sweep] {} tel frames, monotonic run {} (fs {fs:.0} Hz from tick_hz)",
-            tel.len(),
-            pos.len()
-        );
-    }
+    // Dedicated constant-duty traverse = the ripple/LUT source: one clean
+    // uninterrupted sweep (no stall dwells, no poll fragmentation), from which
+    // build_sweep takes the longest moving run. Skipped without --tel-port.
+    let sweep = match &tel_port {
+        Some(port) => {
+            // sweep toward increasing pos; polarity maps duty sign to direction
+            let sweep_sign = if drive_polarity { 1 } else { -1 };
+            let tel = run_sweep(&mut c, id, port, sweep_sign)?;
+            let s = build_sweep(&tel);
+            match &s {
+                Some((pos, _)) => println!(
+                    "[sweep] {} tel frames, moving run {} (fs {fs:.0} Hz from tick_hz)",
+                    tel.len(),
+                    pos.len()
+                ),
+                None => println!("[sweep] {} tel frames, no usable moving run", tel.len()),
+            }
+            s
+        }
+        None => None,
+    };
 
     recenter(&mut c, id, pos_min_phys, pos_max_phys, drive_polarity)?;
 
@@ -135,15 +147,16 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     // the operator overrides. None (no sweep / low SNR / 0) keeps commit 6's
     // plain-input behavior.
     let measured = sweep.as_ref().and_then(|s| measure_gear(s, fs, dpc));
-    if let Some((centi, strength)) = measured {
-        let conf = if strength < RIPPLE_CONF_MIN {
+    if let Some((centi, coverage)) = measured {
+        let conf = if coverage < RIPPLE_CONF_MIN {
             " (low confidence)"
         } else {
             ""
         };
         println!(
-            "measured gear ratio {:.2}, ripple-derived{conf}",
-            centi as f64 / 100.0
+            "measured gear ratio {:.2}, ripple-derived ({:.0}% coverage){conf}",
+            centi as f64 / 100.0,
+            coverage * 100.0,
         );
     }
     let gear_ratio_centi = gear_ratio(args, measured.map(|(c, _)| c))?;
@@ -154,7 +167,7 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
         let phase = lut::cumulative_phase(current, fs, RIPPLE_PER_REV);
         let populated = phase.is_some();
         let l = match phase {
-            Some(p) => lut::build(pos, &p, pos_min_phys as u16, pos_max_phys as u16),
+            Some((p, _)) => lut::build(pos, &p, pos_min_phys as u16, pos_max_phys as u16),
             None => PotLut::identity(pos_min_phys as u16, pos_max_phys as u16),
         };
         (l, populated)
@@ -217,70 +230,64 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
 }
 
 /// Time-aligned (pos, current) sweep from the captured frames: the longest
-/// monotonic-pos run is the clean constant-duty full-travel traverse. None
-/// when no frames were captured or the run is too short to fit anything.
+/// seq-contiguous run. Splitting on seq gaps is the ONLY selection - it keeps
+/// the sample spacing uniform, which the ripple autocorr assumes. Pos is NOT
+/// required to be monotonic: the commutation ripple lives on the winding
+/// current, so a slipping stripped gear (pos jittering while the motor spins)
+/// still carries a clean signal, and lut::build sorts by pos regardless. A
+/// flat stall segment self-rejects downstream (no ripple -> None). None when
+/// nothing was captured.
 fn build_sweep(tel: &[TelFrame]) -> Option<(Vec<u16>, Vec<f64>)> {
-    if tel.is_empty() {
+    let s: Vec<(u8, u16, f64)> = tel
+        .iter()
+        .filter_map(|f| Some((f.seq, f.pos?, f.current? as f64)))
+        .collect();
+    let (lo, hi) = longest_contiguous_run(&s)?;
+    Some((
+        s[lo..hi].iter().map(|x| x.1).collect(),
+        s[lo..hi].iter().map(|x| x.2).collect(),
+    ))
+}
+
+/// Longest half-open index range `[lo, hi)` of samples whose u8 seq increments
+/// by exactly one each step (no dropped frames). None when nothing has >= 2
+/// contiguous samples.
+fn longest_contiguous_run(s: &[(u8, u16, f64)]) -> Option<(usize, usize)> {
+    if s.len() < 2 {
         return None;
     }
-    let samples: Vec<(u16, f64)> = tel
-        .iter()
-        .filter_map(|f| Some((f.pos?, f.current? as f64)))
-        .collect();
-    let (pos, current) = longest_monotonic_run(&samples);
-    (pos.len() >= 2).then_some((pos, current))
-}
-
-/// Longest run of consecutive samples whose pos is monotonic (non-decreasing
-/// OR non-increasing); equal steps keep both directions alive.
-fn longest_monotonic_run(samples: &[(u16, f64)]) -> (Vec<u16>, Vec<f64>) {
-    if samples.is_empty() {
-        return (Vec::new(), Vec::new());
-    }
-    let (mut best_lo, mut best_hi) = (0usize, 1usize);
-    let (mut inc_start, mut dec_start) = (0usize, 0usize);
-    for i in 1..samples.len() {
-        let (prev, cur) = (samples[i - 1].0, samples[i].0);
-        if cur < prev {
-            inc_start = i;
-        }
-        if cur > prev {
-            dec_start = i;
-        }
-        let inc_len = i + 1 - inc_start;
-        let dec_len = i + 1 - dec_start;
-        let (start, len) = if inc_len >= dec_len {
-            (inc_start, inc_len)
-        } else {
-            (dec_start, dec_len)
-        };
-        if len > best_hi - best_lo {
-            best_lo = start;
-            best_hi = i + 1;
+    let (mut best_lo, mut best_hi) = (0usize, 0usize);
+    let mut lo = 0usize;
+    for i in 1..s.len() {
+        if s[i].0 != s[i - 1].0.wrapping_add(1) {
+            if i - lo > best_hi - best_lo {
+                (best_lo, best_hi) = (lo, i);
+            }
+            lo = i;
         }
     }
-    let run = &samples[best_lo..best_hi];
-    (
-        run.iter().map(|s| s.0).collect(),
-        run.iter().map(|s| s.1).collect(),
-    )
+    if s.len() - lo > best_hi - best_lo {
+        (best_lo, best_hi) = (lo, s.len());
+    }
+    (best_hi - best_lo >= 2).then_some((best_lo, best_hi))
 }
 
-/// Ripple-derived gear ratio (centi) + autocorr strength from a monotonic
-/// sweep. None when the ripple SNR is too low to clock motor speed or the
-/// result degenerates to the 0 sentinel.
+/// Ripple-derived gear ratio (centi) + ripple coverage (0..1) from a sweep.
+/// Counts total motor revs by integrating the windowed ripple speed over the
+/// whole traverse (drift-resistant, no constant-velocity assumption) and
+/// divides by the output revs the pot turned through. dt cancels, so total
+/// motor revs and total pot displacement feed gear_ratio_centi directly. None
+/// when the ripple coverage is too low or the result hits the 0 sentinel.
 fn measure_gear(sweep: &(Vec<u16>, Vec<f64>), fs: f64, dpc: f64) -> Option<(u16, f64)> {
     let (pos, current) = sweep;
-    let n = pos.len();
-    if n < 2 || fs <= 0.0 {
+    if pos.len() < 2 || fs <= 0.0 {
         return None;
     }
-    let est = ripple::ripple_speed(current, fs, RIPPLE_PER_REV)?;
-    let dt = (n - 1) as f64 / fs;
-    // endpoint slope of pos vs time = output shaft speed in counts/s
-    let pot_omega_cps = ((pos[n - 1] as f64 - pos[0] as f64) / dt).abs();
-    let centi = kinematics::gear_ratio_centi(est.motor_rev_s, pot_omega_cps, dpc);
-    (centi != 0).then_some((centi, est.strength))
+    let (phase, coverage) = lut::cumulative_phase(current, fs, RIPPLE_PER_REV)?;
+    let motor_revs = phase[phase.len() - 1] - phase[0];
+    let pot_disp = (pos[pos.len() - 1] as f64 - pos[0] as f64).abs();
+    let centi = kinematics::gear_ratio_centi(motor_revs, pot_disp, dpc);
+    (centi != 0).then_some((centi, coverage))
 }
 
 /// Write the PotLutBlock: raw_min/raw_max as scalars, then the 55 corr knots
@@ -309,47 +316,20 @@ fn read_sense(c: &mut Client<NusbPipe>, id: Id) -> Result<SenseParams> {
     })
 }
 
-fn run_endstop(
-    c: &mut Client<NusbPipe>,
-    id: Id,
-    out: &OutDir,
-    tel_port: Option<String>,
-) -> Result<(EndstopResult, Vec<TelFrame>)> {
+fn run_endstop(c: &mut Client<NusbPipe>, id: Id, out: &OutDir) -> Result<EndstopResult> {
     println!("[endstop] seeking both rails (pos guard off)");
     // pos guard off: driving into the physical ends IS the method
     let params = RigParams::default().without_pos_guard();
     let mut log = SnapshotLog::create(out, "endstop_snapshots.csv")?;
     let mut exp = Guarded::new(Endstop::new(EndstopCfg::default(), &params), params);
-    let mut tel: Vec<TelFrame> = Vec::new();
-    // 0x1B = pos|current|duty|vdiff (same TEL mask as ident inertia)
-    let tel_mask: u16 = 0x1B;
-    let ran = if let Some(port) = tel_port {
-        // Endstop itself never enables TEL; wrap it so the pump streams the
-        // side-channel around the rail-to-rail seek (the second seek is a
-        // constant-duty full-travel sweep - the LUT/gear source).
-        let mut wrap = TelWrap {
-            inner: &mut exp,
-            phase: TelInject::MaskOn,
-            mask: tel_mask,
-        };
-        Pump {
-            client: c,
-            id,
-            tel_port: Some(port),
-            tel_mask,
-            log: Some(&mut log),
-        }
-        .run(&mut wrap, |frames| tel.extend_from_slice(frames))
-    } else {
-        Pump {
-            client: c,
-            id,
-            tel_port: None,
-            tel_mask: 0,
-            log: Some(&mut log),
-        }
-        .run(&mut exp, |_| {})
-    };
+    let ran = Pump {
+        client: c,
+        id,
+        tel_port: None,
+        tel_mask: 0,
+        log: Some(&mut log),
+    }
+    .run(&mut exp, |_| {});
     // park safe whether the run finished, errored, or was ctrl-c'd
     let _ = write_reg(c, id, control::GOAL_DUTY, 0);
     let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
@@ -357,11 +337,43 @@ fn run_endstop(
     if let Some(reason) = exp.abort() {
         bail!("endstop aborted by the safety envelope: {reason:?}");
     }
-    let r = exp
-        .into_inner()
+    exp.into_inner()
         .result()
-        .context("endstop did not reach both rails - no writes")?;
-    Ok((r, tel))
+        .context("endstop did not reach both rails - no writes")
+}
+
+/// One dedicated constant-duty ripple traverse, TEL captured throughout. The
+/// pump does nothing but drain the side channel during the sweep (no polls),
+/// so the traverse lands as a single long seq-contiguous run for build_sweep.
+fn run_sweep(
+    c: &mut Client<NusbPipe>,
+    id: Id,
+    port: &str,
+    sweep_sign: i8,
+) -> Result<Vec<TelFrame>> {
+    println!("[sweep] constant-duty ripple traverse");
+    let mut exp = Sweep::new(SweepCfg::default(), sweep_sign);
+    let mut tel: Vec<TelFrame> = Vec::new();
+    // 0x1B = pos|current|duty|vdiff (same TEL mask as ident inertia)
+    let tel_mask: u16 = 0x1B;
+    let mut wrap = TelWrap {
+        inner: &mut exp,
+        phase: TelInject::MaskOn,
+        mask: tel_mask,
+    };
+    let ran = Pump {
+        client: c,
+        id,
+        tel_port: Some(port.to_string()),
+        tel_mask,
+        log: None,
+    }
+    .run(&mut wrap, |frames| tel.extend_from_slice(frames));
+    // park safe whether the run finished, errored, or was ctrl-c'd
+    let _ = write_reg(c, id, control::GOAL_DUTY, 0);
+    let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
+    ran?;
+    Ok(tel)
 }
 
 /// Injects the TEL enable/mask writes around an inner experiment so the pump
@@ -595,29 +607,39 @@ mod tests {
         assert_eq!(soft_to_count(50.0, 90.0, 90.0, 100, 4000), 100);
     }
 
-    #[test]
-    fn monotonic_run_picks_longest_clean_traverse() {
-        // rising 5, a bump, then a longer falling run of 6 -> the fall wins
-        let s: Vec<(u16, f64)> = [10u16, 20, 30, 40, 50, 45, 60, 55, 44, 33, 22, 11]
-            .iter()
-            .map(|&p| (p, p as f64))
-            .collect();
-        let (pos, cur) = longest_monotonic_run(&s);
-        assert_eq!(pos, vec![60, 55, 44, 33, 22, 11]);
-        assert_eq!(cur.len(), pos.len());
+    /// Contiguous-seq samples from a pos list (current = pos for simplicity).
+    fn seqd(pos: &[u16]) -> Vec<(u8, u16, f64)> {
+        pos.iter()
+            .enumerate()
+            .map(|(i, &p)| (i as u8, p, p as f64))
+            .collect()
     }
 
     #[test]
-    fn monotonic_run_allows_equal_steps() {
-        let s: Vec<(u16, f64)> = [1u16, 1, 2, 2, 3, 3].iter().map(|&p| (p, 0.0)).collect();
-        let (pos, _) = longest_monotonic_run(&s);
-        assert_eq!(pos, vec![1, 1, 2, 2, 3, 3]);
+    fn contiguous_run_splits_on_seq_gap_and_picks_longest() {
+        // 30 samples, seq gap at index 20: the longer half [0,20) wins, and
+        // pos need not be monotonic (slip is fine - current carries ripple).
+        let mut s = seqd(&(0..30).map(|k| 1000 + (k % 3) * 10).collect::<Vec<_>>());
+        for e in s.iter_mut().skip(20) {
+            e.0 = e.0.wrapping_add(7); // punch a seq discontinuity at 20
+        }
+        assert_eq!(longest_contiguous_run(&s), Some((0, 20)));
     }
 
     #[test]
-    fn monotonic_run_empty_and_single() {
-        assert_eq!(longest_monotonic_run(&[]), (Vec::new(), Vec::new()));
-        assert_eq!(longest_monotonic_run(&[(7, 1.0)]), (vec![7], vec![1.0]));
+    fn contiguous_run_seq_wraps_cleanly() {
+        // u8 seq wrapping 255->0 mid-run stays contiguous.
+        let mut s = seqd(&[10u16; 6]);
+        for (i, e) in s.iter_mut().enumerate() {
+            e.0 = (253u8).wrapping_add(i as u8); // 253,254,255,0,1,2
+        }
+        assert_eq!(longest_contiguous_run(&s), Some((0, 6)));
+    }
+
+    #[test]
+    fn contiguous_run_none_when_too_short() {
+        assert!(longest_contiguous_run(&[]).is_none());
+        assert!(longest_contiguous_run(&seqd(&[7])).is_none());
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -26,7 +26,7 @@ use osc_ident::exp::sweep::{Sweep, SweepCfg};
 use osc_ident::exp::{Cmd, Experiment, Guarded, RigParams};
 use osc_ident::frame::{TelFrame, TelemetrySnapshot};
 use osc_ident::kinematics::{self, KinematicsResult, angle_endpoints};
-use osc_ident::lut::{self, PotLut};
+use osc_ident::lut::{self, PotLut, build_multi, stitched_motor_revs};
 use osc_ident::regs::{calib, config, control};
 use osc_ident::slip;
 use osc_ident::units::{self, SenseParams};
@@ -117,10 +117,12 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
         if drive_polarity { "normal" } else { "reversed" },
     );
 
-    // Dedicated constant-duty traverse = the ripple/LUT source: one clean
-    // uninterrupted sweep (no stall dwells, no poll fragmentation), from which
-    // build_sweep takes the longest moving run. Skipped without --tel-port.
-    let sweep = match &tel_port {
+    // Dedicated constant-duty traverse = the ripple/LUT source. A real capture
+    // fragments into several clean chunks (poll seams, brief dropouts), so the
+    // LUT + anchor stitch ALL chunks (build_sweep_chunks) over the shared pos
+    // axis; the single longest run (build_sweep) is kept only for the slip
+    // health-check and the moving-run print. Skipped without --tel-port.
+    let (sweep, chunks) = match &tel_port {
         Some(port) => {
             let tel = run_sweep(
                 &mut c,
@@ -132,6 +134,7 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
                 &out,
             )?;
             let s = build_sweep(&tel);
+            let chunks = build_sweep_chunks(&tel);
             match &s {
                 Some((pos, _)) => println!(
                     "[sweep] {} tel frames, moving run {} (fs {fs:.0} Hz from tick_hz)",
@@ -140,23 +143,34 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
                 ),
                 None => println!("[sweep] {} tel frames, no usable moving run", tel.len()),
             }
-            s
+            (s, chunks)
         }
-        None => None,
+        None => (None, Vec::new()),
     };
 
     recenter(&mut c, id, pos_min_phys, pos_max_phys, drive_polarity)?;
 
     // Full-traverse motor revs from the ripple sweep: anchor-free geometry,
-    // extrapolated from the moving run's phase span to the whole count span.
-    // Paired with a gear ratio it yields travel; paired with a travel angle it
-    // yields the gear. Both anchors consume this same ripple half.
-    let count_span = pos_max_phys as f64 - pos_min_phys as f64;
-    let motor_revs_full = sweep
-        .as_ref()
-        .and_then(|s| full_motor_revs(s, fs, count_span));
+    // stitched over all chunks and extrapolated from the covered phase span to
+    // the whole rail count span. Paired with a gear ratio it yields travel;
+    // paired with a travel angle it yields the gear. Both anchors consume this
+    // same ripple half. Empty chunks (no --tel-port) -> None.
+    let motor_revs_full = stitched_motor_revs(
+        &chunks,
+        fs,
+        RIPPLE_PER_REV,
+        pos_min_phys as u16,
+        pos_max_phys as u16,
+    );
     let mrf = motor_revs_full.map(|(m, _)| m);
     let coverage = motor_revs_full.map(|(_, c)| c);
+    if tel_port.is_some() {
+        println!(
+            "[sweep] {} clean chunks, stitched coverage {:.0}%",
+            chunks.len(),
+            coverage.unwrap_or(0.0) * 100.0
+        );
+    }
 
     // Resolve the anchor: gear is preferred, travel is the fallback. --yes stays
     // headless through the pure resolve_anchor; interactively the operator
@@ -178,31 +192,29 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     let (angle_min_cdeg, angle_max_cdeg) = angle_endpoints(phys_min, phys_max);
     let dpc = kinematics::deg_per_count(angle_min_cdeg, angle_max_cdeg, pos_min_phys, pos_max_phys);
 
-    // pot LUT from the same sweep; identity when the ripple SNR is too low to
-    // clock true angle. No sweep at all -> None, LUT left untouched below.
-    let lut = sweep.as_ref().map(|(pos, current)| {
-        let (raw_min, raw_max) = (pos_min_phys as u16, pos_max_phys as u16);
-        let phase = lut::cumulative_phase(current, fs, RIPPLE_PER_REV);
-        let phase_found = phase.is_some();
-        let l = match phase {
-            Some((p, _)) => lut::build(pos, &p, raw_min, raw_max),
-            None => PotLut::identity(raw_min, raw_max),
-        };
-        // build may return identity even with a phase (low span coverage), so
-        // read populated off the result, not phase.is_some().
+    // pot LUT stitched from all chunks; identity when the stitched coverage is
+    // too low (or the ripple SNR is too low to clock true angle) - build_multi
+    // decides internally and returns identity in either case. No chunks at all
+    // (no --tel-port) -> None, LUT left untouched below.
+    let lut = (!chunks.is_empty()).then(|| {
+        let l = build_multi(
+            &chunks,
+            fs,
+            RIPPLE_PER_REV,
+            pos_min_phys as u16,
+            pos_max_phys as u16,
+        );
         let populated = l.corr.iter().any(|&c| c != 0);
-        let coverage = lut::span_coverage(pos, raw_min, raw_max);
-        (l, phase_found, populated, coverage)
+        (l, populated)
     });
     match &lut {
-        Some((l, _, true, _)) => {
+        Some((l, true)) => {
             let maxc = l.corr.iter().map(|&c| c.unsigned_abs()).max().unwrap_or(0);
             println!("pot LUT: populated, max |corr| {maxc} counts");
         }
-        Some((_, false, _, _)) => println!("pot LUT: identity (ripple SNR too low)"),
-        Some((_, true, false, coverage)) => println!(
-            "pot LUT: identity (sweep covered only {:.0}% of travel)",
-            coverage * 100.0
+        Some((_, false)) => println!(
+            "pot LUT: identity (stitched coverage {:.0}% of travel)",
+            coverage.unwrap_or(0.0) * 100.0
         ),
         None => {}
     }
@@ -308,6 +320,50 @@ fn build_sweep(tel: &[TelFrame]) -> Option<(Vec<u16>, Vec<f64>)> {
     ))
 }
 
+/// A chunk shorter than this is too short to carry usable ripple and is almost
+/// certainly a corruption fragment, so it is dropped from the stitch.
+const MIN_CHUNK_SAMPLES: usize = 200;
+
+/// ALL clean sweep chunks (not just the longest): each maximal run of
+/// seq-contiguous, in-range (pos<=4095) frames, as (pos, current). Chunks
+/// shorter than MIN_CHUNK_SAMPLES are dropped as corruption fragments. The
+/// stitch (lut::build_multi) reassembles them over the shared pos axis.
+pub(super) fn build_sweep_chunks(tel: &[TelFrame]) -> Vec<(Vec<u16>, Vec<f64>)> {
+    // Same filter as build_sweep: a dropped (corrupt/absent) frame removes its
+    // seq, so the run splits there just as a seq gap would.
+    let s: Vec<(u8, u16, f64)> = tel
+        .iter()
+        .filter_map(|f| {
+            let pos = f.pos?;
+            pos_plausible(pos).then_some((f.seq, pos, f.current? as f64))
+        })
+        .collect();
+    let mut chunks = Vec::new();
+    if s.is_empty() {
+        return chunks;
+    }
+    let mut lo = 0usize;
+    for i in 1..s.len() {
+        if s[i].0 != s[i - 1].0.wrapping_add(1) {
+            emit_chunk(&s[lo..i], &mut chunks);
+            lo = i;
+        }
+    }
+    emit_chunk(&s[lo..], &mut chunks);
+    chunks
+}
+
+/// Push one maximal seq-contiguous run as a (pos, current) chunk, dropping it
+/// when shorter than MIN_CHUNK_SAMPLES.
+fn emit_chunk(run: &[(u8, u16, f64)], chunks: &mut Vec<(Vec<u16>, Vec<f64>)>) {
+    if run.len() >= MIN_CHUNK_SAMPLES {
+        chunks.push((
+            run.iter().map(|x| x.1).collect(),
+            run.iter().map(|x| x.2).collect(),
+        ));
+    }
+}
+
 /// Longest half-open index range `[lo, hi)` of samples whose u8 seq increments
 /// by exactly one each step (no dropped frames). None when nothing has >= 2
 /// contiguous samples.
@@ -329,24 +385,6 @@ fn longest_contiguous_run(s: &[(u8, u16, f64)]) -> Option<(usize, usize)> {
         (best_lo, best_hi) = (lo, s.len());
     }
     (best_hi - best_lo >= 2).then_some((best_lo, best_hi))
-}
-
-/// Full-traverse motor revs + ripple coverage (0..1) from a sweep. Counts motor
-/// revs over the moving run by integrating the windowed ripple speed (drift-
-/// resistant, no constant-velocity assumption), then extrapolates to the whole
-/// rail-to-rail count span. This is the ripple half shared by both anchors: a
-/// gear ratio turns it into travel, a travel angle turns it into the gear. None
-/// when the ripple coverage is too low or the extrapolation hits the 0 sentinel.
-fn full_motor_revs(sweep: &(Vec<u16>, Vec<f64>), fs: f64, count_span: f64) -> Option<(f64, f64)> {
-    let (pos, current) = sweep;
-    if pos.len() < 2 || fs <= 0.0 {
-        return None;
-    }
-    let (phase, coverage) = lut::cumulative_phase(current, fs, RIPPLE_PER_REV)?;
-    let motor_revs = phase[phase.len() - 1] - phase[0];
-    let pot_disp = (pos[pos.len() - 1] as f64 - pos[0] as f64).abs();
-    let full = kinematics::full_span_motor_revs(motor_revs, pot_disp, count_span);
-    (full != 0.0).then_some((full, coverage))
 }
 
 /// Write the PotLutBlock: raw_min/raw_max as scalars, then the 55 corr knots
@@ -986,6 +1024,35 @@ mod tests {
         assert!(!pos.contains(&9999));
         assert_eq!(pos, vec![1000, 1001, 1002, 1003, 1004]);
         assert_eq!(current.len(), pos.len());
+    }
+
+    #[test]
+    fn build_sweep_chunks_keeps_big_runs_drops_fragments() {
+        // seq = index (u8, wraps cleanly), pos in-range except at two split
+        // points. Run A = 250, run B = 300 (both >= MIN_CHUNK_SAMPLES), and a
+        // trailing 50-sample fragment (< MIN_CHUNK_SAMPLES) is dropped.
+        let mut frames: Vec<TelFrame> = (0..602u32)
+            .map(|i| TelFrame {
+                seq: i as u8,
+                pos: Some(1000 + (i % 3) as u16),
+                current: Some(50),
+                ..Default::default()
+            })
+            .collect();
+        frames[250].pos = Some(9999); // splits run A | run B
+        frames[551].pos = Some(9999); // splits run B | tiny fragment
+        let chunks = build_sweep_chunks(&frames);
+        assert_eq!(chunks.len(), 2, "exactly the two big chunks survive");
+        assert_eq!(chunks[0].0.len(), 250);
+        assert_eq!(chunks[1].0.len(), 300);
+        // current vec length tracks pos in each chunk
+        assert_eq!(chunks[0].1.len(), 250);
+        assert_eq!(chunks[1].1.len(), 300);
+    }
+
+    #[test]
+    fn build_sweep_chunks_empty_without_frames() {
+        assert!(build_sweep_chunks(&[]).is_empty());
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -1,0 +1,352 @@
+//! `osc cal` -- the calibration orchestrator: find the mechanical end-stops,
+//! confirm the real-world angle range with the operator, print the
+//! count->unit report, then write the limits + drive polarity + angle
+//! endpoints and persist with MGMT SAVE. Interactive by default; flags make
+//! it headless. Gear ratio here is an operator input only - measuring it (a
+//! TEL ripple sweep) is a later commit. The endstop state machine and the
+//! kinematics/units math live in osc-ident; this wrapper owns USB, prompts,
+//! and files.
+
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use dialoguer::{Confirm, Input};
+use osc_client::Id;
+use osc_client::blocking::Client;
+use osc_client::nusb::NusbPipe;
+use osc_ident::exp::endstop::{Endstop, EndstopCfg, EndstopResult};
+use osc_ident::exp::{Guarded, RigParams};
+use osc_ident::kinematics::{self, KinematicsResult, angle_endpoints};
+use osc_ident::regs::{calib, config, control};
+use osc_ident::units::{self, SenseParams};
+
+use crate::rig::csvio::{OutDir, SnapshotLog};
+use crate::rig::pump::{self, Pump, read_snapshot, write_reg};
+use crate::rig::snapshot::{self, read_u16};
+
+/// Assumed total rated travel when the operator gives no phys angle: a 0..180
+/// deg span. Only a default; every real servo overrides it.
+const DEFAULT_TRAVEL_DEG: f64 = 180.0;
+
+/// `osc cal` args: output dir plus the headless overrides. `--baud`/`--id`
+/// come from the top-level osc globals.
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    /// Output dir for the rollback snapshot + endstop log (default ./cal-out).
+    #[arg(long)]
+    out: Option<std::path::PathBuf>,
+    /// Real angle (deg) at the min-count rail.
+    #[arg(long)]
+    phys_angle_min: Option<f64>,
+    /// Real angle (deg) at the max-count rail.
+    #[arg(long)]
+    phys_angle_max: Option<f64>,
+    /// App-facing working-range min (deg); defaults to the phys min.
+    #[arg(long)]
+    soft_angle_min: Option<f64>,
+    /// App-facing working-range max (deg); defaults to the phys max.
+    #[arg(long)]
+    soft_angle_max: Option<f64>,
+    /// Known gear ratio (motor rev per output rev); unset leaves it 0.
+    #[arg(long)]
+    gear_ratio: Option<f64>,
+    /// Assume yes: never prompt. Required values must come from flags.
+    #[arg(long)]
+    yes: bool,
+}
+
+/// Entry from the top-level `osc cal` dispatch.
+pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
+    pump::install_ctrlc();
+    let mut c = crate::rig::connect(&baud)?;
+    let id = Id::new(id);
+
+    let sense = read_sense(&mut c, id)?;
+    let ke_vpc_q = read_u16(&mut c, id, calib::KE_VPC_Q)?;
+    if ke_vpc_q == 0 {
+        eprintln!("warning: ke_vpc_q is 0 - run `osc ident` first for the torque report");
+    }
+
+    // Safety gate before any motion: both mechanical ends get driven.
+    if !args.yes {
+        println!("cal drives the servo into BOTH mechanical end-stops.");
+        if !confirm("proceed", false)? {
+            println!("declined, no writes");
+            return Ok(());
+        }
+    }
+
+    let out = OutDir::create(args.out.as_deref().unwrap_or(Path::new("./cal-out")))?;
+    let r = run_endstop(&mut c, id, &out)?;
+    let EndstopResult {
+        pos_min_phys,
+        pos_max_phys,
+        drive_polarity,
+        i_stall_counts,
+    } = r;
+    let span = pos_max_phys - pos_min_phys;
+    println!(
+        "rails: min {pos_min_phys} max {pos_max_phys} span {span} counts, polarity {}, stall {i_stall_counts} counts",
+        if drive_polarity { "normal" } else { "reversed" },
+    );
+
+    recenter(&mut c, id, pos_min_phys, pos_max_phys, drive_polarity)?;
+
+    let (phys_min, phys_max) = phys_angles(args)?;
+    let (soft_min_deg, soft_max_deg) = soft_angles(args, phys_min, phys_max)?;
+    let gear_ratio_centi = gear_ratio(args)?;
+
+    // soft angle -> phys count via the linear phys map, clamped to the rails
+    let soft_min_count =
+        soft_to_count(soft_min_deg, phys_min, phys_max, pos_min_phys, pos_max_phys);
+    let soft_max_count =
+        soft_to_count(soft_max_deg, phys_min, phys_max, pos_min_phys, pos_max_phys);
+
+    let (angle_min_cdeg, angle_max_cdeg) = angle_endpoints(phys_min, phys_max);
+    let kin = KinematicsResult {
+        angle_min_cdeg,
+        angle_max_cdeg,
+        gear_ratio_centi,
+    };
+    let factors = units::derive(&sense, &kin, pos_min_phys, pos_max_phys, ke_vpc_q);
+    print!("{}", units::render(&factors));
+
+    let dpc = kinematics::deg_per_count(angle_min_cdeg, angle_max_cdeg, pos_min_phys, pos_max_phys);
+    println!("deg/count {dpc:.6}");
+    println!(
+        "phys angle {phys_min:.2}..{phys_max:.2} deg, soft angle {soft_min_deg:.2}..{soft_max_deg:.2} deg"
+    );
+    println!("soft counts {soft_min_count}..{soft_max_count}");
+
+    if !args.yes && !confirm("write these values and MGMT SAVE", false)? {
+        println!("declined before write");
+        return Ok(());
+    }
+
+    // snapshot the calib + gain block before any write (rollback safety)
+    snapshot::take_snapshot(&mut c, id, &out.0.join("snapshot.json"))?;
+
+    write_reg(&mut c, id, config::POS_MIN_PHYS_COUNTS, pos_min_phys)?;
+    write_reg(&mut c, id, config::POS_MAX_PHYS_COUNTS, pos_max_phys)?;
+    write_reg(&mut c, id, config::POS_MIN_SOFT_COUNTS, soft_min_count)?;
+    write_reg(&mut c, id, config::POS_MAX_SOFT_COUNTS, soft_max_count)?;
+    write_reg(&mut c, id, config::DRIVE_POLARITY, drive_polarity as i32)?;
+    write_reg(&mut c, id, calib::ANGLE_MIN_CDEG, angle_min_cdeg as i32)?;
+    write_reg(&mut c, id, calib::ANGLE_MAX_CDEG, angle_max_cdeg as i32)?;
+    write_reg(&mut c, id, calib::GEAR_RATIO_CENTI, gear_ratio_centi as i32)?;
+
+    // SAVE needs torque off (protocol sec 9.4); park was already torque-off.
+    write_reg(&mut c, id, control::TORQUE_ENABLE, 0)?;
+    c.save(id).context("MGMT SAVE")?;
+    println!("saved");
+    Ok(())
+}
+
+fn read_sense(c: &mut Client<NusbPipe>, id: Id) -> Result<SenseParams> {
+    Ok(SenseParams {
+        shunt_r_mohm: read_u16(c, id, calib::SHUNT_R_MOHM)?,
+        gain_milli: read_u16(c, id, calib::GAIN_MILLI)?,
+        vmotor_div_top: read_u16(c, id, calib::VMOTOR_DIV_TOP)?,
+        vmotor_div_bot: read_u16(c, id, calib::VMOTOR_DIV_BOT)?,
+        vdd_mv: read_u16(c, id, calib::VDD_MV)?,
+        tick_hz: read_u16(c, id, calib::TICK_HZ)?,
+    })
+}
+
+fn run_endstop(c: &mut Client<NusbPipe>, id: Id, out: &OutDir) -> Result<EndstopResult> {
+    println!("[endstop] seeking both rails (pos guard off)");
+    // pos guard off: driving into the physical ends IS the method
+    let params = RigParams::default().without_pos_guard();
+    let mut log = SnapshotLog::create(out, "endstop_snapshots.csv")?;
+    let mut exp = Guarded::new(Endstop::new(EndstopCfg::default(), &params), params);
+    let ran = Pump {
+        client: c,
+        id,
+        tel_port: None,
+        tel_mask: 0,
+        log: Some(&mut log),
+    }
+    .run(&mut exp, |_| {});
+    // park safe whether the run finished, errored, or was ctrl-c'd
+    let _ = write_reg(c, id, control::GOAL_DUTY, 0);
+    let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
+    ran?;
+    if let Some(reason) = exp.abort() {
+        bail!("endstop aborted by the safety envelope: {reason:?}");
+    }
+    exp.into_inner()
+        .result()
+        .context("endstop did not reach both rails - no writes")
+}
+
+/// Drive to the rail midpoint so the servo does not rest on a hard stop.
+/// Best-effort: uses the measured polarity to pick the duty sign toward the
+/// midpoint, parks torque-off on arrival, and gives up quietly after the loop.
+fn recenter(
+    c: &mut Client<NusbPipe>,
+    id: Id,
+    pos_min: i32,
+    pos_max: i32,
+    drive_polarity: bool,
+) -> Result<()> {
+    const DUTY: i32 = 9000;
+    let mid = (pos_min + pos_max) / 2;
+    let margin = ((pos_max - pos_min) / 10).max(1);
+    let lo = (mid - margin).clamp(0, u16::MAX as i32) as u16;
+    let hi = (mid + margin).clamp(0, u16::MAX as i32) as u16;
+    let park = |c: &mut Client<NusbPipe>| {
+        let _ = write_reg(c, id, control::GOAL_DUTY, 0);
+        let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
+    };
+    write_reg(c, id, control::MODE, 0)?;
+    write_reg(c, id, control::TORQUE_ENABLE, 1)?;
+    for _ in 0..200 {
+        if pump::STOP.load(Ordering::SeqCst) {
+            park(c);
+            bail!("interrupted");
+        }
+        let pos = read_snapshot(c, id)?.pos;
+        if (lo..=hi).contains(&pos) {
+            park(c);
+            return Ok(());
+        }
+        // duty sign toward the midpoint: polarity maps count direction to sign
+        let toward_higher = (pos as i32) < mid;
+        let duty = if toward_higher == drive_polarity {
+            DUTY
+        } else {
+            -DUTY
+        };
+        write_reg(c, id, control::GOAL_DUTY, duty)?;
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    park(c);
+    println!("[recenter] did not reach mid-travel (gear slip?), left parked");
+    Ok(())
+}
+
+/// Phys angle at each rail: from flags under `--yes` (both required), else
+/// prompted with the flags or 0..DEFAULT_TRAVEL_DEG as defaults.
+fn phys_angles(args: &Args) -> Result<(f64, f64)> {
+    if args.yes {
+        let min = args
+            .phys_angle_min
+            .context("--yes needs --phys-angle-min")?;
+        let max = args
+            .phys_angle_max
+            .context("--yes needs --phys-angle-max")?;
+        return Ok((min, max));
+    }
+    let min = input_f64(
+        "phys angle at min rail (deg)",
+        args.phys_angle_min.unwrap_or(0.0),
+    )?;
+    let max = input_f64(
+        "phys angle at max rail (deg)",
+        args.phys_angle_max.unwrap_or(DEFAULT_TRAVEL_DEG),
+    )?;
+    Ok((min, max))
+}
+
+/// Soft (working-range) angle: flags under `--yes` (defaulting to phys), else
+/// prompted with the flags or the phys angles as defaults.
+fn soft_angles(args: &Args, phys_min: f64, phys_max: f64) -> Result<(f64, f64)> {
+    if args.yes {
+        return Ok((
+            args.soft_angle_min.unwrap_or(phys_min),
+            args.soft_angle_max.unwrap_or(phys_max),
+        ));
+    }
+    let min = input_f64(
+        "soft angle min (deg)",
+        args.soft_angle_min.unwrap_or(phys_min),
+    )?;
+    let max = input_f64(
+        "soft angle max (deg)",
+        args.soft_angle_max.unwrap_or(phys_max),
+    )?;
+    Ok((min, max))
+}
+
+/// Gear ratio as centi (x100); 0 is the firmware "unset" sentinel.
+fn gear_ratio(args: &Args) -> Result<u16> {
+    let ratio = if args.yes {
+        args.gear_ratio
+    } else if let Some(g) = args.gear_ratio {
+        Some(input_f64("gear ratio (motor rev per output rev)", g)?)
+    } else if confirm("enter a known gear ratio", false)? {
+        Some(input_f64("gear ratio (motor rev per output rev)", 1.0)?)
+    } else {
+        None
+    };
+    Ok(ratio_to_centi(ratio))
+}
+
+fn ratio_to_centi(ratio: Option<f64>) -> u16 {
+    match ratio {
+        Some(r) if r.is_finite() && r > 0.0 => {
+            (r * 100.0).round().clamp(0.0, u16::MAX as f64) as u16
+        }
+        _ => 0,
+    }
+}
+
+fn soft_to_count(angle: f64, phys_min: f64, phys_max: f64, pos_min: i32, pos_max: i32) -> i32 {
+    let denom = phys_max - phys_min;
+    let frac = if denom == 0.0 {
+        0.0
+    } else {
+        (angle - phys_min) / denom
+    };
+    let count = pos_min as f64 + frac * (pos_max - pos_min) as f64;
+    let (lo, hi) = (pos_min.min(pos_max), pos_min.max(pos_max));
+    (count.round() as i32).clamp(lo, hi)
+}
+
+fn confirm(prompt: &str, default: bool) -> Result<bool> {
+    Ok(Confirm::new()
+        .with_prompt(prompt)
+        .default(default)
+        .interact()?)
+}
+
+fn input_f64(prompt: &str, default: f64) -> Result<f64> {
+    Ok(Input::<f64>::new()
+        .with_prompt(prompt)
+        .default(default)
+        .interact_text()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soft_maps_and_clamps_within_rails() {
+        // 0..180 deg over counts 100..4000
+        assert_eq!(soft_to_count(0.0, 0.0, 180.0, 100, 4000), 100);
+        assert_eq!(soft_to_count(180.0, 0.0, 180.0, 100, 4000), 4000);
+        assert_eq!(soft_to_count(90.0, 0.0, 180.0, 100, 4000), 2050);
+        // tighter-than-phys stays in band; out-of-range clamps to a rail
+        assert_eq!(soft_to_count(-10.0, 0.0, 180.0, 100, 4000), 100);
+        assert_eq!(soft_to_count(200.0, 0.0, 180.0, 100, 4000), 4000);
+    }
+
+    #[test]
+    fn soft_degenerate_phys_span_is_min_rail() {
+        assert_eq!(soft_to_count(50.0, 90.0, 90.0, 100, 4000), 100);
+    }
+
+    #[test]
+    fn ratio_centi_encoding_and_sentinel() {
+        assert_eq!(ratio_to_centi(Some(150.0)), 15000);
+        assert_eq!(ratio_to_centi(Some(1.5)), 150);
+        assert_eq!(ratio_to_centi(None), 0);
+        assert_eq!(ratio_to_centi(Some(0.0)), 0);
+        assert_eq!(ratio_to_centi(Some(-3.0)), 0);
+        assert_eq!(ratio_to_centi(Some(f64::NAN)), 0);
+        assert_eq!(ratio_to_centi(Some(1e9)), u16::MAX);
+    }
+}

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -120,9 +120,7 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     // build_sweep takes the longest moving run. Skipped without --tel-port.
     let sweep = match &tel_port {
         Some(port) => {
-            // sweep toward increasing pos; polarity maps duty sign to direction
-            let sweep_sign = if drive_polarity { 1 } else { -1 };
-            let tel = run_sweep(&mut c, id, port, sweep_sign)?;
+            let tel = run_sweep(&mut c, id, port, pos_min_phys, pos_max_phys, drive_polarity)?;
             let s = build_sweep(&tel);
             match &s {
                 Some((pos, _)) => println!(
@@ -379,17 +377,55 @@ fn run_endstop(c: &mut Client<NusbPipe>, id: Id, out: &OutDir) -> Result<Endstop
         .context("endstop did not reach both rails - no writes")
 }
 
-/// One dedicated constant-duty ripple traverse, TEL captured throughout. The
-/// pump does nothing but drain the side channel during the sweep (no polls),
-/// so the traverse lands as a single long seq-contiguous run for build_sweep.
+/// One dedicated constant-duty ripple capture, TEL captured throughout. The
+/// motion stays strictly between count-insets from both rails, so the clone's
+/// end-jam is never reached: positioning + a speed probe run first with TEL off
+/// (polling is free there), then the capture is TIME-bounded (no polls), sized
+/// from the probed speed so the pump drains TEL as a single long seq-contiguous
+/// run for build_sweep. The ~3% inset clears the rail jam yet leaves ~94% of
+/// travel captured (still passes the LUT coverage gate).
 fn run_sweep(
     c: &mut Client<NusbPipe>,
     id: Id,
     port: &str,
-    sweep_sign: i8,
+    pos_min_phys: i32,
+    pos_max_phys: i32,
+    drive_polarity: bool,
 ) -> Result<Vec<TelFrame>> {
-    println!("[sweep] constant-duty ripple traverse");
-    let mut exp = Sweep::new(SweepCfg::default(), sweep_sign);
+    const DUTY: i16 = 8520;
+    let span = (pos_max_phys - pos_min_phys) as f64;
+    let inset = (span * 0.03).max(80.0) as i32;
+    let mut start = pos_min_phys + inset;
+    let mut end = pos_max_phys - inset;
+    if end <= start {
+        // travel too short for an inset capture: fall back to the rails rather
+        // than crossing over (capture_ms still clamps the duration).
+        start = pos_min_phys;
+        end = pos_max_phys;
+    }
+    // capture direction = increasing pos; polarity maps duty sign to direction
+    let sweep_sign = if drive_polarity { 1 } else { -1 };
+
+    // speed probe, TEL off: drive AWAY from the nearer rail (toward the
+    // interior) for a short window so the probe itself never reaches a stop.
+    let mid = (pos_min_phys + pos_max_phys) / 2;
+    let here = read_snapshot(c, id)?.pos as i32;
+    let probe_sign = if here < mid { sweep_sign } else { -sweep_sign };
+    let speed = probe_speed(c, id, DUTY, probe_sign, 150)?;
+
+    // position to the capture start rail-inset (still TEL off, polling free)
+    drive_to(c, id, start, drive_polarity, DUTY)?;
+
+    let ms = capture_ms(end as f64 - start as f64, speed, 0.95);
+    println!("[sweep] capture {ms} ms over counts {start}..{end} (speed {speed:.0} cps)");
+
+    let mut exp = Sweep::new(
+        SweepCfg {
+            duty_q15: DUTY,
+            capture_ms: ms,
+        },
+        sweep_sign,
+    );
     let mut tel: Vec<TelFrame> = Vec::new();
     // 0x1B = pos|current|duty|vdiff (same TEL mask as ident inertia)
     let tel_mask: u16 = 0x1B;
@@ -521,6 +557,94 @@ fn recenter(
     park(c);
     println!("[recenter] did not reach mid-travel (gear slip?), left parked");
     Ok(())
+}
+
+/// Measure traverse speed (counts/s) at the capture duty over a short window,
+/// TEL off so pos polling is free. Drives one fixed duty for `ms` and divides
+/// the pos delta by the elapsed time. Leaves duty 0 + torque ON (the caller
+/// positions next); ctrl-c parks duty 0 + torque off and bails.
+fn probe_speed(c: &mut Client<NusbPipe>, id: Id, duty_q15: i16, sign: i8, ms: u32) -> Result<f64> {
+    let park = |c: &mut Client<NusbPipe>| {
+        let _ = write_reg(c, id, control::GOAL_DUTY, 0);
+        let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
+    };
+    if pump::STOP.load(Ordering::SeqCst) {
+        park(c);
+        bail!("interrupted");
+    }
+    write_reg(c, id, control::MODE, 0)?;
+    write_reg(c, id, control::TORQUE_ENABLE, 1)?;
+    let p0 = read_snapshot(c, id)?.pos as f64;
+    write_reg(c, id, control::GOAL_DUTY, sign as i32 * duty_q15 as i32)?;
+    std::thread::sleep(Duration::from_millis(ms as u64));
+    if pump::STOP.load(Ordering::SeqCst) {
+        park(c);
+        bail!("interrupted");
+    }
+    let p1 = read_snapshot(c, id)?.pos as f64;
+    write_reg(c, id, control::GOAL_DUTY, 0)?;
+    Ok((p1 - p0).abs() / (ms as f64 / 1000.0))
+}
+
+/// Closed-loop drive toward a target count, TEL off. Polls pos, picks the duty
+/// sign toward target via the measured polarity, and stops within a small band.
+/// Leaves duty 0 + torque ON (holds position for the capture that follows);
+/// ctrl-c parks duty 0 + torque off and bails.
+fn drive_to(
+    c: &mut Client<NusbPipe>,
+    id: Id,
+    target: i32,
+    drive_polarity: bool,
+    duty_q15: i16,
+) -> Result<()> {
+    // fixed band, well inside the >=80 count rail inset so we never settle on
+    // (or overshoot into) a stop.
+    const BAND: i32 = 40;
+    let duty = duty_q15 as i32;
+    let park = |c: &mut Client<NusbPipe>| {
+        let _ = write_reg(c, id, control::GOAL_DUTY, 0);
+        let _ = write_reg(c, id, control::TORQUE_ENABLE, 0);
+    };
+    write_reg(c, id, control::MODE, 0)?;
+    write_reg(c, id, control::TORQUE_ENABLE, 1)?;
+    for _ in 0..200 {
+        if pump::STOP.load(Ordering::SeqCst) {
+            park(c);
+            bail!("interrupted");
+        }
+        let pos = read_snapshot(c, id)?.pos as i32;
+        if (pos - target).abs() <= BAND {
+            write_reg(c, id, control::GOAL_DUTY, 0)?;
+            return Ok(());
+        }
+        // duty sign toward target: polarity maps count direction to sign
+        let toward_higher = pos < target;
+        let d = if toward_higher == drive_polarity {
+            duty
+        } else {
+            -duty
+        };
+        write_reg(c, id, control::GOAL_DUTY, d)?;
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    write_reg(c, id, control::GOAL_DUTY, 0)?;
+    println!("[sweep] drive_to did not reach start inset (gear slip?), capturing from here");
+    Ok(())
+}
+
+/// Capture duration (ms) to traverse `span_counts` at `speed_cps`, scaled by a
+/// `safety` factor and clamped to [200, 4000] ms so a bad speed reading can
+/// never drive for minutes. A non-positive or non-finite speed returns the
+/// 4000 ms max (defensive - the clamp still bounds it).
+fn capture_ms(span_counts: f64, speed_cps: f64, safety: f64) -> u32 {
+    if !speed_cps.is_finite() || speed_cps <= 0.0 {
+        return 4000;
+    }
+    let ms = span_counts / speed_cps * 1000.0 * safety;
+    if !ms.is_finite() {
+        return 4000;
+    }
+    ms.clamp(200.0, 4000.0).round() as u32
 }
 
 /// Phys angle at each rail: from flags under `--yes` (both required), else
@@ -870,6 +994,21 @@ mod tests {
         );
         // gear flag but no ripple and no travel -> nothing to anchor on
         assert_eq!(resolve_anchor(None, Some(150.0), None, None), (0.0, 0.0, 0));
+    }
+
+    #[test]
+    fn capture_ms_scales_clamps_and_defends() {
+        // 3400 counts at 3400 cps * 0.95 safety = 950 ms
+        assert_eq!(capture_ms(3400.0, 3400.0, 0.95), 950);
+        // fast motor -> below the 200 ms floor -> clamped up
+        assert_eq!(capture_ms(100.0, 20000.0, 0.95), 200);
+        // slow motor -> above the 4000 ms ceiling -> clamped down
+        assert_eq!(capture_ms(4000.0, 200.0, 0.95), 4000);
+        // bad speed readings -> defensive 4000 ms max
+        assert_eq!(capture_ms(3400.0, 0.0, 0.95), 4000);
+        assert_eq!(capture_ms(3400.0, -50.0, 0.95), 4000);
+        assert_eq!(capture_ms(3400.0, f64::NAN, 0.95), 4000);
+        assert_eq!(capture_ms(3400.0, f64::INFINITY, 0.95), 4000);
     }
 
     #[test]

--- a/tools/osc/src/cal/mod.rs
+++ b/tools/osc/src/cal/mod.rs
@@ -314,9 +314,12 @@ fn build_sweep(tel: &[TelFrame]) -> Option<(Vec<u16>, Vec<f64>)> {
         })
         .collect();
     let (lo, hi) = longest_contiguous_run(&s)?;
+    // trim fused rail dwell here too: the slip check reads this run, and a
+    // pinned-pot buzz segment reads as a stuck (slipping) gear segment.
+    let run = trim_edge_dwell(&s[lo..hi]);
     Some((
-        s[lo..hi].iter().map(|x| x.1).collect(),
-        s[lo..hi].iter().map(|x| x.2).collect(),
+        run.iter().map(|x| x.1).collect(),
+        run.iter().map(|x| x.2).collect(),
     ))
 }
 
@@ -330,6 +333,56 @@ const MIN_CHUNK_SAMPLES: usize = 200;
 /// has many samples but ~0 pos travel, so its revs/count is nonsense (spikes
 /// the stitched anchor and dumps a bogus rail correction); drop it by span.
 const MIN_CHUNK_SPAN: u16 = 50;
+
+/// A moving run can also carry a rail dwell FUSED to its ends (too much travel
+/// for the span gate above to catch): the traverse overshoots into an end-stop
+/// and buzzes there seq-contiguously with the sweep, pot pinned while the motor
+/// keeps turning. Those samples accrue ripple revs with ~zero pot travel and
+/// poison the per-count density (bench: 270 ms of max-rail buzz fused to one
+/// chunk deposited 71 garbage revs into the top bins - travel read 340 deg on a
+/// ~225 deg servo, and the pinned-pot segment faked a gear-slip warning). Trim
+/// each end at the sweep's first crossing out of / into the band this many
+/// counts from that end's extreme pos.
+const EDGE_DWELL_COUNTS: u16 = 8;
+
+/// Trim rail dwell fused to a run's ends (see EDGE_DWELL_COUNTS): keep from the
+/// first sample past the head-extreme band to the first sample reaching the
+/// tail-extreme band. First-crossing on both ends is robust to buzz wiggle and
+/// mid-run jitter; on a clean rail-to-rail sweep it costs only the outermost
+/// EDGE_DWELL_COUNTS counts of each end. Runs narrower than the two bands are
+/// returned unchanged.
+fn trim_edge_dwell(run: &[(u8, u16, f64)]) -> &[(u8, u16, f64)] {
+    let (mut lo, mut hi) = (run[0].1, run[0].1);
+    for x in run {
+        lo = lo.min(x.1);
+        hi = hi.max(x.1);
+    }
+    if hi - lo <= 2 * EDGE_DWELL_COUNTS {
+        return run;
+    }
+    let up = run[run.len() - 1].1 >= run[0].1;
+    let past_head = |p: u16| {
+        if up {
+            p > lo + EDGE_DWELL_COUNTS
+        } else {
+            p < hi - EDGE_DWELL_COUNTS
+        }
+    };
+    let at_tail = |p: u16| {
+        if up {
+            p >= hi - EDGE_DWELL_COUNTS
+        } else {
+            p <= lo + EDGE_DWELL_COUNTS
+        }
+    };
+    let start = run.iter().position(|x| past_head(x.1)).unwrap_or(0);
+    let end = run
+        .iter()
+        .position(|x| at_tail(x.1))
+        .map(|i| i + 1)
+        .unwrap_or(run.len());
+    &run[start..end.max(start + 1)]
+}
 
 /// ALL clean sweep chunks (not just the longest): each maximal run of
 /// seq-contiguous, in-range (pos<=4095) frames, as (pos, current). Chunks
@@ -362,7 +415,8 @@ pub(super) fn build_sweep_chunks(tel: &[TelFrame]) -> Vec<(Vec<u16>, Vec<f64>)> 
 
 /// Push one maximal seq-contiguous run as a (pos, current) chunk, dropping it
 /// when shorter than MIN_CHUNK_SAMPLES or when its pos span is below
-/// MIN_CHUNK_SPAN (a rail stall, not a sweep segment).
+/// MIN_CHUNK_SPAN (a rail stall, not a sweep segment). Rail dwell fused to the
+/// ends is trimmed first; the length gate re-applies to the trimmed run.
 fn emit_chunk(run: &[(u8, u16, f64)], chunks: &mut Vec<(Vec<u16>, Vec<f64>)>) {
     if run.len() < MIN_CHUNK_SAMPLES {
         return;
@@ -372,7 +426,11 @@ fn emit_chunk(run: &[(u8, u16, f64)], chunks: &mut Vec<(Vec<u16>, Vec<f64>)>) {
         lo = lo.min(x.1);
         hi = hi.max(x.1);
     }
-    if hi - lo >= MIN_CHUNK_SPAN {
+    if hi - lo < MIN_CHUNK_SPAN {
+        return;
+    }
+    let run = trim_edge_dwell(run);
+    if run.len() >= MIN_CHUNK_SAMPLES {
         chunks.push((
             run.iter().map(|x| x.1).collect(),
             run.iter().map(|x| x.2).collect(),
@@ -1044,10 +1102,11 @@ mod tests {
 
     #[test]
     fn build_sweep_chunks_keeps_big_runs_drops_fragments_and_stalls() {
-        // seq = index (u8, wraps cleanly). Three moving runs (pos sweeps a real
-        // span) split by out-of-range pos, plus a trailing short fragment and a
-        // long STALL run (pos frozen at a rail). Kept: the two big MOVING runs.
-        // Dropped: the <MIN_CHUNK_SAMPLES fragment AND the stall (span 0).
+        // seq = index (u8, wraps cleanly). Moving runs (pos sweeps a real span)
+        // split by out-of-range pos, plus a trailing short fragment, a long
+        // STALL run (pos frozen at a rail), and a moving run with a rail buzz
+        // FUSED to its tail. Kept: the moving runs, edge-trimmed by
+        // EDGE_DWELL_COUNTS; the fused buzz tail is trimmed off entirely.
         let mut frames: Vec<TelFrame> = Vec::new();
         let mut push = |base: u16, count: u32, moving: bool| {
             for j in 0..count {
@@ -1061,22 +1120,31 @@ mod tests {
                 });
             }
         };
-        push(1000, 250, true); // run A: span 249, kept
+        push(1000, 250, true); // run A: span 249, kept (trimmed)
         push(9999, 1, true); // split (out-of-range)
-        push(2000, 300, true); // run B: span 299, kept
+        push(2000, 300, true); // run B: span 299, kept (trimmed)
         push(9999, 1, true); // split
         push(3000, 50, true); // fragment: < MIN_CHUNK_SAMPLES, dropped
         push(9999, 1, true); // split
         push(4095, 250, false); // stall: >= samples but span 0, dropped
+        push(9999, 1, true); // split
+        push(3600, 300, true); // run C sweeps 3600..3899 ...
+        push(3899, 400, false); // ... then buzzes at the rail seq-contiguously
 
         let chunks = build_sweep_chunks(&frames);
-        assert_eq!(chunks.len(), 2, "only the two moving runs survive");
-        assert_eq!(chunks[0].0.len(), 250);
-        assert_eq!(chunks[1].0.len(), 300);
-        assert_eq!(chunks[0].1.len(), 250);
-        assert_eq!(chunks[1].1.len(), 300);
+        assert_eq!(chunks.len(), 3, "the three moving runs survive");
+        // each end trimmed at the first crossing out of the extreme band:
+        // head loses EDGE_DWELL_COUNTS+1 samples, tail keeps through the first
+        // sample inside the band (1 count/sample here)
+        let trimmed = |n: usize| n - (2 * EDGE_DWELL_COUNTS as usize + 1);
+        assert_eq!(chunks[0].0.len(), trimmed(250));
+        assert_eq!(chunks[1].0.len(), trimmed(300));
+        assert_eq!(chunks[0].1.len(), trimmed(250));
         // the stall run (span 0) is gone despite having >= MIN_CHUNK_SAMPLES
         assert!(chunks.iter().all(|(p, _)| p.iter().max() != Some(&4095)));
+        // run C: the 400-sample fused buzz is trimmed off with the tail band
+        assert_eq!(chunks[2].0.len(), trimmed(300));
+        assert!(chunks[2].0.iter().max() < Some(&3899));
     }
 
     #[test]

--- a/tools/osc/src/cal/replay.rs
+++ b/tools/osc/src/cal/replay.rs
@@ -12,9 +12,9 @@
 
 use anyhow::{Context, Result, bail};
 use osc_ident::frame::{TelDeframer, TelFrame};
-use osc_ident::lut::{self, PotLut};
+use osc_ident::lut::{self, build_multi, stitched_motor_revs};
 
-use super::{RIPPLE_PER_REV, build_sweep, full_motor_revs, pos_plausible};
+use super::{RIPPLE_PER_REV, build_sweep, build_sweep_chunks, pos_plausible};
 
 /// A pos delta larger than this across two truly-consecutive samples is
 /// physically impossible at the sweep sample rate (the capture traverses at a
@@ -127,6 +127,8 @@ pub fn run(args: &Args) -> Result<()> {
     let raw_max = args.raw_max.or(obs_max).unwrap_or(0);
 
     let sweep = build_sweep(&frames);
+    let chunks = build_sweep_chunks(&frames);
+    let chunk_samples: usize = chunks.iter().map(|(pos, _)| pos.len()).sum();
     let run_len = sweep.as_ref().map(|(pos, _)| pos.len()).unwrap_or(0);
     let run_cov = sweep
         .as_ref()
@@ -163,47 +165,45 @@ pub fn run(args: &Args) -> Result<()> {
         "longest run:       {run_len} samples, span coverage {:.0}% of rails {raw_min}..{raw_max}",
         run_cov * 100.0
     );
+    println!(
+        "chunks:            {} (samples total {chunk_samples})",
+        chunks.len()
+    );
     println!("verdict:           {verdict}");
 
     println!("--- pipeline replay ---");
-    match sweep.as_ref() {
-        Some(s) => {
-            let (pos, current) = s;
-            println!("moving run: {} samples", pos.len());
-            let phase = lut::cumulative_phase(current, args.fs, RIPPLE_PER_REV);
-            match &phase {
-                Some((_, good)) => println!("ripple coverage: {:.0}%", good * 100.0),
-                None => println!("ripple coverage: none (SNR too low or run too short)"),
-            }
-            let count_span = raw_max as f64 - raw_min as f64;
-            match full_motor_revs(s, args.fs, count_span) {
-                Some((m, cov)) => println!(
-                    "motor revs (full travel): {m:.2} (ripple coverage {:.0}%)",
-                    cov * 100.0
-                ),
-                None => println!("motor revs (full travel): unavailable"),
-            }
-            // same LUT summary logic/wording as cal::run
-            let phase_found = phase.is_some();
-            let l = match &phase {
-                Some((p, _)) => lut::build(pos, p, raw_min, raw_max),
-                None => PotLut::identity(raw_min, raw_max),
-            };
-            let populated = l.corr.iter().any(|&c| c != 0);
-            let cov = lut::span_coverage(pos, raw_min, raw_max);
-            if populated {
-                let maxc = l.corr.iter().map(|&c| c.unsigned_abs()).max().unwrap_or(0);
-                println!("pot LUT: populated, max |corr| {maxc} counts");
-            } else if !phase_found {
-                println!("pot LUT: identity (ripple SNR too low)");
-            } else {
-                println!(
-                    "pot LUT: identity (sweep covered only {:.0}% of travel)",
-                    cov * 100.0
-                );
-            }
+    if chunks.is_empty() {
+        println!("no usable chunks");
+    } else {
+        println!(
+            "stitching {} chunks ({chunk_samples} samples)",
+            chunks.len()
+        );
+        match stitched_motor_revs(&chunks, args.fs, RIPPLE_PER_REV, raw_min, raw_max) {
+            Some((m, cov)) => println!(
+                "motor revs (full travel): {m:.2} (stitched coverage {:.0}%)",
+                cov * 100.0
+            ),
+            None => println!("motor revs (full travel): unavailable"),
         }
-        None => println!("no usable moving run"),
+        // same LUT summary wording as cal::run; build_multi decides populated vs
+        // identity (stitched coverage / ripple SNR) internally.
+        let l = build_multi(&chunks, args.fs, RIPPLE_PER_REV, raw_min, raw_max);
+        let populated = l.corr.iter().any(|&c| c != 0);
+        if populated {
+            let maxc = l.corr.iter().map(|&c| c.unsigned_abs()).max().unwrap_or(0);
+            println!("pot LUT: populated, max |corr| {maxc} counts");
+        } else {
+            let all_pos: Vec<u16> = chunks
+                .iter()
+                .flat_map(|(pos, _)| pos.iter().copied())
+                .collect();
+            let cov = lut::span_coverage(&all_pos, raw_min, raw_max);
+            println!(
+                "pot LUT: identity (stitched coverage {:.0}% of travel)",
+                cov * 100.0
+            );
+        }
     }
     Ok(())
 }

--- a/tools/osc/src/cal/replay.rs
+++ b/tools/osc/src/cal/replay.rs
@@ -1,0 +1,259 @@
+//! `osc cal-replay` -- offline replay + corruption diagnostic for a saved
+//! `tel-raw.bin`. `osc cal --tel-port` streams the ripple sweep and writes the
+//! raw side-channel bytes; this command deframes those bytes without a servo,
+//! classifies which corruption mode (if any) the stream carries, and re-runs
+//! the same pot-LUT / motor-rev pipeline so the analysis can be iterated
+//! offline. It NEVER connects to the servo (no baud/id).
+//!
+//! Two corruption modes are distinguished: whole-frame CDC drops (the values
+//! that survive are clean, seq continuity has holes) versus in-frame bit-errors
+//! (frame framing holds but field contents are corrupted - pos out of the
+//! 12-bit range, or a within-range pos jump no motor could make in one sample).
+
+use anyhow::{Context, Result, bail};
+use osc_ident::frame::{TelDeframer, TelFrame};
+use osc_ident::lut::{self, PotLut};
+
+use super::{RIPPLE_PER_REV, build_sweep, full_motor_revs, pos_plausible};
+
+/// A pos delta larger than this across two truly-consecutive samples is
+/// physically impossible at the sweep sample rate (the capture traverses at a
+/// few thousand counts/s, i.e. well under one count per 20 kHz sample), so it
+/// marks a within-range bit-flip rather than real motion.
+const MAX_STEP_COUNTS: u32 = 200;
+
+/// `osc cal-replay` args. Offline: only the file and decode parameters, no bus.
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    /// The tel-raw.bin captured during `osc cal --tel-port`.
+    path: std::path::PathBuf,
+    /// TEL mask used at capture (hex ok, e.g. 0x1B); must match the capture.
+    #[arg(long, default_value = "0x1B")]
+    mask: String,
+    /// Ripple sample rate (Hz); the cal capture uses the servo tick_hz.
+    #[arg(long, default_value_t = 20000.0)]
+    fs: f64,
+    /// Pot count at the min rail; default = min plausible pos observed.
+    #[arg(long)]
+    raw_min: Option<u16>,
+    /// Pot count at the max rail; default = max plausible pos observed.
+    #[arg(long)]
+    raw_max: Option<u16>,
+}
+
+/// Parse a mask given as decimal-free hex, with or without a `0x` prefix.
+fn parse_mask(s: &str) -> Result<u16> {
+    let t = s.trim();
+    let t = t
+        .strip_prefix("0x")
+        .or_else(|| t.strip_prefix("0X"))
+        .unwrap_or(t);
+    u16::from_str_radix(t, 16).with_context(|| format!("invalid --mask hex {s:?}"))
+}
+
+/// Corruption tallies from a decoded frame list.
+struct Classification {
+    /// Frames with pos > 4095 (12-bit ADC overflow = definite bit corruption).
+    out_of_range: usize,
+    /// Truly-consecutive (seq delta 1) within-range pos pairs whose |delta|
+    /// exceeds MAX_STEP_COUNTS - a within-range bit-flip.
+    implausible_jumps: usize,
+    /// Largest |pos delta| seen across the same within-range consecutive pairs.
+    max_consec_delta: u32,
+}
+
+fn classify(frames: &[TelFrame]) -> Classification {
+    let out_of_range = frames
+        .iter()
+        .filter(|f| matches!(f.pos, Some(p) if !pos_plausible(p)))
+        .count();
+    let mut implausible_jumps = 0usize;
+    let mut max_consec_delta = 0u32;
+    for w in frames.windows(2) {
+        let (a, b) = (&w[0], &w[1]);
+        // only truly consecutive frames (no dropped seq in between)
+        if b.seq.wrapping_sub(a.seq) != 1 {
+            continue;
+        }
+        // both ends within range: an out-of-range end is already counted above,
+        // and this keeps the jump metric a distinct within-range signal.
+        if let (Some(pa), Some(pb)) = (a.pos, b.pos)
+            && pos_plausible(pa)
+            && pos_plausible(pb)
+        {
+            let delta = (pa as i32 - pb as i32).unsigned_abs();
+            if delta > MAX_STEP_COUNTS {
+                implausible_jumps += 1;
+            }
+            max_consec_delta = max_consec_delta.max(delta);
+        }
+    }
+    Classification {
+        out_of_range,
+        implausible_jumps,
+        max_consec_delta,
+    }
+}
+
+pub fn run(args: &Args) -> Result<()> {
+    let mask = parse_mask(&args.mask)?;
+    let bytes =
+        std::fs::read(&args.path).with_context(|| format!("read {}", args.path.display()))?;
+    println!("file: {} ({} bytes)", args.path.display(), bytes.len());
+
+    let mut d = match TelDeframer::new(mask) {
+        Some(d) => d,
+        None => bail!("invalid TEL mask {mask:#06x}: reserved bits set or empty"),
+    };
+    let mut frames: Vec<TelFrame> = Vec::new();
+    d.push(&bytes, &mut frames);
+    let stats = d.stats();
+    let cls = classify(&frames);
+
+    // resolve rails: explicit flags win; otherwise fall back to the observed
+    // plausible-pos bounds and say so.
+    let observed_used = args.raw_min.is_none() || args.raw_max.is_none();
+    let obs_min = frames
+        .iter()
+        .filter_map(|f| f.pos)
+        .filter(|&p| pos_plausible(p))
+        .min();
+    let obs_max = frames
+        .iter()
+        .filter_map(|f| f.pos)
+        .filter(|&p| pos_plausible(p))
+        .max();
+    let raw_min = args.raw_min.or(obs_min).unwrap_or(0);
+    let raw_max = args.raw_max.or(obs_max).unwrap_or(0);
+
+    let sweep = build_sweep(&frames);
+    let run_len = sweep.as_ref().map(|(pos, _)| pos.len()).unwrap_or(0);
+    let run_cov = sweep
+        .as_ref()
+        .map(|(pos, _)| lut::span_coverage(pos, raw_min, raw_max))
+        .unwrap_or(0.0);
+
+    // significant when >1% of decoded frames went missing (advisory heuristic)
+    let significant_gaps = stats.frames > 0 && stats.seq_gaps.saturating_mul(100) > stats.frames;
+    let verdict = if cls.out_of_range > 0 || cls.implausible_jumps > 0 {
+        "looks like bit-errors in-frame (LinkE UART / PWM noise corrupting contents)"
+    } else if significant_gaps {
+        "looks like CDC frame drops (values clean, whole frames lost)"
+    } else {
+        "stream looks clean"
+    };
+
+    println!("--- classification ---");
+    println!("bytes:             {}", bytes.len());
+    println!("frames decoded:    {}", stats.frames);
+    println!("realigns:          {}", stats.realigns);
+    println!("seq gaps:          {}", stats.seq_gaps);
+    println!(
+        "out-of-range pos:  {} (pos > 4095, in-frame bit corruption)",
+        cls.out_of_range
+    );
+    println!(
+        "implausible jumps: {} (|pos delta| > {} across consecutive seq; max consec delta {})",
+        cls.implausible_jumps, MAX_STEP_COUNTS, cls.max_consec_delta
+    );
+    if observed_used {
+        println!("note: rails from observed plausible pos bounds (no --raw-min/--raw-max)");
+    }
+    println!(
+        "longest run:       {run_len} samples, span coverage {:.0}% of rails {raw_min}..{raw_max}",
+        run_cov * 100.0
+    );
+    println!("verdict:           {verdict}");
+
+    println!("--- pipeline replay ---");
+    match sweep.as_ref() {
+        Some(s) => {
+            let (pos, current) = s;
+            println!("moving run: {} samples", pos.len());
+            let phase = lut::cumulative_phase(current, args.fs, RIPPLE_PER_REV);
+            match &phase {
+                Some((_, good)) => println!("ripple coverage: {:.0}%", good * 100.0),
+                None => println!("ripple coverage: none (SNR too low or run too short)"),
+            }
+            let count_span = raw_max as f64 - raw_min as f64;
+            match full_motor_revs(s, args.fs, count_span) {
+                Some((m, cov)) => println!(
+                    "motor revs (full travel): {m:.2} (ripple coverage {:.0}%)",
+                    cov * 100.0
+                ),
+                None => println!("motor revs (full travel): unavailable"),
+            }
+            // same LUT summary logic/wording as cal::run
+            let phase_found = phase.is_some();
+            let l = match &phase {
+                Some((p, _)) => lut::build(pos, p, raw_min, raw_max),
+                None => PotLut::identity(raw_min, raw_max),
+            };
+            let populated = l.corr.iter().any(|&c| c != 0);
+            let cov = lut::span_coverage(pos, raw_min, raw_max);
+            if populated {
+                let maxc = l.corr.iter().map(|&c| c.unsigned_abs()).max().unwrap_or(0);
+                println!("pot LUT: populated, max |corr| {maxc} counts");
+            } else if !phase_found {
+                println!("pot LUT: identity (ripple SNR too low)");
+            } else {
+                println!(
+                    "pot LUT: identity (sweep covered only {:.0}% of travel)",
+                    cov * 100.0
+                );
+            }
+        }
+        None => println!("no usable moving run"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_parses_hex_with_and_without_prefix() {
+        assert_eq!(parse_mask("0x1B").unwrap(), 0x1B);
+        assert_eq!(parse_mask("1b").unwrap(), 0x1B);
+        assert_eq!(parse_mask("3F").unwrap(), 0x3F);
+        assert_eq!(parse_mask(" 0X0f ").unwrap(), 0x0F);
+        assert!(parse_mask("zz").is_err());
+        assert!(parse_mask("").is_err());
+    }
+
+    fn frame(seq: u8, pos: u16) -> TelFrame {
+        TelFrame {
+            seq,
+            pos: Some(pos),
+            current: Some(0),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn classify_counts_out_of_range_and_within_range_jumps() {
+        let frames = vec![
+            frame(0, 1000),
+            frame(1, 1010), // +10, ok
+            frame(2, 5000), // out-of-range (bit corruption)
+            frame(3, 1020), // 2->3 consecutive but seq 2 out-of-range -> not a jump
+            frame(4, 1900), // 1020->1900 = 880, within-range implausible jump
+            frame(6, 1905), // seq gap (5 dropped) -> not consecutive, skipped
+        ];
+        let c = classify(&frames);
+        assert_eq!(c.out_of_range, 1);
+        assert_eq!(c.implausible_jumps, 1);
+        assert_eq!(c.max_consec_delta, 880);
+    }
+
+    #[test]
+    fn classify_clean_stream_has_no_flags() {
+        // small monotonic steps, all consecutive, all in range
+        let frames: Vec<TelFrame> = (0..8u8).map(|k| frame(k, 1000 + k as u16)).collect();
+        let c = classify(&frames);
+        assert_eq!(c.out_of_range, 0);
+        assert_eq!(c.implausible_jumps, 0);
+        assert_eq!(c.max_consec_delta, 1);
+    }
+}

--- a/tools/osc/src/ident/mod.rs
+++ b/tools/osc/src/ident/mod.rs
@@ -4,14 +4,12 @@
 //! snapshot/rollback safety. The sans-io engine lives in osc-ident; this
 //! wrapper owns USB, the TEL serial port, wall time, and files.
 
-mod csvio;
-mod params;
-mod pump;
-mod snapshot;
-mod tel;
+pub(crate) mod params;
 
 use std::path::PathBuf;
 
+use crate::rig::pump::{self, Pump, write_reg};
+use crate::rig::{csvio, snapshot};
 use anyhow::{Context, Result, bail};
 use clap::Subcommand;
 use osc_client::Id;
@@ -34,7 +32,6 @@ use params::{
     BiasJson, BreakawayJson, GainJson, InertiaJson, LadderJson, ParamsFile, PlantJson,
     ResistanceJson, SenseJson,
 };
-use pump::{Pump, write_reg};
 
 /// The `osc ident` arg group: TEL wiring, output, rig envelope, and
 /// bandwidth targets, all scoped to the ident subtree. `--baud`/`--id` come
@@ -152,7 +149,7 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     if let Cmd::Fit { dir } = &args.cmd {
         return fit_dir(&cli, dir.clone());
     }
-    let mut c = connect(&cli)?;
+    let mut c = crate::rig::connect(&cli.baud)?;
     let id = Id::new(id);
     match &args.cmd {
         Cmd::Run => run_all(&cli, &mut c, id),
@@ -241,26 +238,6 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
         Cmd::Show => snapshot::show(&mut c, id),
         Cmd::Fit { .. } => unreachable!("handled above"),
     }
-}
-
-fn connect(cli: &Ctx) -> Result<Client<NusbPipe>> {
-    let mut c = Client::connect(NusbPipe::open()?)?;
-    match cli.baud.as_str() {
-        "auto" => match c.find_bus_baud()? {
-            Some(rate) => println!("bus at {} baud", rate.as_hz()),
-            None => bail!("no servo bus found at any supported baud"),
-        },
-        s => {
-            use osc_client::BaudRate as B;
-            let bps: u32 = s.parse().context("baud is an integer rate or `auto`")?;
-            let rate = [B::B500000, B::B1000000, B::B2000000, B::B3000000]
-                .into_iter()
-                .find(|r| r.as_hz() == bps)
-                .ok_or_else(|| anyhow::anyhow!("unsupported baud {bps}"))?;
-            c.host_baud(rate)?;
-        }
-    }
-    Ok(c)
 }
 
 fn rig(cli: &Ctx) -> RigParams {

--- a/tools/osc/src/ident/mod.rs
+++ b/tools/osc/src/ident/mod.rs
@@ -521,6 +521,9 @@ fn run_verify(cli: &Ctx, c: &mut Client<NusbPipe>, id: Id) -> Result<()> {
     })?;
     check_abort("verify-current", e5.abort())?;
     let cur = e5.into_inner().result();
+    // E5 ends stalled against an end-stop; E6 runs with the pos guard on
+    // and its first read would abort right there
+    recenter(c, id)?;
     println!("[E6 velocity legs]");
     let mut e6 = Guarded::new(
         VerifyVelocity::new(VerifyVelocityCfg::default(), &params, tick_hz),

--- a/tools/osc/src/ident/mod.rs
+++ b/tools/osc/src/ident/mod.rs
@@ -338,6 +338,7 @@ fn run_bias(
             tel_port: None,
             tel_mask: 0,
             log: Some(&mut log),
+            tel_raw_path: None,
         }
         .run(&mut exp, |_| {})
     })?;
@@ -367,6 +368,7 @@ fn run_resistance(
             tel_port: None,
             tel_mask: 0,
             log: Some(&mut log),
+            tel_raw_path: None,
         }
         .run(&mut exp, |_| {})
     })?;
@@ -395,6 +397,7 @@ fn run_breakaway(
             tel_port: None,
             tel_mask: 0,
             log: Some(&mut log),
+            tel_raw_path: None,
         }
         .run(&mut exp, |_| {})
     })?;
@@ -421,6 +424,7 @@ fn run_ladder(
             tel_port: None,
             tel_mask: 0,
             log: Some(&mut log),
+            tel_raw_path: None,
         }
         .run(&mut exp, |_| {})
     })?;
@@ -464,6 +468,7 @@ fn run_inertia(
             tel_port: (!cli.tel_port.is_empty()).then(|| cli.tel_port.clone()),
             tel_mask: 0x1B,
             log: Some(&mut log),
+            tel_raw_path: None,
         };
         // split borrow: hand frames to the guarded experiment mid-run
         let exp_cell = std::cell::RefCell::new(&mut exp);
@@ -510,6 +515,7 @@ fn run_verify(cli: &Ctx, c: &mut Client<NusbPipe>, id: Id) -> Result<()> {
             tel_port: None,
             tel_mask: 0,
             log: None,
+            tel_raw_path: None,
         }
         .run(&mut e5, |_| {})
     })?;
@@ -527,6 +533,7 @@ fn run_verify(cli: &Ctx, c: &mut Client<NusbPipe>, id: Id) -> Result<()> {
             tel_port: None,
             tel_mask: 0,
             log: None,
+            tel_raw_path: None,
         }
         .run(&mut e6, |_| {})
     })?;

--- a/tools/osc/src/main.rs
+++ b/tools/osc/src/main.rs
@@ -5,6 +5,7 @@
 //! osc-client -- every choreography lives in the library. Wire measurement is
 //! the bench `tool-*` binaries' job, not this tool's.
 
+mod cal;
 mod descriptor;
 mod ident;
 mod rig;
@@ -114,7 +115,7 @@ enum Cmd {
     },
     /// Broadcast CAL break trains (protocol sec 9.3) with per-servo
     /// convergence readback.
-    Cal {
+    Syntonize {
         /// Trains to send (>= 2 per the sec 9.3 boot guidance).
         #[arg(long, default_value_t = 3)]
         trains: u8,
@@ -210,6 +211,9 @@ enum Cmd {
     /// Identify the motor and synthesize its gains: experiments, fits,
     /// write-back.
     Ident(ident::Args),
+    /// Calibrate: find the end-stops, confirm the angle range, write limits +
+    /// polarity + angle endpoints, then SAVE.
+    Cal(cal::Args),
 }
 
 #[derive(Subcommand, Debug)]
@@ -688,7 +692,7 @@ fn main() -> Result<()> {
             );
             Ok(())
         }
-        Cmd::Cal {
+        Cmd::Syntonize {
             trains,
             gap_us,
             gaps,
@@ -821,5 +825,6 @@ fn main() -> Result<()> {
         } => set(&mut connect_bus(&cli)?, id, field, value, *hold, *noreply),
         Cmd::Dump => dump(&mut connect_bus(&cli)?, id),
         Cmd::Ident(args) => ident::run(args, cli.baud.clone(), cli.id),
+        Cmd::Cal(args) => cal::run(args, cli.baud.clone(), cli.id),
     }
 }

--- a/tools/osc/src/main.rs
+++ b/tools/osc/src/main.rs
@@ -7,6 +7,7 @@
 
 mod descriptor;
 mod ident;
+mod rig;
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};

--- a/tools/osc/src/main.rs
+++ b/tools/osc/src/main.rs
@@ -214,6 +214,9 @@ enum Cmd {
     /// Calibrate: find the end-stops, confirm the angle range, write limits +
     /// polarity + angle endpoints, then SAVE.
     Cal(cal::Args),
+    /// Replay a saved cal tel-raw.bin offline: classify stream corruption and
+    /// re-run the pot-LUT / motor-rev pipeline without a servo.
+    CalReplay(cal::replay::Args),
 }
 
 #[derive(Subcommand, Debug)]
@@ -826,5 +829,6 @@ fn main() -> Result<()> {
         Cmd::Dump => dump(&mut connect_bus(&cli)?, id),
         Cmd::Ident(args) => ident::run(args, cli.baud.clone(), cli.id),
         Cmd::Cal(args) => cal::run(args, cli.baud.clone(), cli.id),
+        Cmd::CalReplay(a) => cal::replay::run(a),
     }
 }

--- a/tools/osc/src/rig/csvio.rs
+++ b/tools/osc/src/rig/csvio.rs
@@ -15,10 +15,10 @@ use osc_ident::exp::resistance::DwellSample;
 use osc_ident::fits::{RungPoint, StepSeries};
 use osc_ident::frame::{TelFrame, TelemetrySnapshot};
 
-pub struct OutDir(pub PathBuf);
+pub(crate) struct OutDir(pub(crate) PathBuf);
 
 impl OutDir {
-    pub fn create(base: &Path) -> Result<Self> {
+    pub(crate) fn create(base: &Path) -> Result<Self> {
         let stamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -28,7 +28,7 @@ impl OutDir {
         Ok(Self(dir))
     }
 
-    pub fn file(&self, name: &str) -> Result<BufWriter<File>> {
+    pub(crate) fn file(&self, name: &str) -> Result<BufWriter<File>> {
         let p = self.0.join(name);
         Ok(BufWriter::new(
             File::create(&p).with_context(|| format!("create {}", p.display()))?,
@@ -37,12 +37,12 @@ impl OutDir {
 }
 
 /// Raw snapshot log: one row per Read, full field dump.
-pub struct SnapshotLog {
+pub(crate) struct SnapshotLog {
     w: BufWriter<File>,
 }
 
 impl SnapshotLog {
-    pub fn create(dir: &OutDir, name: &str) -> Result<Self> {
+    pub(crate) fn create(dir: &OutDir, name: &str) -> Result<Self> {
         let mut w = dir.file(name)?;
         writeln!(
             w,
@@ -55,7 +55,7 @@ impl SnapshotLog {
         Ok(Self { w })
     }
 
-    pub fn push(&mut self, host_ms: f64, s: &TelemetrySnapshot) -> Result<()> {
+    pub(crate) fn push(&mut self, host_ms: f64, s: &TelemetrySnapshot) -> Result<()> {
         writeln!(
             self.w,
             "{host_ms:.1},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
@@ -88,7 +88,7 @@ impl SnapshotLog {
     }
 }
 
-pub fn write_tel_frames(dir: &OutDir, name: &str, frames: &[TelFrame]) -> Result<()> {
+pub(crate) fn write_tel_frames(dir: &OutDir, name: &str, frames: &[TelFrame]) -> Result<()> {
     let mut w = dir.file(name)?;
     writeln!(w, "seq,window_valid,pos,current,duty_q15,vdiff")?;
     let opt = |v: Option<i32>| v.map(|v| v.to_string()).unwrap_or_default();
@@ -109,7 +109,7 @@ pub fn write_tel_frames(dir: &OutDir, name: &str, frames: &[TelFrame]) -> Result
 
 // --- derived fit inputs -----------------------------------------------------
 
-pub fn write_dwell_samples(dir: &OutDir, samples: &[DwellSample]) -> Result<()> {
+pub(crate) fn write_dwell_samples(dir: &OutDir, samples: &[DwellSample]) -> Result<()> {
     let mut w = dir.file("resistance.csv")?;
     writeln!(w, "dwell,dir,t_ms,i,vdiff,duty_q15")?;
     for s in samples {
@@ -122,7 +122,7 @@ pub fn write_dwell_samples(dir: &OutDir, samples: &[DwellSample]) -> Result<()> 
     Ok(())
 }
 
-pub fn read_dwell_samples(dir: &Path) -> Result<Vec<DwellSample>> {
+pub(crate) fn read_dwell_samples(dir: &Path) -> Result<Vec<DwellSample>> {
     let mut out = Vec::new();
     for parts in rows(&dir.join("resistance.csv"), 6)? {
         out.push(DwellSample {
@@ -139,7 +139,7 @@ pub fn read_dwell_samples(dir: &Path) -> Result<Vec<DwellSample>> {
     Ok(out)
 }
 
-pub fn write_rungs(dir: &OutDir, rungs: &[RungSummary]) -> Result<()> {
+pub(crate) fn write_rungs(dir: &OutDir, rungs: &[RungSummary]) -> Result<()> {
     let mut w = dir.file("rungs.csv")?;
     writeln!(w, "duty_q15,omega,omega_r2,i,v,windows,used,note")?;
     for r in rungs {
@@ -160,7 +160,7 @@ pub fn write_rungs(dir: &OutDir, rungs: &[RungSummary]) -> Result<()> {
 }
 
 /// Used rungs back as fit points (the unused ones only matter to humans).
-pub fn read_rung_points(dir: &Path) -> Result<Vec<RungPoint>> {
+pub(crate) fn read_rung_points(dir: &Path) -> Result<Vec<RungPoint>> {
     Ok(read_rungs(dir)?
         .iter()
         .filter(|r| r.used)
@@ -172,7 +172,7 @@ pub fn read_rung_points(dir: &Path) -> Result<Vec<RungPoint>> {
         .collect())
 }
 
-pub fn read_rungs(dir: &Path) -> Result<Vec<RungSummary>> {
+pub(crate) fn read_rungs(dir: &Path) -> Result<Vec<RungSummary>> {
     let mut out = Vec::new();
     for parts in rows(&dir.join("rungs.csv"), 8)? {
         out.push(RungSummary {
@@ -195,7 +195,7 @@ pub fn read_rungs(dir: &Path) -> Result<Vec<RungSummary>> {
 
 /// Long form, one row per sample; `src` tags tel/agg per step so the
 /// offline fit picks the same smoothing window the live one did.
-pub fn write_step_series(dir: &OutDir, series: &[(StepSeries, bool)]) -> Result<()> {
+pub(crate) fn write_step_series(dir: &OutDir, series: &[(StepSeries, bool)]) -> Result<()> {
     let mut w = dir.file("inertia_steps.csv")?;
     writeln!(w, "step,src,duty_q15,t,pos,i,mask")?;
     for (k, (s, tel)) in series.iter().enumerate() {
@@ -211,7 +211,7 @@ pub fn write_step_series(dir: &OutDir, series: &[(StepSeries, bool)]) -> Result<
     Ok(())
 }
 
-pub fn read_step_series(dir: &Path) -> Result<Vec<(StepSeries, bool)>> {
+pub(crate) fn read_step_series(dir: &Path) -> Result<Vec<(StepSeries, bool)>> {
     let mut out: Vec<(StepSeries, bool)> = Vec::new();
     let mut cur: Option<usize> = None;
     for parts in rows(&dir.join("inertia_steps.csv"), 7)? {

--- a/tools/osc/src/rig/mod.rs
+++ b/tools/osc/src/rig/mod.rs
@@ -1,0 +1,32 @@
+//! Shared rig plumbing for the experiment subcommands: the bus connection,
+//! the four-arm driver pump, table snapshot/rollback, CSV record/replay, and
+//! the TEL side-channel. `ident` drives these; `cal` reaches the same set.
+
+pub(crate) mod csvio;
+pub(crate) mod pump;
+pub(crate) mod snapshot;
+pub(crate) mod tel;
+
+use anyhow::{Context, Result, bail};
+use osc_client::blocking::Client;
+use osc_client::nusb::NusbPipe;
+
+pub(crate) fn connect(baud: &str) -> Result<Client<NusbPipe>> {
+    let mut c = Client::connect(NusbPipe::open()?)?;
+    match baud {
+        "auto" => match c.find_bus_baud()? {
+            Some(rate) => println!("bus at {} baud", rate.as_hz()),
+            None => bail!("no servo bus found at any supported baud"),
+        },
+        s => {
+            use osc_client::BaudRate as B;
+            let bps: u32 = s.parse().context("baud is an integer rate or `auto`")?;
+            let rate = [B::B500000, B::B1000000, B::B2000000, B::B3000000]
+                .into_iter()
+                .find(|r| r.as_hz() == bps)
+                .ok_or_else(|| anyhow::anyhow!("unsupported baud {bps}"))?;
+            c.host_baud(rate)?;
+        }
+    }
+    Ok(c)
+}

--- a/tools/osc/src/rig/pump.rs
+++ b/tools/osc/src/rig/pump.rs
@@ -65,6 +65,9 @@ pub(crate) struct Pump<'a> {
     pub(crate) tel_port: Option<String>,
     pub(crate) tel_mask: u16,
     pub(crate) log: Option<&'a mut SnapshotLog>,
+    /// Lossless raw-byte capture of the TEL stream, in addition to the live
+    /// deframing; None skips the file (e.g. endstop has no ripple sweep).
+    pub(crate) tel_raw_path: Option<std::path::PathBuf>,
 }
 
 impl Pump<'_> {
@@ -97,6 +100,7 @@ impl Pump<'_> {
                             sink = Some(TelSink::open(
                                 self.tel_port.as_deref().expect("checked"),
                                 self.tel_mask,
+                                self.tel_raw_path.as_deref(),
                             )?);
                         } else if value == 0
                             && let Some(mut s) = sink.take()

--- a/tools/osc/src/rig/pump.rs
+++ b/tools/osc/src/rig/pump.rs
@@ -16,15 +16,15 @@ use osc_ident::regs::{Reg, control, telemetry};
 use super::csvio::SnapshotLog;
 use super::tel::TelSink;
 
-pub static STOP: AtomicBool = AtomicBool::new(false);
+pub(crate) static STOP: AtomicBool = AtomicBool::new(false);
 
-pub fn install_ctrlc() {
+pub(crate) fn install_ctrlc() {
     let _ = ctrlc::set_handler(|| STOP.store(true, Ordering::SeqCst));
 }
 
 /// Write one register, value LE-truncated to the field width (negative
 /// i32 -> correct two's complement for 2/4-byte fields).
-pub fn write_reg(c: &mut Client<NusbPipe>, id: Id, reg: Reg, value: i32) -> Result<()> {
+pub(crate) fn write_reg(c: &mut Client<NusbPipe>, id: Id, reg: Reg, value: i32) -> Result<()> {
     let bytes = value.to_le_bytes();
     c.write(id, reg.addr, &bytes[..reg.width as usize])
         .with_context(|| format!("write addr {:#06x}", reg.addr))?;
@@ -41,7 +41,7 @@ const IDENT_LEN: u16 = telemetry::AGG_SEQ.addr + 2 - IDENT_BASE;
 /// agg_seq agrees is returned (the block is written mid-tick; agg_seq lands
 /// last). Bounded retries - a stubbornly torn read returns the last full
 /// snapshot, which the engine's WindowStream then dedups by seq anyway.
-pub fn read_snapshot(c: &mut Client<NusbPipe>, id: Id) -> Result<TelemetrySnapshot> {
+pub(crate) fn read_snapshot(c: &mut Client<NusbPipe>, id: Id) -> Result<TelemetrySnapshot> {
     let mut last = None;
     for _ in 0..3 {
         let raw = c.read(id, TEL_BASE, TEL_LEN).context("telemetry read")?;
@@ -57,20 +57,20 @@ pub fn read_snapshot(c: &mut Client<NusbPipe>, id: Id) -> Result<TelemetrySnapsh
     Ok(last.expect("loop ran"))
 }
 
-pub struct Pump<'a> {
-    pub client: &'a mut Client<NusbPipe>,
-    pub id: Id,
+pub(crate) struct Pump<'a> {
+    pub(crate) client: &'a mut Client<NusbPipe>,
+    pub(crate) id: Id,
     /// TEL device path; the sink opens on the experiment's tel_enable=1
     /// write and closes (frames flushed) on tel_enable=0.
-    pub tel_port: Option<String>,
-    pub tel_mask: u16,
-    pub log: Option<&'a mut SnapshotLog>,
+    pub(crate) tel_port: Option<String>,
+    pub(crate) tel_mask: u16,
+    pub(crate) log: Option<&'a mut SnapshotLog>,
 }
 
 impl Pump<'_> {
     /// Run one experiment to completion. `on_tel` receives decoded TEL
     /// frames as they drain (inertia's push_tel; pass |_| {} otherwise).
-    pub fn run(
+    pub(crate) fn run(
         &mut self,
         exp: &mut dyn Experiment,
         mut on_tel: impl FnMut(&[TelFrame]),

--- a/tools/osc/src/rig/snapshot.rs
+++ b/tools/osc/src/rig/snapshot.rs
@@ -38,6 +38,7 @@ pub(crate) const SNAPSHOT_FIELDS: &[(&str, Reg)] = &[
     ("v_kaw_q412", config::V_KAW_Q412),
     ("j_ff_q88", config::J_FF_Q88),
     ("p_kp_q88", config::P_KP_Q88),
+    ("pos_deadband_counts", config::POS_DEADBAND_COUNTS),
     ("l1_q016", config::L1_Q016),
     ("l2_q88", config::L2_Q88),
     ("l3_q88", config::L3_Q88),

--- a/tools/osc/src/rig/snapshot.rs
+++ b/tools/osc/src/rig/snapshot.rs
@@ -26,7 +26,7 @@ pub(crate) const SNAPSHOT_FIELDS: &[(&str, Reg)] = &[
     ("t0_cc", calib::T0_CC),
     ("ke_vpc_q", calib::KE_VPC_Q),
     ("recip_ke_q", calib::RECIP_KE_Q),
-    ("b_i_q016", calib::B_I_Q016),
+    ("b_i_q313", calib::B_I_Q313),
     ("fric_fc_counts", calib::FRIC_FC_COUNTS),
     ("fric_fv_q016", calib::FRIC_FV_Q016),
     ("fric_breakaway_counts", calib::FRIC_BREAKAWAY_COUNTS),

--- a/tools/osc/src/rig/snapshot.rs
+++ b/tools/osc/src/rig/snapshot.rs
@@ -11,16 +11,16 @@ use osc_client::blocking::Client;
 use osc_client::nusb::NusbPipe;
 use osc_ident::regs::{ALL, Reg, calib, config};
 
-use super::params::GainJson;
 use super::pump::write_reg;
+use crate::ident::params::GainJson;
 
 /// name -> Reg for every writable field the gain set names.
-pub fn reg_by_name(name: &str) -> Option<Reg> {
+pub(crate) fn reg_by_name(name: &str) -> Option<Reg> {
     ALL.iter().find(|(n, _)| *n == name).map(|(_, r)| *r)
 }
 
 /// The write-set superset: everything snapshot/rollback/show handles.
-pub const SNAPSHOT_FIELDS: &[(&str, Reg)] = &[
+pub(crate) const SNAPSHOT_FIELDS: &[(&str, Reg)] = &[
     ("r_q12", calib::R_Q12),
     ("r0_q12", calib::R0_Q12),
     ("t0_cc", calib::T0_CC),
@@ -44,12 +44,12 @@ pub const SNAPSHOT_FIELDS: &[(&str, Reg)] = &[
     ("l_bemf_q016", config::L_BEMF_Q016),
 ];
 
-pub fn read_u16(c: &mut Client<NusbPipe>, id: Id, reg: Reg) -> Result<u16> {
+pub(crate) fn read_u16(c: &mut Client<NusbPipe>, id: Id, reg: Reg) -> Result<u16> {
     let raw = c.read(id, reg.addr, 2).context("field read")?;
     Ok(u16::from_le_bytes([raw[0], raw[1]]))
 }
 
-pub fn take_snapshot(c: &mut Client<NusbPipe>, id: Id, path: &Path) -> Result<()> {
+pub(crate) fn take_snapshot(c: &mut Client<NusbPipe>, id: Id, path: &Path) -> Result<()> {
     let mut map = BTreeMap::new();
     for (name, reg) in SNAPSHOT_FIELDS {
         map.insert(name.to_string(), read_u16(c, id, *reg)?);
@@ -60,7 +60,7 @@ pub fn take_snapshot(c: &mut Client<NusbPipe>, id: Id, path: &Path) -> Result<()
     Ok(())
 }
 
-pub fn rollback(c: &mut Client<NusbPipe>, id: Id, path: &Path) -> Result<()> {
+pub(crate) fn rollback(c: &mut Client<NusbPipe>, id: Id, path: &Path) -> Result<()> {
     let map: BTreeMap<String, u16> = serde_json::from_str(
         &std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?,
     )?;
@@ -78,7 +78,7 @@ pub fn rollback(c: &mut Client<NusbPipe>, id: Id, path: &Path) -> Result<()> {
 }
 
 /// Write the encoded set, read-back verifying each field.
-pub fn write_gains(c: &mut Client<NusbPipe>, id: Id, gains: &[GainJson]) -> Result<()> {
+pub(crate) fn write_gains(c: &mut Client<NusbPipe>, id: Id, gains: &[GainJson]) -> Result<()> {
     for g in gains {
         let reg =
             reg_by_name(&g.name).ok_or_else(|| anyhow::anyhow!("{}: not a known field", g.name))?;
@@ -95,7 +95,7 @@ pub fn write_gains(c: &mut Client<NusbPipe>, id: Id, gains: &[GainJson]) -> Resu
     Ok(())
 }
 
-pub fn show(c: &mut Client<NusbPipe>, id: Id) -> Result<()> {
+pub(crate) fn show(c: &mut Client<NusbPipe>, id: Id) -> Result<()> {
     for (name, reg) in SNAPSHOT_FIELDS {
         println!("{name:24} {}", read_u16(c, id, *reg)?);
     }

--- a/tools/osc/src/rig/tel.rs
+++ b/tools/osc/src/rig/tel.rs
@@ -9,7 +9,7 @@
 //! CLOCAL|CREAD set and the speed configured - a bare O_NONBLOCK open
 //! reads almost nothing (that combination is what pyserial sets up).
 
-use std::io::Read;
+use std::io::{BufWriter, Read, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -35,7 +35,7 @@ pub(crate) struct TelSink {
 }
 
 impl TelSink {
-    pub(crate) fn open(path: &str, mask: u16) -> Result<Self> {
+    pub(crate) fn open(path: &str, mask: u16, raw_path: Option<&std::path::Path>) -> Result<Self> {
         let mut port = std::fs::OpenOptions::new()
             .read(true)
             .custom_flags(libc::O_NONBLOCK | libc::O_NOCTTY)
@@ -73,6 +73,10 @@ impl TelSink {
             libc::fcntl(fd, libc::F_SETFL, 0);
         }
 
+        // Best-effort: raw capture is a post-mortem artifact, so a file that
+        // fails to create just means no raw copy, never an aborted capture.
+        let raw_writer = raw_path.and_then(|p| std::fs::File::create(p).ok().map(BufWriter::new));
+
         let rx = Arc::new(Mutex::new(Vec::new()));
         let stop = Arc::new(AtomicBool::new(false));
         let bytes = Arc::new(AtomicU64::new(0));
@@ -82,15 +86,22 @@ impl TelSink {
             let bytes = bytes.clone();
             std::thread::spawn(move || {
                 let mut buf = [0u8; 65536];
+                let mut w = raw_writer;
                 while !stop.load(Ordering::Relaxed) {
                     match port.read(&mut buf) {
                         Ok(0) => {}
                         Ok(n) => {
                             bytes.fetch_add(n as u64, Ordering::Relaxed);
                             rx.lock().expect("tel buf").extend_from_slice(&buf[..n]);
+                            if let Some(w) = w.as_mut() {
+                                let _ = w.write_all(&buf[..n]);
+                            }
                         }
                         Err(_) => break,
                     }
+                }
+                if let Some(w) = w.as_mut() {
+                    let _ = w.flush();
                 }
             })
         };

--- a/tools/osc/src/rig/tel.rs
+++ b/tools/osc/src/rig/tel.rs
@@ -25,7 +25,7 @@ const IOSSIOSPEED: libc::c_ulong = 0x8004_5402;
 /// sample at exactly this.
 const TEL_BAUD: libc::c_int = 3_000_000;
 
-pub struct TelSink {
+pub(crate) struct TelSink {
     rx: Arc<Mutex<Vec<u8>>>,
     stop: Arc<AtomicBool>,
     bytes: Arc<AtomicU64>,
@@ -35,7 +35,7 @@ pub struct TelSink {
 }
 
 impl TelSink {
-    pub fn open(path: &str, mask: u16) -> Result<Self> {
+    pub(crate) fn open(path: &str, mask: u16) -> Result<Self> {
         let mut port = std::fs::OpenOptions::new()
             .read(true)
             .custom_flags(libc::O_NONBLOCK | libc::O_NOCTTY)
@@ -106,22 +106,22 @@ impl TelSink {
     }
 
     /// Feed everything the reader thread has buffered through the deframer.
-    pub fn drain(&mut self) {
+    pub(crate) fn drain(&mut self) {
         let bytes = std::mem::take(&mut *self.rx.lock().expect("tel buf"));
         if !bytes.is_empty() {
             self.deframer.push(&bytes, &mut self.frames);
         }
     }
 
-    pub fn take_frames(&mut self) -> Vec<TelFrame> {
+    pub(crate) fn take_frames(&mut self) -> Vec<TelFrame> {
         std::mem::take(&mut self.frames)
     }
 
-    pub fn stats(&self) -> TelStats {
+    pub(crate) fn stats(&self) -> TelStats {
         self.deframer.stats()
     }
 
-    pub fn bytes_read(&self) -> u64 {
+    pub(crate) fn bytes_read(&self) -> u64 {
         self.bytes.load(Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
Makes the servo self-describing: it measures its own end-stops, angle range, and gear ratio and stores them on the device, so any host can read raw counts back as real-world units.