### PR TITLE
capture: scan reorder, validity floor reseed, zero-duty brake, sweep segments

### DIFF
--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -270,99 +270,106 @@
       ]
     },
     {
-      "name": "derate_start_cc",
+      "name": "openloop_zero_brake",
       "addr": 90,
-      "width": 2,
+      "width": 1,
       "access": "rw",
-      "kind": "int"
+      "kind": "bool"
     },
     {
-      "name": "cutoff_cc",
+      "name": "derate_start_cc",
       "addr": 92,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "recover_cc",
+      "name": "cutoff_cc",
       "addr": 94,
       "width": 2,
       "access": "rw",
       "kind": "int"
     },
     {
-      "name": "v_undervolt_counts",
+      "name": "recover_cc",
       "addr": 96,
       "width": 2,
       "access": "rw",
-      "kind": "uint"
+      "kind": "int"
     },
     {
-      "name": "rtherm_i_min_counts",
+      "name": "v_undervolt_counts",
       "addr": 98,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "rtherm_omega_max_cps",
+      "name": "rtherm_i_min_counts",
       "addr": 100,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l1_q016",
+      "name": "rtherm_omega_max_cps",
       "addr": 102,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l2_q88",
+      "name": "l1_q016",
       "addr": 104,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l3_q88",
+      "name": "l2_q88",
       "addr": 106,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "l_bemf_q016",
+      "name": "l3_q88",
       "addr": 108,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "pos_error_counts",
+      "name": "l_bemf_q016",
       "addr": 110,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "pos_error_time_ms",
+      "name": "pos_error_counts",
       "addr": 112,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "sensor_delta_max",
+      "name": "pos_error_time_ms",
       "addr": 114,
       "width": 2,
       "access": "rw",
       "kind": "uint"
     },
     {
-      "name": "sensor_bad_count",
+      "name": "sensor_delta_max",
       "addr": 116,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "sensor_bad_count",
+      "addr": 118,
       "width": 1,
       "access": "rw",
       "kind": "uint"

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -50,13 +50,15 @@ fn main() -> ! {
                 bot_ohm: 10_000,
             },
             vdd_mv: 3300,
-            i_window_min_ticks: 240,
-            // one floor for BOTH terminals: the scan converts vmotor_b one
-            // slot after vmotor_a, so B's edge sits ~50 ticks later (bench:
-            // B garbage at 238, clean at 274; A clean at 222). A floor
-            // below B's edge let a position-mode launch seed the vbus EWMA
-            // from off-phase samples and latch a false undervolt.
-            v_window_min_ticks: 300,
+            // Scan order is [shunt, vmA, vmB, pos, vcal]. The i floor is
+            // amp-settling-bound: arm-B network measured true from duty 13%
+            // (bringup docs/armb-comp-sizing.md). The v floor covers
+            // vmotor_b's S/H close ~182 ticks after the crest trigger plus
+            // margin; a v floor below the true edge lets off-phase samples
+            // seed the vbus EWMA and latch a false undervolt. Both floors
+            // pending bench re-validation on the new order.
+            i_window_min_ticks: 160,
+            v_window_min_ticks: 210,
         },
         defaults: ConfigDefaults {
             pos_min_phys_counts: 0,

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -585,15 +585,22 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                     if (self.i_band.hi == 0 && duty > 0) || (self.i_band.lo == 0 && duty < 0) {
                         duty = 0;
                     }
-                    let decay = match lim_cfg.openloop_decay {
-                        DecaySelect::Slow => DecayMode::Slow,
-                        DecaySelect::Fast => DecayMode::Fast,
-                    };
                     self.duty_q15 = duty;
-                    self.decay = decay;
-                    MotorCmd::Drive {
-                        duty: Effort(duty),
-                        decay,
+                    if duty == 0 && lim_cfg.openloop_zero_brake {
+                        // chip-side Drive{0, Slow} maps to coast; a winding
+                        // short must be commanded explicitly
+                        self.decay = DecayMode::Slow;
+                        MotorCmd::Brake
+                    } else {
+                        let decay = match lim_cfg.openloop_decay {
+                            DecaySelect::Slow => DecayMode::Slow,
+                            DecaySelect::Fast => DecayMode::Fast,
+                        };
+                        self.decay = decay;
+                        MotorCmd::Drive {
+                            duty: Effort(duty),
+                            decay,
+                        }
                     }
                 }
                 mode => {

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -91,6 +91,7 @@ fn seed(shared: &Shared) {
         c.limits.oc_trip_counts = 2400;
         c.limits.oc_trip_ticks = 4;
         c.limits.openloop_decay = DecaySelect::Slow;
+        c.limits.openloop_zero_brake = false;
         c.thermal.derate_start_cc = 8000;
         c.thermal.cutoff_cc = 10000;
         c.thermal.recover_cc = 9000;
@@ -424,6 +425,60 @@ fn openloop_duty_passthrough_clamped_with_decay() {
     k.on_tick(frame(2000, BIAS), &sh);
     match last_cmd(&k) {
         MotorCmd::Drive { duty, .. } => assert_eq!(duty.0, 5000),
+        other => panic!("expected Drive, got {other:?}"),
+    }
+}
+
+#[test]
+fn openloop_zero_duty_drives_zero_when_brake_flag_clear() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 0;
+    });
+    let mut k = kernel();
+    k.on_tick(frame(2000, BIAS), &sh);
+    match last_cmd(&k) {
+        MotorCmd::Drive { duty, decay } => {
+            assert_eq!(duty.0, 0);
+            assert!(matches!(decay, DecayMode::Slow));
+        }
+        other => panic!("expected Drive, got {other:?}"),
+    }
+}
+
+#[test]
+fn openloop_zero_duty_brakes_when_flag_set() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 0;
+        t.config.limits.openloop_zero_brake = true;
+    });
+    let mut k = kernel();
+    k.on_tick(frame(2000, BIAS), &sh);
+    assert!(matches!(last_cmd(&k), MotorCmd::Brake));
+    assert_eq!(k.duty_q15, 0);
+}
+
+#[test]
+fn openloop_nonzero_duty_drives_despite_brake_flag() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 8000;
+        t.config.limits.openloop_zero_brake = true;
+    });
+    let mut k = kernel();
+    k.on_tick(frame(2000, BIAS), &sh);
+    match last_cmd(&k) {
+        MotorCmd::Drive { duty, .. } => assert_eq!(duty.0, 8000),
         other => panic!("expected Drive, got {other:?}"),
     }
 }

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -41,7 +41,7 @@ pub const CALIB_IMAGE_LEN: usize = HEADER_LEN + CALIB_LEN;
 pub const IMAGE_MAGIC: u8 = b'C';
 /// Bump on any CONFIG/PROFILE layout change; a mismatched image is ignored
 /// (boot keeps board defaults) rather than migrated.
-pub const IMAGE_VERSION: u8 = 3;
+pub const IMAGE_VERSION: u8 = 4;
 
 pub const CALIB_IMAGE_MAGIC: u8 = b'K';
 /// Bump on any CALIB layout change; independent of [`IMAGE_VERSION`].

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -144,6 +144,10 @@ pub struct ConfigLimits {
     pub oc_trip_counts: u16,
     pub oc_trip_ticks: u8,
     pub openloop_decay: DecaySelect,
+    /// true = Brake at zero commanded duty in OpenLoop (default coast).
+    pub openloop_zero_brake: bool,
+    #[ct_field(skip)]
+    pub _rsvd_align: u8,
 }
 
 // Permissive-safe SG90-class limits: core-owned policy seeded at boot,
@@ -234,7 +238,7 @@ pub struct ConfigRegs {
     pub fusion: ConfigFusion,
     pub fault_cfg: ConfigFaultCfg,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 10],
+    pub _rsvd_tail: [u8; 8],
 }
 
 /// Boot-time seed for `ControlTable.config`; stamped pre-IRQ, then host-owned.

--- a/firmware/servo-ch32/src/cfg/chip.rs
+++ b/firmware/servo-ch32/src/cfg/chip.rs
@@ -60,6 +60,10 @@ const fn tim1_channel_pin(m: Tim1Mapping, c: timer::Channel) -> Pin {
 
 pub const ADC_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
 
+/// OPA output is low-Z, so the short aperture is safe; the divider/pot
+/// channels need `ADC_SAMPLE_TIME`.
+pub const ADC_SHUNT_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES3;
+
 /// ADC channels available as board-configurable sensor inputs on the V006F8P6.
 /// Excludes A0 (PA2): the pin is reserved for OPA input routing, which is
 /// board wiring, not a sensor slot.

--- a/firmware/servo-ch32/src/control/sensors/scan.rs
+++ b/firmware/servo-ch32/src/control/sensors/scan.rs
@@ -9,9 +9,10 @@ use core::cell::SyncUnsafeCell;
 pub(crate) const ADC_SENSOR_COUNT: usize = 3;
 
 /// Slot 0 is the current-sense amplifier output, read on whichever external
-/// channel the board routes the OPA output to; the rest follow `AdcPins`.
+/// channel the board routes the OPA output to; then both motor terminals
+/// (drive-window-critical, so they convert early), then pos, then Vcal.
 /// On osc-dev-v006 that is
-/// `[IN7/PD4 current, IN3/PD2 pos, IN5/PD5 vmA, IN6/PD6 vmB, IN10/Vcal]`.
+/// `[IN7/PD4 current, IN5/PD5 vmA, IN6/PD6 vmB, IN3/PD2 pos, IN10/Vcal]`.
 pub(crate) const ADC_SCAN_LEN: usize = 5;
 
 /// Two scans per PWM period (peak + trough under center-aligned PWM, RCR=0).
@@ -24,9 +25,9 @@ pub(super) const SCAN_PEAK_OFFSET: usize = ADC_SCAN_LEN;
 pub(super) const SCAN_TROUGH_OFFSET: usize = 0;
 
 pub(super) const SCAN_IDX_SHUNT_POST: usize = 0;
-pub(super) const SCAN_IDX_POS: usize = 1;
-pub(super) const SCAN_IDX_VMOTOR_A: usize = 2;
-pub(super) const SCAN_IDX_VMOTOR_B: usize = 3;
+pub(super) const SCAN_IDX_VMOTOR_A: usize = 1;
+pub(super) const SCAN_IDX_VMOTOR_B: usize = 2;
+pub(super) const SCAN_IDX_POS: usize = 3;
 pub(super) const SCAN_IDX_VCAL: usize = 4;
 
 /// Read trough slots before peak; DMA overwrites trough first after TC.

--- a/firmware/servo-ch32/src/runtime/init.rs
+++ b/firmware/servo-ch32/src/runtime/init.rs
@@ -118,7 +118,7 @@ fn calib_sense(wiring: &BoardWiring, cal: &Calibration) -> CalibSense {
 
 // Order must mirror the scan tail in `configure_adc_dma_scan`.
 fn sensor_channels(s: &AdcPins) -> [AnalogChannel; ADC_SENSOR_COUNT] {
-    [s.pos, s.vmotor.0, s.vmotor.1]
+    [s.vmotor.0, s.vmotor.1, s.pos]
 }
 
 fn enable_clocks_and_remaps(w: &BoardWiring) {
@@ -216,7 +216,7 @@ fn bring_up_analog_chain(cs: &CurrentSenseConfig) {
 /// every other register it touches is rewritten there.
 fn measure_current_bias(cs: &CurrentSenseConfig) -> u16 {
     let ch = cs.current_channel().channel();
-    adc::set_sample_time(ch, chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(ch, chip::ADC_SHUNT_SAMPLE_TIME);
     adc::set_low_power(false);
     adc::set_scan_mode(false);
     adc::set_dma(false);
@@ -250,7 +250,7 @@ fn configure_adc_dma_scan(w: &BoardWiring) {
     let sensors = &w.sensors;
     let current = w.current_sense.current_channel().channel();
 
-    adc::set_sample_time(current, chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(current, chip::ADC_SHUNT_SAMPLE_TIME);
     adc::set_sample_time(sensors.pos.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.vmotor.0.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.vmotor.1.channel(), chip::ADC_SAMPLE_TIME);
@@ -259,9 +259,9 @@ fn configure_adc_dma_scan(w: &BoardWiring) {
 
     let seq = [
         current,
-        sensors.pos.channel(),
         sensors.vmotor.0.channel(),
         sensors.vmotor.1.channel(),
+        sensors.pos.channel(),
         adc::Channel::Vcal,
     ];
     adc::set_sequence(&seq);

--- a/ident/src/regs.rs
+++ b/ident/src/regs.rs
@@ -32,11 +32,11 @@ pub mod config {
     pub const CURRENT_LIMIT_COUNTS: Reg = reg(0x0048, 2);
     pub const DRIVE_POLARITY: Reg = reg(0x004b, 1);
     pub const STALL_TAU_TRIP_COUNTS: Reg = reg(0x0054, 2);
-    pub const V_UNDERVOLT_COUNTS: Reg = reg(0x0060, 2);
-    pub const L1_Q016: Reg = reg(0x0066, 2);
-    pub const L2_Q88: Reg = reg(0x0068, 2);
-    pub const L3_Q88: Reg = reg(0x006a, 2);
-    pub const L_BEMF_Q016: Reg = reg(0x006c, 2);
+    pub const V_UNDERVOLT_COUNTS: Reg = reg(0x0062, 2);
+    pub const L1_Q016: Reg = reg(0x0068, 2);
+    pub const L2_Q88: Reg = reg(0x006a, 2);
+    pub const L3_Q88: Reg = reg(0x006c, 2);
+    pub const L_BEMF_Q016: Reg = reg(0x006e, 2);
 }
 
 pub mod calib {

--- a/tools/osc/src/sweep.rs
+++ b/tools/osc/src/sweep.rs
@@ -6,6 +6,11 @@
 //! land in sweep.csv, the run's constants in meta.json, both directly in
 //! --out (no timestamp subdir).
 //!
+//! `coast:MS` / `brake:MS` schedule entries capture a zero-duty segment:
+//! the preceding drive step feeds it without a settle (momentum carries
+//! across the burst gap), and a brake segment runs with openloop_zero_brake
+//! set (cleared again right after, so coast segments always see it clear).
+//!
 //! Duty sign is taken as-is (fwd = +duty): the seek's bang-bang polling
 //! assumes normal drive polarity and bails the run if a reversed servo
 //! walks away from the band.
@@ -20,8 +25,9 @@ use osc_client::Id;
 use osc_client::blocking::Client;
 use osc_client::nusb::NusbPipe;
 use osc_ident::frame::TelFrame;
-use osc_ident::regs::{calib, control};
+use osc_ident::regs::{Reg, calib, control};
 
+use crate::descriptor;
 use crate::rig::pump::{self, STOP, exchange_tel_burst, read_snapshot, with_guard, write_reg};
 use crate::rig::snapshot::read_u16;
 
@@ -32,17 +38,68 @@ enum Dirs {
     Rev,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum Decay {
+    Slow,
+    Fast,
+}
+
+impl Decay {
+    fn as_str(self) -> &'static str {
+        match self {
+            Decay::Slow => "slow",
+            Decay::Fast => "fast",
+        }
+    }
+}
+
+/// One schedule entry: a drive rung, or a zero-duty coast/brake segment.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Step {
+    Drive(u8),
+    Coast(u32),
+    Brake(u32),
+}
+
+impl std::fmt::Display for Step {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Step::Drive(pct) => write!(f, "{pct}"),
+            Step::Coast(ms) => write!(f, "coast:{ms}"),
+            Step::Brake(ms) => write!(f, "brake:{ms}"),
+        }
+    }
+}
+
+fn parse_step(s: &str) -> Result<Step, String> {
+    let ms = |v: &str| v.parse().map_err(|_| format!("bad ms {v:?}"));
+    if let Some(v) = s.strip_prefix("coast:") {
+        return Ok(Step::Coast(ms(v)?));
+    }
+    if let Some(v) = s.strip_prefix("brake:") {
+        return Ok(Step::Brake(ms(v)?));
+    }
+    s.parse()
+        .map(Step::Drive)
+        .map_err(|_| format!("step is duty pct, coast:MS, or brake:MS, got {s:?}"))
+}
+
 /// `osc sweep` args. `--baud`/`--id` come from the top-level osc globals.
 #[derive(clap::Args, Debug)]
 pub struct Args {
     /// Output dir; sweep.csv + meta.json land here directly.
     #[arg(long, default_value = "./sweep-out")]
     out: PathBuf,
-    /// Duty grid, percent of full scale.
-    #[arg(long, value_delimiter = ',', default_values_t = (1..=20u8).map(|k| k * 5))]
-    duty_pct: Vec<u8>,
+    /// Duty grid, percent of full scale; `coast:MS` / `brake:MS` entries
+    /// capture a zero-duty segment chained to the preceding step.
+    #[arg(long, value_delimiter = ',', value_parser = parse_step,
+          default_values_t = (1..=20u8).map(|k| Step::Drive(k * 5)))]
+    duty_pct: Vec<Step>,
     #[arg(long, value_enum, default_value_t = Dirs::Both)]
     dirs: Dirs,
+    /// openloop_decay written before the run.
+    #[arg(long, value_enum, default_value_t = Decay::Slow)]
+    decay: Decay,
     /// Capture per rung; samples = window_ms x 20 ticks.
     #[arg(long, default_value_t = 150)]
     window_ms: u32,
@@ -224,6 +281,20 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     std::fs::create_dir_all(&args.out).with_context(|| format!("mkdir {}", args.out.display()))?;
 
     let identity = c.identity(id)?;
+    let registry = descriptor::Registry::load()?;
+    let (d, note) = registry.select(identity.model, identity.fw)?;
+    if let Some(note) = note {
+        println!("{note}");
+    }
+    let field_reg = |name: &str| -> Result<Reg> {
+        let f = d.field(name)?;
+        Ok(Reg {
+            addr: f.addr,
+            width: f.width as u8,
+        })
+    };
+    let decay_reg = field_reg("openloop_decay")?;
+    let zb_reg = field_reg("openloop_zero_brake")?;
     let tick_hz = read_u16(&mut c, id, calib::TICK_HZ)?;
     let vbus_counts = read_snapshot(&mut c, id)?.vbus_counts;
     let dirs: &[i8] = match args.dirs {
@@ -243,7 +314,8 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
             "vmotor_div_bot": read_u16(&mut c, id, calib::VMOTOR_DIV_BOT)?,
             "vdd_mv": read_u16(&mut c, id, calib::VDD_MV)?,
         },
-        "duty_pct": args.duty_pct,
+        "schedule": args.duty_pct.iter().map(Step::to_string).collect::<Vec<_>>(),
+        "decay": args.decay.as_str(),
         "dirs": dirs,
         "window_ms": args.window_ms,
         "rest_ms": args.rest_ms,
@@ -270,6 +342,8 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
 
     let seek_duty = pct_q15(args.seek_duty_pct);
     let r = with_guard(&mut c, id, |c| {
+        write_reg(c, id, decay_reg, args.decay as i32)?;
+        write_reg(c, id, zb_reg, 0)?;
         write_reg(c, id, control::TEL_MASK, mask as i32)?;
 
         // baseline: mid-travel, torque off, noise floor at full tick rate
@@ -283,44 +357,76 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
         );
         write_rows(&mut w, 0, 0, 0, &frames)?;
 
+        let steps = &args.duty_pct;
+        // A coast/brake segment chains to the step before it: no settle in
+        // between, so the drive's momentum carries into the zero-duty burst.
+        let feeds = |k: usize| matches!(steps.get(k + 1), Some(Step::Coast(_) | Step::Brake(_)));
+
         let mut seg = 1u32;
         for &dir in dirs {
-            for &pct in &args.duty_pct {
+            let mut live = false;
+            for (k, &step) in steps.iter().enumerate() {
                 check_stop()?;
-                check_fault(c, id)?;
-                let duty = dir as i32 * pct_q15(pct) as i32;
-                seek_band(
-                    c,
-                    id,
-                    start_band(dir, args.guard_lo, args.guard_hi),
-                    seek_duty,
-                )?;
-                write_reg(c, id, control::MODE, 0)?;
-                write_reg(c, id, control::TORQUE_ENABLE, 1)?;
+                let (ms, duty) = match step {
+                    Step::Drive(pct) => {
+                        check_fault(c, id)?;
+                        seek_band(
+                            c,
+                            id,
+                            start_band(dir, args.guard_lo, args.guard_hi),
+                            seek_duty,
+                        )?;
+                        write_reg(c, id, control::MODE, 0)?;
+                        write_reg(c, id, control::TORQUE_ENABLE, 1)?;
+                        (args.window_ms, dir as i32 * pct_q15(pct) as i32)
+                    }
+                    Step::Coast(ms) | Step::Brake(ms) => {
+                        if !live {
+                            check_fault(c, id)?;
+                            write_reg(c, id, control::MODE, 0)?;
+                            write_reg(c, id, control::TORQUE_ENABLE, 1)?;
+                        }
+                        (ms, 0)
+                    }
+                };
+                if matches!(step, Step::Brake(_)) {
+                    write_reg(c, id, zb_reg, 1)?;
+                }
                 let (frames, st) = exchange_tel_burst(
                     c,
                     id,
-                    samples_of_ms(args.window_ms),
+                    samples_of_ms(ms),
                     Some((control::GOAL_DUTY, duty)),
                     mask,
                 )?;
+                if matches!(step, Step::Brake(_)) {
+                    write_reg(c, id, zb_reg, 0)?;
+                }
+                let what = match step {
+                    Step::Drive(pct) => format!("duty {:+}%", dir as i32 * pct as i32),
+                    Step::Coast(ms) => format!("coast {ms} ms"),
+                    Step::Brake(ms) => format!("brake {ms} ms"),
+                };
                 println!(
-                    "  seg {seg} (duty {:+}%): {} frames, {} samples, {} seq holes, {} garble bytes",
-                    dir as i32 * pct as i32,
-                    st.frames,
-                    st.samples,
-                    st.holes,
-                    st.garble
+                    "  seg {seg} ({what}): {} frames, {} samples, {} seq holes, {} garble bytes",
+                    st.frames, st.samples, st.holes, st.garble
                 );
                 write_rows(&mut w, seg, duty as i16, dir, &frames)?;
-                brake_to_rest(c, id, dir)?;
-                write_reg(c, id, control::TORQUE_ENABLE, 0)?;
-                rest(args.rest_ms)?;
+                if feeds(k) {
+                    live = true;
+                } else {
+                    brake_to_rest(c, id, dir)?;
+                    write_reg(c, id, control::TORQUE_ENABLE, 0)?;
+                    rest(args.rest_ms)?;
+                    live = false;
+                }
                 seg += 1;
             }
         }
         Ok(())
     });
+    // Belt for a run cut mid-brake-segment: the flag must end the sweep clear.
+    let _ = write_reg(&mut c, id, zb_reg, 0);
     w.flush()?;
     r?;
     println!("sweep: {}", csv_path.display());
@@ -345,6 +451,21 @@ mod tests {
         assert_eq!(samples_of_ms(150), 3000);
         assert_eq!(samples_of_ms(1000), 20000);
         assert_eq!(samples_of_ms(10_000), u16::MAX);
+    }
+
+    #[test]
+    fn steps_parse_and_display_round_trip() {
+        for (s, want) in [
+            ("35", Step::Drive(35)),
+            ("coast:200", Step::Coast(200)),
+            ("brake:150", Step::Brake(150)),
+        ] {
+            assert_eq!(parse_step(s).unwrap(), want);
+            assert_eq!(want.to_string(), s);
+        }
+        assert!(parse_step("coast").is_err());
+        assert!(parse_step("brake:x").is_err());
+        assert!(parse_step("slow").is_err());
     }
 
     #[test]


### PR DESCRIPTION
- ADC scan reordered [shunt, vmA, vmB, pos, vcal] with a short shunt aperture; validity floors reseeded to 160/210 ticks (bench re-validation scheduled)
- openloop_zero_brake config flag: zero commanded duty in OpenLoop brakes instead of coasting when set; config image version bumped for the layout shift
- osc sweep: --decay slow|fast, coast:MS / brake:MS schedule segments chained to the preceding drive step