### PR TITLE
fw: direct supply-sense and ntc channels, terminal bias measured at boot

### DIFF
--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -557,6 +557,48 @@
       "kind": "uint"
     },
     {
+      "name": "vbus_div_top_ohm",
+      "addr": 288,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "vbus_div_bot_ohm",
+      "addr": 290,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "ntc_pullup_ohm",
+      "addr": 292,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "ntc_r25_ohm",
+      "addr": 294,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "ntc_beta",
+      "addr": 296,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "vmotor_bias_nom_counts",
+      "addr": 298,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
       "name": "torque_enable",
       "addr": 384,
       "width": 1,
@@ -844,43 +886,64 @@
       "kind": "uint"
     },
     {
-      "name": "i_mean_counts",
+      "name": "vbus_raw",
       "addr": 596,
       "width": 2,
       "access": "ro",
-      "kind": "int"
+      "kind": "uint"
     },
     {
-      "name": "i_min_counts",
+      "name": "ntc_raw",
       "addr": 598,
       "width": 2,
       "access": "ro",
-      "kind": "int"
+      "kind": "uint"
     },
     {
-      "name": "i_max_counts",
+      "name": "vmotor_bias_counts",
       "addr": 600,
       "width": 2,
       "access": "ro",
-      "kind": "int"
+      "kind": "uint"
     },
     {
-      "name": "vdiff_mean",
+      "name": "i_mean_counts",
       "addr": 602,
       "width": 2,
       "access": "ro",
       "kind": "int"
     },
     {
-      "name": "duty_mean_q15",
+      "name": "i_min_counts",
       "addr": 604,
       "width": 2,
       "access": "ro",
       "kind": "int"
     },
     {
-      "name": "agg_seq",
+      "name": "i_max_counts",
       "addr": 606,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "vdiff_mean",
+      "addr": 608,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "duty_mean_q15",
+      "addr": 610,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "agg_seq",
+      "addr": 612,
       "width": 2,
       "access": "ro",
       "kind": "uint"

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -41,6 +41,8 @@ fn main() -> ! {
             sensors: AdcPins {
                 pos: AnalogChannel::A3,
                 vmotor: (AnalogChannel::A5, AnalogChannel::A6),
+                vbus: AnalogChannel::A0,
+                ntc: AnalogChannel::A2,
             },
         },
         calibration: Calibration {
@@ -49,8 +51,20 @@ fn main() -> ! {
                 top_ohm: 20_000,
                 bot_ohm: 10_000,
             },
+            // Board D bodge; rev-2A lands 20_000/10_000.
+            vbus_divider: Divider {
+                top_ohm: 22_000,
+                bot_ohm: 10_000,
+            },
+            ntc: Ntc {
+                pullup_ohm: 10_000,
+                r25_ohm: 10_000,
+                beta: 3950,
+            },
+            // Terminal-divider bias VB from 3V3 through 430/100: 4095 x 100 / 530.
+            vmotor_bias_nom_counts: 773,
             vdd_mv: 3300,
-            // Scan order is [shunt, vmA, vmB, pos, vcal]. The i floor is
+            // Scan order is [shunt, vmA, vmB, pos, vcal, vbus, ntc]. The i floor is
             // amp-settling-bound: arm-B network measured true from duty 13%
             // (bringup docs/armb-comp-sizing.md). The v floor covers
             // vmotor_b's S/H close ~182 ticks after the crest trigger plus

--- a/firmware/lib/core/src/estimator/vbus.rs
+++ b/firmware/lib/core/src/estimator/vbus.rs
@@ -1,66 +1,49 @@
-//! Supply-voltage estimator. EWMA of the driven-terminal sample (fwd ->
-//! vmotor_a, rev -> vmotor_b; the kernel window-selects) plus the cached Q15
-//! supply reciprocal the current loop compensates with. The spec sketches an
-//! incremental one-Newton-step-per-tick reciprocal; this runs the shared
-//! full-accuracy `math::recip_div` every step instead - ~10 multiplies at
-//! MEDIUM (2 kHz) is noise, and one reciprocal implementation beats two.
+//! Supply-voltage estimator. EWMA of the direct rail tap (`vbus_raw`, every
+//! tick, drive or not) rescaled into motor-terminal divider counts - the
+//! unit `v_undervolt_counts`, the bemf math and the current loop already
+//! speak - plus the cached Q15 supply reciprocal the current loop
+//! compensates with. The spec sketches an incremental
+//! one-Newton-step-per-tick reciprocal; this runs the shared full-accuracy
+//! `math::recip_div` every step instead - ~10 multiplies at MEDIUM (2 kHz)
+//! is noise, and one reciprocal implementation beats two.
 
-use crate::math::recip_div;
+use crate::math::{q_mul_u, recip_div};
 
 const GUARD: u32 = 3;
 const ALPHA_SHIFT: u32 = 3;
 
-/// EWMA alpha 1/8 with 3 guard bits; the first valid sample seeds the state
+/// EWMA alpha 1/8 with 3 guard bits; the first sample seeds the state
 /// (`BemfObs` convention). A fresh `new()` carries recip 0 - duty 0 through
-/// the current loop - until the first sample or an install-time `seed`.
-#[derive(Default)]
+/// the current loop - until the first step.
 pub struct VbusEst {
     state_qg: i32,
     initialized: bool,
     recip_q15: u32,
-    fresh: bool,
+    scale_q15: u32,
 }
 
 impl VbusEst {
-    pub const fn new() -> Self {
+    /// `scale_q15` maps rail-tap counts onto vmotor-tap counts:
+    /// `(vbus_top + vbus_bot) * vmotor_bot / (vbus_bot * (vmotor_top +
+    /// vmotor_bot))` in Q15, const-evaluated chip-side from the board's two
+    /// dividers (`Precomputed`), so core never divides.
+    pub const fn new(scale_q15: u32) -> Self {
         Self {
             state_qg: 0,
             initialized: false,
             recip_q15: 0,
-            fresh: false,
+            scale_q15,
         }
     }
 
-    /// True iff a valid drive-window sample landed since the last call;
-    /// clears on read. Undervolt verdicts gate on this: a held (stale)
-    /// estimate is not evidence - a sagged reading frozen by the fault's
-    /// own bridge-off otherwise re-latches forever (fault -> no drive ->
-    /// no fresh sample -> fault).
-    pub fn take_fresh(&mut self) -> bool {
-        core::mem::take(&mut self.fresh)
-    }
-
-    /// Install-time seed from the first frame or a nominal, so boot does not
-    /// ride a zero reciprocal through an EWMA settle.
-    pub fn seed(&mut self, vbus_counts: u16, floor: u16) {
-        self.state_qg = (vbus_counts as i32) << GUARD;
-        self.initialized = true;
-        self.update_recip(floor);
-    }
-
-    /// One MEDIUM-tick update. `vdrive` = the window-selected driven-terminal
-    /// sample; `None` (window under the vmotor validity floor) holds the last
-    /// estimate - vbus moves slowly.
-    pub fn step(&mut self, vdrive: Option<u16>, undervolt_floor_counts: u16) {
-        if let Some(v) = vdrive {
-            let x = (v as i32) << GUARD;
-            if self.initialized {
-                self.state_qg += (x - self.state_qg) >> ALPHA_SHIFT;
-            } else {
-                self.state_qg = x;
-                self.initialized = true;
-            }
-            self.fresh = true;
+    /// One MEDIUM-tick update from the tick's rail tap.
+    pub fn step(&mut self, vbus_raw: u16, undervolt_floor_counts: u16) {
+        let x = (q_mul_u(vbus_raw as u32, self.scale_q15, 15) as i32) << GUARD;
+        if self.initialized {
+            self.state_qg += (x - self.state_qg) >> ALPHA_SHIFT;
+        } else {
+            self.state_qg = x;
+            self.initialized = true;
         }
         self.update_recip(undervolt_floor_counts);
     }
@@ -91,62 +74,62 @@ mod tests {
     use super::*;
     use crate::math::q_mul;
 
+    const UNITY: u32 = 1 << 15;
+    /// osc-dev-v006 board D: 22k/10k rail divider over the 20k/10k terminal
+    /// dividers, 32000 x 10000 / (10000 x 30000) = 1.0667.
+    const BOARD_D: u32 = 34952;
+
     /// Contract residual: 0 means q_mul(vbus, recip, 15) hit 32767 exactly.
     fn recip_err(vbus: u16, recip: u32) -> i32 {
         q_mul(vbus as i32, recip as i32, 15) - 32767
     }
 
     #[test]
-    fn seed_sets_state_and_recip() {
-        let mut est = VbusEst::new();
-        assert_eq!(est.recip_q15(), 0);
-        est.seed(3000, 100);
-        assert_eq!(est.vbus_counts(), 3000);
-        assert!(recip_err(3000, est.recip_q15()).abs() <= 1);
-    }
-
-    #[test]
     fn first_sample_seeds_then_ewma_pins() {
-        let mut est = VbusEst::new();
-        est.step(Some(800), 1);
+        let mut est = VbusEst::new(UNITY);
+        assert_eq!(est.recip_q15(), 0);
+        est.step(800, 1);
         assert_eq!(est.vbus_counts(), 800);
+        assert!(recip_err(800, est.recip_q15()).abs() <= 1);
         // alpha 1/8: 800 + 800/8 = 900, then 900 + 700/8 = 987 in Q3
-        est.step(Some(1600), 1);
+        est.step(1600, 1);
         assert_eq!(est.vbus_counts(), 900);
-        est.step(Some(1600), 1);
+        est.step(1600, 1);
         assert_eq!(est.vbus_counts(), 987);
     }
 
     #[test]
-    fn none_holds_value_and_recip() {
-        let mut est = VbusEst::new();
-        est.seed(2500, 1);
-        let r = est.recip_q15();
-        est.step(None, 1);
-        assert_eq!(est.vbus_counts(), 2500);
-        assert_eq!(est.recip_q15(), r);
+    fn scale_maps_rail_tap_onto_terminal_counts() {
+        // 2S at 7.4 V: 2313 on the 22k/10k tap reads as 2467 on a 20k/10k tap
+        let mut est = VbusEst::new(BOARD_D);
+        est.step(2313, 1);
+        assert_eq!(est.vbus_counts(), 2467);
+        // a 20k/10k rail tap (rev-2A) is the identity
+        let mut est = VbusEst::new(UNITY);
+        est.step(2313, 1);
+        assert_eq!(est.vbus_counts(), 2313);
     }
 
     #[test]
     fn floor_clamps_recip() {
         // vbus sags to 5: the estimate follows but the reciprocal caps at
         // the floor's, not 5's (~200x larger)
-        let mut est = VbusEst::new();
-        est.seed(5, 1000);
+        let mut est = VbusEst::new(UNITY);
+        est.step(5, 1000);
         assert_eq!(est.vbus_counts(), 5);
         assert!(recip_err(1000, est.recip_q15()).abs() <= 1);
-        // never-seeded zero vbus with floor 0: the >= 1 backstop pins the
-        // recip_div d <= 1 path
-        let mut cold = VbusEst::new();
-        cold.step(None, 0);
+        // zero rail with floor 0: the >= 1 backstop pins the recip_div
+        // d <= 1 path
+        let mut cold = VbusEst::new(UNITY);
+        cold.step(0, 0);
         assert_eq!(cold.recip_q15(), 32767 << 15);
     }
 
     #[test]
     fn recip_contract_sweep() {
-        let mut est = VbusEst::new();
         for vbus in 1000..4000u16 {
-            est.seed(vbus, 1);
+            let mut est = VbusEst::new(UNITY);
+            est.step(vbus, 1);
             let err = recip_err(vbus, est.recip_q15());
             assert!(err.abs() <= 1, "vbus={vbus} err={err}");
         }
@@ -154,11 +137,11 @@ mod tests {
 
     #[test]
     fn recip_tracks_vbus_step_within_ewma_lag() {
-        let mut est = VbusEst::new();
-        est.seed(4000, 100);
+        let mut est = VbusEst::new(UNITY);
+        est.step(4000, 100);
         // tau ~8 steps; 80 steps is >5 tau plus the truncation tail
         for _ in 0..80 {
-            est.step(Some(3000), 100);
+            est.step(3000, 100);
         }
         let v = est.vbus_counts();
         assert!((v as i32 - 3000).abs() <= 1, "v={v}");

--- a/firmware/lib/core/src/estimator/window.rs
+++ b/firmware/lib/core/src/estimator/window.rs
@@ -49,12 +49,12 @@ pub fn i_from_frame(
     Some(if duty_sign_positive { mag } else { -mag })
 }
 
-/// Drive-window vmotor pair: (driven-high terminal sample = vbus candidate,
-/// differential `va - vb`). Positive duty drives IN1 (TIM1 CH3, PC6) ->
-/// DRV8212P OUT1 -> MOT_A -> VSNA -> `vmotor_a`, so forward drive reads
-/// `vmotor_a` and `va - vb` is positive under forward drive, negative under
-/// reverse - the sign convention downstream bemf math relies on.
-pub fn vdrive_from_frame(frame: &SensorFrame, sel: WindowSel, forward: bool) -> Option<(u16, i32)> {
+/// Drive-window terminal differential `va - vb`. Positive duty drives IN1
+/// (TIM1 CH3, PC6) -> DRV8212P OUT1 -> MOT_A -> VSNA -> `vmotor_a`, so
+/// `va - vb` is positive under forward drive, negative under reverse - the
+/// sign convention downstream bemf math relies on. Both taps share the
+/// board's terminal bias, so it cancels here.
+pub fn vdiff_from_frame(frame: &SensorFrame, sel: WindowSel) -> Option<i32> {
     if !sel.v_valid {
         return None;
     }
@@ -63,8 +63,7 @@ pub fn vdrive_from_frame(frame: &SensorFrame, sel: WindowSel, forward: bool) -> 
     } else {
         (frame.vmotor_a, frame.vmotor_b)
     };
-    let vdrive = if forward { va } else { vb };
-    Some((vdrive, va as i32 - vb as i32))
+    Some(va as i32 - vb as i32)
 }
 
 /// Mirrors chip-side `effort_to_ticks` (`mag * arr / 32767` approximated as
@@ -153,48 +152,32 @@ mod tests {
     }
 
     #[test]
-    fn vdrive_geometry_all_four_rows() {
+    fn vdiff_peak_vs_trough_pick() {
         let f = frame();
-        // Slow fwd: vmotor_a peak
-        assert_eq!(
-            vdrive_from_frame(&f, valid(false), true),
-            Some((3000, 2900))
-        );
-        // Slow rev: vmotor_b peak
-        assert_eq!(
-            vdrive_from_frame(&f, valid(false), false),
-            Some((100, 2900))
-        );
-        // Fast fwd: vmotor_a trough
-        assert_eq!(vdrive_from_frame(&f, valid(true), true), Some((2900, 2810)));
-        // Fast rev: vmotor_b trough
-        assert_eq!(vdrive_from_frame(&f, valid(true), false), Some((90, 2810)));
+        assert_eq!(vdiff_from_frame(&f, valid(false)), Some(2900));
+        assert_eq!(vdiff_from_frame(&f, valid(true)), Some(2810));
     }
 
     #[test]
-    fn vdrive_differential_sign_tracks_drive_direction() {
-        let fwd = frame();
-        let (_, d) = vdrive_from_frame(&fwd, valid(false), true).unwrap();
-        assert!(d > 0);
+    fn vdiff_sign_tracks_drive_direction() {
+        assert!(vdiff_from_frame(&frame(), valid(false)).unwrap() > 0);
         let rev = SensorFrame {
             vmotor_a: 100,
             vmotor_b: 3000,
             ..Default::default()
         };
-        let (v, d) = vdrive_from_frame(&rev, valid(false), false).unwrap();
-        assert_eq!(v, 3000);
-        assert!(d < 0);
+        assert_eq!(vdiff_from_frame(&rev, valid(false)), Some(-2900));
     }
 
     #[test]
-    fn vdrive_invalid_window_is_none() {
+    fn vdiff_invalid_window_is_none() {
         let f = frame();
         let sel = WindowSel {
             i_valid: true,
             v_valid: false,
             use_trough: false,
         };
-        assert_eq!(vdrive_from_frame(&f, sel, true), None);
+        assert_eq!(vdiff_from_frame(&f, sel), None);
     }
 
     #[test]

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -39,9 +39,10 @@ pub const DECIM_MED: u8 = 10;
 /// MEDIUM -> SLOW decimation: SLOW_HZ = MED_HZ / DECIM_SLOW (62.5 Hz).
 pub const DECIM_SLOW: u8 = 32;
 
-/// Finished timing constants the chip const-evals from `MOTOR_PWM_FREQ_HZ`
-/// and the TIM1 ARR, so core never divides at runtime or install - every
-/// field is a compile-time quotient on the chip side (`Precomputed`).
+/// Finished constants the chip const-evals from `MOTOR_PWM_FREQ_HZ`, the
+/// TIM1 ARR and the board's dividers, so core never divides at runtime or
+/// install - every field is a compile-time quotient on the chip side
+/// (`Precomputed`).
 #[derive(Copy, Clone)]
 pub struct KernelTiming {
     /// The TIM1 auto-reload the motor write programs; drive-window widths
@@ -59,6 +60,8 @@ pub struct KernelTiming {
     pub dt_med_q32: u32,
     /// `(MED_HZ << 16) / 1000`: ms -> medium ticks via `q_mul_u(ms, ., 16)`.
     pub med_ticks_per_ms_q16: u32,
+    /// Rail-tap -> vmotor-tap counts, Q15 (`VbusEst::new`).
+    pub vbus_scale_q15: u32,
 }
 
 /// Runs in the ADC DMA TC ISR (PFIC LOW); one `on_tick` per PWM period.
@@ -141,7 +144,7 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
             vel: VelocityLoop::new(),
             limits: LimitState::new(),
             i_band: IBand { lo: 0, hi: 0 },
-            vbus: VbusEst::new(),
+            vbus: VbusEst::new(timing.vbus_scale_q15),
             thermal: WindingTherm::new(),
             bemf: BemfObs::new(),
             faults: faults::FaultLatch::new(),
@@ -200,6 +203,8 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
             (&raw mut (*s).vmotor_a).write_volatile(frame.vmotor_a);
             (&raw mut (*s).vmotor_b).write_volatile(frame.vmotor_b);
             (&raw mut (*s).current_trough).write_volatile(frame.current_trough);
+            (&raw mut (*s).vbus_raw).write_volatile(frame.vbus_raw);
+            (&raw mut (*s).ntc_raw).write_volatile(frame.ntc_raw);
         }
 
         // torque_enable 0->1 is the fault ack: latch, detectors, and the
@@ -236,7 +241,7 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
         // IDENT: per-tick sample aligned to the window the PREVIOUS command
         // drove - duty_q15 still holds that command here; i/vdiff hold
         // last-valid through invalid windows (ident module doc).
-        if let Some((_, vdiff)) = window::vdrive_from_frame(&frame, sel, fwd) {
+        if let Some(vdiff) = window::vdiff_from_frame(&frame, sel) {
             self.vdiff_last = vdiff.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
         }
         // TEL emits HERE, on the fast path before the medium/slow branches:
@@ -254,6 +259,8 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                 current_raw: frame.current,
                 vmotor_a: frame.vmotor_a,
                 vmotor_b: frame.vmotor_b,
+                vbus_raw: frame.vbus_raw,
+                ntc_raw: frame.ntc_raw,
                 window_valid: i_meas.is_some(),
                 fault: self.faults.mask() != 0,
             };
@@ -445,12 +452,10 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                 }
             }
 
-            // vbus plus the shared v_mean: computed ONCE here, consumed by
-            // bemf now and the thermometer at SLOW (bemf RECIP_ARR contract)
-            let vdrive = window::vdrive_from_frame(&frame, sel, fwd);
-            self.vbus
-                .step(vdrive.map(|(v, _)| v), therm_cfg.v_undervolt_counts);
-            let v_mean = vdrive.map(|(_, vdiff)| {
+            self.vbus.step(frame.vbus_raw, therm_cfg.v_undervolt_counts);
+            // the shared v_mean: computed ONCE here, consumed by bemf now and
+            // the thermometer at SLOW (bemf RECIP_ARR contract)
+            let v_mean = window::vdiff_from_frame(&frame, sel).map(|vdiff| {
                 q_mul(
                     ticks as i32 * vdiff,
                     self.timing.recip_arr_q24 as i32,
@@ -533,12 +538,9 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                     self.faults
                         .raise(faults::BIT_OVER_TEMP, faults::CODE_OVER_TEMP);
                 }
-                // undervolt needs FRESH evidence: a held estimate frozen by
-                // the fault's own bridge-off (no drive -> no window) would
-                // re-latch forever off a recovered rail. Recovery is a retry
-                // probe: ack -> drive resumes -> fresh sample -> verdict.
-                let vb = self.vbus.vbus_counts();
-                if self.vbus.take_fresh() && vb < therm_cfg.v_undervolt_counts {
+                // the rail tap samples drive or not, so a held sag never
+                // outlives the sag itself: ack clears once the rail is back
+                if self.vbus.vbus_counts() < therm_cfg.v_undervolt_counts {
                     self.faults
                         .raise(faults::BIT_UNDER_VOLT, faults::CODE_UNDER_VOLT);
                 }

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -10,6 +10,8 @@ use crate::{RegionStorage, Shared};
 
 const BIAS: u16 = 2048;
 const ARR: u16 = 1200;
+/// osc-dev-v006 board D rail scale (22k/10k tap over 20k/10k terminals).
+const VBUS_SCALE_Q15: u32 = 34952;
 
 // The chip-side const-eval for a 20 kHz FAST rate (MED 2 kHz).
 const TIMING: KernelTiming = KernelTiming {
@@ -18,6 +20,7 @@ const TIMING: KernelTiming = KernelTiming {
     tick_hz: 20_000,
     dt_med_q32: ((1u64 << 32) / 2000) as u32,
     med_ticks_per_ms_q16: 2 << 16,
+    vbus_scale_q15: VBUS_SCALE_Q15,
 };
 
 struct FakeSensors;
@@ -124,6 +127,11 @@ fn seed(shared: &Shared) {
     });
 }
 
+/// Rail-tap counts that scale to exactly `vmotor` terminal counts.
+fn vbus_raw(vmotor: u16) -> u16 {
+    ((vmotor as u32 * 32768).div_ceil(VBUS_SCALE_Q15)) as u16
+}
+
 fn frame(pos: u16, current: u16) -> SensorFrame {
     SensorFrame {
         pos,
@@ -134,6 +142,8 @@ fn frame(pos: u16, current: u16) -> SensorFrame {
         vmotor_b: 40,
         vmotor_b_trough: 40,
         vcal: 1200,
+        vbus_raw: vbus_raw(3000),
+        ntc_raw: 2048,
         tick: 0,
     }
 }
@@ -249,9 +259,8 @@ fn endstop_allows_retreat_from_the_wall() {
     );
     // the door back out must be open: a retreat goal drives immediately
     // (the magnitude-fold deadlock read the zeroed i_ref as inward forever).
-    // Reverse drive samples the OTHER terminal, so the frame carries the
-    // rail on vmotor_b - a forward-shaped frame would read the low leg as
-    // a collapsed rail and latch UNDER_VOLT.
+    // Reverse drive puts the rail on vmotor_b, so va - vb flips with the
+    // command (the bemf sign convention).
     sh.table
         .with_mut(|t| t.control.lifecycle.goal_current = -120);
     let mut rev = frame(4095, BIAS);
@@ -269,7 +278,7 @@ fn endstop_allows_retreat_from_the_wall() {
 }
 
 #[test]
-fn undervolt_needs_fresh_evidence_no_stale_relatch() {
+fn undervolt_follows_the_rail_tap_through_bridge_off() {
     let sh = Shared::new();
     seed(&sh);
     sh.table.with_mut(|t| {
@@ -278,17 +287,16 @@ fn undervolt_needs_fresh_evidence_no_stale_relatch() {
         t.control.lifecycle.goal_duty = 8192;
     });
     let mut k = kernel();
-    // sagged rail: valid drive windows carry va under the undervolt floor
+    // sagged rail on the direct tap; the terminal taps are irrelevant
     let mut sagged = frame(2000, BIAS);
-    sagged.vmotor_a = 1000;
-    sagged.vmotor_a_trough = 1000;
+    sagged.vbus_raw = vbus_raw(1000);
     for _ in 0..400 {
         k.on_tick(sagged, &sh);
     }
     assert_eq!(k.faults.mask(), faults::BIT_UNDER_VOLT, "sag latches");
     assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
-    // bridge off -> no window -> vbus estimate frozen at the sag; the ack
-    // must stick because there is no fresh evidence
+    // the tap keeps sampling with the bridge off: an ack against a still
+    // sagged rail re-latches, an ack against a recovered rail sticks
     sh.table
         .with_mut(|t| t.control.lifecycle.torque_enable = false);
     for _ in 0..400 {
@@ -296,17 +304,25 @@ fn undervolt_needs_fresh_evidence_no_stale_relatch() {
     }
     sh.table
         .with_mut(|t| t.control.lifecycle.torque_enable = true);
-    // recovered rail from here on
-    for _ in 0..2000 {
-        k.on_tick(frame(2000, BIAS), &sh);
-    }
-    assert_eq!(k.faults.mask(), 0, "stale sag re-latched undervolt");
-    assert!(matches!(last_cmd(&k), MotorCmd::Drive { .. }));
-    // a genuinely low rail re-latches through the same retry probe
     for _ in 0..2000 {
         k.on_tick(sagged, &sh);
     }
-    assert_eq!(k.faults.mask(), faults::BIT_UNDER_VOLT);
+    assert_eq!(k.faults.mask(), faults::BIT_UNDER_VOLT, "sag re-latches");
+    sh.table
+        .with_mut(|t| t.control.lifecycle.torque_enable = false);
+    for _ in 0..400 {
+        k.on_tick(frame(2000, BIAS), &sh);
+    }
+    sh.table
+        .with_mut(|t| t.control.lifecycle.torque_enable = true);
+    for _ in 0..2000 {
+        k.on_tick(frame(2000, BIAS), &sh);
+    }
+    assert_eq!(k.faults.mask(), 0, "recovered rail re-latched undervolt");
+    assert!(matches!(last_cmd(&k), MotorCmd::Drive { .. }));
+    // EWMA truncation tail: settles within 1 count of the rail
+    let v = sh.table.with(|t| t.telemetry.estimates.vbus_counts) as i32;
+    assert!((v - 3000).abs() <= 1, "vbus_counts={v}");
 }
 
 #[test]
@@ -579,7 +595,7 @@ fn publishes_land_in_the_table() {
         assert_eq!(t.telemetry.estimates.omega_hat_cps, k.fusion.omega_q16());
         assert_eq!(t.telemetry.estimates.i_lim_counts, 1200);
         assert_eq!(t.telemetry.estimates.duty_applied_q15, 0);
-        assert_eq!(t.telemetry.estimates.vbus_counts, 0); // never driven
+        assert_eq!(t.telemetry.estimates.vbus_counts, 3000);
         assert_eq!(t.telemetry.mode.mode_active, Mode::Position as u8);
         assert_eq!(t.telemetry.mode.fault_code, faults::CODE_NONE);
         assert_eq!(t.telemetry.common.fault_flags, 0);
@@ -744,6 +760,8 @@ impl Plant {
             vmotor_b: vb,
             vmotor_b_trough: vb,
             vcal: 1200,
+            vbus_raw: vbus_raw(self.vbus),
+            ntc_raw: 2048,
             tick: 0,
         }
     }

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -27,12 +27,12 @@ pub use kernel::{Kernel, KernelTiming};
 pub use persist::{ConfigStore, StoreError};
 pub use regions::config::{BaudRate, ConfigDefaults};
 pub use regions::{
-    BootMode, CalibKinematics, CalibMotor, CalibRegs, CalibSense, CalibWinding, ConfigCommon,
-    ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent, ConfigLoopPosition,
-    ConfigLoopVelocity, ConfigPosLimits, ConfigRegs, ConfigThermal, ControlLifecycle, ControlRegs,
-    ControlSystem, ControlTable, ControlTableCell, DecaySelect, Mode, PotLutBlock, StallResponse,
-    TelemetryCommon, TelemetryEstimates, TelemetryIdent, TelemetryMode, TelemetryRegs,
-    TelemetrySensors,
+    BootMode, CalibKinematics, CalibMotor, CalibRegs, CalibSense, CalibSenseExt, CalibWinding,
+    ConfigCommon, ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent,
+    ConfigLoopPosition, ConfigLoopVelocity, ConfigPosLimits, ConfigRegs, ConfigThermal,
+    ControlLifecycle, ControlRegs, ControlSystem, ControlTable, ControlTableCell, DecaySelect,
+    Mode, PotLutBlock, StallResponse, TelemetryCommon, TelemetryEstimates, TelemetryIdent,
+    TelemetryMode, TelemetryRegs, TelemetrySensors,
 };
 pub use sensor_frame::SensorFrame;
 pub use services::bus::{Dispatcher, Session};

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -291,7 +291,7 @@ impl ControlTableCell {
     }
 
     /// Overlay a validated calib image -- whole region, nothing skipped: every
-    /// field is data. RO board facts (the `CalibSense` block) must be
+    /// field is data. RO board facts (`CalibSense`, `CalibSenseExt`) must be
     /// re-seeded by install AFTER this overlay so board data always wins over
     /// a stale image. Bringup-only, pre-IRQ; sole writer.
     pub fn overlay_persistent_calib(&self, calib: &[u8; CALIB_LEN]) {
@@ -605,16 +605,26 @@ mod tests {
     #[test]
     fn calib_boot_overlay_without_valid_image_keeps_seeds() {
         let table = seeded_table();
-        table.seed_calib_sense(&crate::regions::calib::CalibSense {
-            shunt_r_mohm: 0,
-            gain_milli: 0,
-            vmotor_div_top: 0,
-            vmotor_div_bot: 0,
-            vdd_mv: 0,
-            tick_hz: 20000,
-            i_window_min_ticks: 0,
-            v_window_min_ticks: 0,
-        });
+        table.seed_calib_sense(
+            &crate::regions::calib::CalibSense {
+                shunt_r_mohm: 0,
+                gain_milli: 0,
+                vmotor_div_top: 0,
+                vmotor_div_bot: 0,
+                vdd_mv: 0,
+                tick_hz: 20000,
+                i_window_min_ticks: 0,
+                v_window_min_ticks: 0,
+            },
+            &crate::regions::calib::CalibSenseExt {
+                vbus_div_top_ohm: 0,
+                vbus_div_bot_ohm: 0,
+                ntc_pullup_ohm: 0,
+                ntc_r25_ohm: 0,
+                ntc_beta: 0,
+                vmotor_bias_nom_counts: 0,
+            },
+        );
         let pick = boot_overlay_calib(&table, &[0xFF; CALIB_IMAGE_LEN], &[0u8; CALIB_IMAGE_LEN]);
         assert_eq!(
             pick,

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -81,6 +81,29 @@ pub struct CalibKinematics {
     pub gear_ratio_centi: u16,
 }
 
+/// Supply-sense and thermistor board data (protocol sec 5.5): the direct
+/// rail divider legs, the NTC pull-up / R25 / beta, and the nominal
+/// motor-terminal divider bias (the boot-measured value publishes in
+/// telemetry). Lands after `kinematics` in what was the reserved tail so no
+/// persisted CALIB field moves: images saved before this block carry zeros
+/// here, harmless because install re-stamps every RO block after the overlay.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct CalibSenseExt {
+    #[ct_field(access = ro)]
+    pub vbus_div_top_ohm: u16,
+    #[ct_field(access = ro)]
+    pub vbus_div_bot_ohm: u16,
+    #[ct_field(access = ro)]
+    pub ntc_pullup_ohm: u16,
+    #[ct_field(access = ro)]
+    pub ntc_r25_ohm: u16,
+    #[ct_field(access = ro)]
+    pub ntc_beta: u16,
+    #[ct_field(access = ro)]
+    pub vmotor_bias_nom_counts: u16,
+}
+
 /// Calibration section: always writable (normal field validation applies),
 /// volatile until persisted -- persistence is SAVE's job, not a write gate.
 #[repr(C)]
@@ -95,6 +118,7 @@ pub struct CalibRegs {
     pub winding: CalibWinding,
     pub motor: CalibMotor,
     pub kinematics: CalibKinematics,
+    pub sense_ext: CalibSenseExt,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 96],
+    pub _rsvd_tail: [u8; 84],
 }

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -21,7 +21,9 @@ pub(crate) mod hooks;
 pub mod profile;
 pub mod telemetry;
 
-pub use calib::{CalibKinematics, CalibMotor, CalibRegs, CalibSense, CalibWinding, PotLutBlock};
+pub use calib::{
+    CalibKinematics, CalibMotor, CalibRegs, CalibSense, CalibSenseExt, CalibWinding, PotLutBlock,
+};
 pub use config::{
     BaudRate, ConfigCommon, ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent,
     ConfigLoopPosition, ConfigLoopVelocity, ConfigPosLimits, ConfigRegs, ConfigThermal,
@@ -130,9 +132,12 @@ impl ControlTableCell {
     /// Stamp the RO sense primitives the host converts raw counts with
     /// (protocol sec 5.5) -- board facts, not host-writable state.
     /// Caller must be sole writer (install-time, pre-IRQ).
-    pub fn seed_calib_sense(&self, sense: &CalibSense) {
+    pub fn seed_calib_sense(&self, sense: &CalibSense, ext: &CalibSenseExt) {
         // SAFETY: install-time, pre-IRQ, sole writer.
-        self.with_mut(|t| t.calib.sense = *sense);
+        self.with_mut(|t| {
+            t.calib.sense = *sense;
+            t.calib.sense_ext = *ext;
+        });
     }
 
     /// Stamp the boot-measured zero-current output of the sense chain, in raw
@@ -142,6 +147,15 @@ impl ControlTableCell {
         crate::log::debug!("seed current bias: {} counts", counts);
         // SAFETY: install-time, pre-IRQ, sole writer.
         self.with_mut(|t| t.telemetry.sensors.current_bias_counts = counts);
+    }
+
+    /// Stamp the boot-measured motor-terminal divider bias (both terminals
+    /// high-impedance, driver disabled), in raw ADC counts.
+    /// Caller must be sole writer (install-time, pre-IRQ).
+    pub fn seed_vmotor_bias(&self, counts: u16) {
+        crate::log::debug!("seed vmotor bias: {} counts", counts);
+        // SAFETY: install-time, pre-IRQ, sole writer.
+        self.with_mut(|t| t.telemetry.sensors.vmotor_bias_counts = counts);
     }
 }
 

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -105,6 +105,17 @@ pub struct TelemetrySensors {
     /// Boot-measured zero-current sense-chain output, raw ADC counts.
     #[ct_field(access = ro)]
     pub current_bias_counts: u16,
+    /// Direct supply divider tap, raw ADC counts (the rail `vbus_counts`
+    /// derives from).
+    #[ct_field(access = ro)]
+    pub vbus_raw: u16,
+    /// NTC divider tap, raw ADC counts.
+    #[ct_field(access = ro)]
+    pub ntc_raw: u16,
+    /// Boot-measured motor-terminal divider bias (terminals high-impedance),
+    /// raw ADC counts; the terminal taps read this with the rail at 0.
+    #[ct_field(access = ro)]
+    pub vmotor_bias_counts: u16,
 }
 
 /// Identification aggregates on their own fast-tick /16 window (mean =
@@ -141,5 +152,5 @@ pub struct TelemetryRegs {
     pub sensors: TelemetrySensors,
     pub ident: TelemetryIdent,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 32],
+    pub _rsvd_tail: [u8; 26],
 }

--- a/firmware/lib/core/src/sensor_frame.rs
+++ b/firmware/lib/core/src/sensor_frame.rs
@@ -11,4 +11,6 @@ pub struct SensorFrame {
     pub vmotor_b: u16,
     pub vmotor_b_trough: u16,
     pub vcal: u16,
+    pub vbus_raw: u16,
+    pub ntc_raw: u16,
 }

--- a/firmware/lib/core/src/tel.rs
+++ b/firmware/lib/core/src/tel.rs
@@ -12,7 +12,7 @@
 //!                      2 bytes each; count = payload remainder / sample_len
 
 /// `tel_mask` bits, in canonical sample order. All v1 fields are 2 bytes.
-/// Bits 0..6 predate the raw set; 6..9 are the per-tick ADC frame raw
+/// Bits 0..6 predate the raw set; 6..11 are the per-tick ADC frame raw
 /// values (`current` at bit 1 is the kernel's bias-subtracted held window
 /// sample - a conclusion, streamable for validating against host math).
 pub const BIT_POS: u16 = 1 << 0;
@@ -24,7 +24,9 @@ pub const BIT_VBUS: u16 = 1 << 5;
 pub const BIT_CURRENT_RAW: u16 = 1 << 6;
 pub const BIT_VMOTOR_A: u16 = 1 << 7;
 pub const BIT_VMOTOR_B: u16 = 1 << 8;
-pub const MASK_ALL: u16 = 0x1FF;
+pub const BIT_VBUS_RAW: u16 = 1 << 9;
+pub const BIT_NTC_RAW: u16 = 1 << 10;
+pub const MASK_ALL: u16 = 0x7FF;
 
 /// Wire budget: a 16-sample batch must fit its own tick window at 3 Mbaud,
 /// which caps a sample at 6 fields (12 bytes). `tel_mask`'s table rule and
@@ -54,8 +56,8 @@ pub const fn mask_valid(mask: u16) -> bool {
 }
 
 /// One fast tick's streamable primitives, in device counts. `pos`,
-/// `current_raw`, `current_trough`, `vmotor_a`, `vmotor_b` are the tick's
-/// raw ADC frame; `current` (signed, bias-subtracted, held - the fitter's
+/// `current_raw`, `current_trough`, `vmotor_a`, `vmotor_b`, `vbus_raw`,
+/// `ntc_raw` are the tick's raw ADC frame; `current` (signed, bias-subtracted, held - the fitter's
 /// domain, matching `i_hat_counts`), `vdiff`, and `vbus` are kernel
 /// conclusions, streamable to validate them against host re-derivations.
 /// `window_valid` (this tick's drive window met the sampling floors)
@@ -71,6 +73,8 @@ pub struct TelSample {
     pub current_raw: u16,
     pub vmotor_a: u16,
     pub vmotor_b: u16,
+    pub vbus_raw: u16,
+    pub ntc_raw: u16,
     pub window_valid: bool,
     /// Kernel fault mask nonzero this tick. Travels in the frame's INST
     /// ALERT bit (the fault contract), never in the payload.
@@ -147,6 +151,8 @@ pub fn encode_sample(
     put(BIT_CURRENT_RAW, s.current_raw.to_le_bytes());
     put(BIT_VMOTOR_A, s.vmotor_a.to_le_bytes());
     put(BIT_VMOTOR_B, s.vmotor_b.to_le_bytes());
+    put(BIT_VBUS_RAW, s.vbus_raw.to_le_bytes());
+    put(BIT_NTC_RAW, s.ntc_raw.to_le_bytes());
     n
 }
 
@@ -184,7 +190,7 @@ mod tests {
     use super::*;
 
     /// The pre-raw six fields: the byte-golden mask below pins that adding
-    /// bits 6..9 moved nothing.
+    /// bits 6..11 moved nothing.
     const MASK_SIX: u16 = 0x3F;
     /// The raw-capture default: the ADC frame set plus applied duty.
     const MASK_RAW: u16 =
@@ -197,7 +203,7 @@ mod tests {
         assert_eq!(sample_len(BIT_POS | BIT_DUTY | BIT_VDIFF), 6);
         assert_eq!(sample_len(MASK_SIX), 12);
         assert_eq!(sample_len(MASK_RAW), 12);
-        assert_eq!(sample_len(MASK_ALL), 18);
+        assert_eq!(sample_len(MASK_ALL), 22);
         assert_eq!(STREAM_PAYLOAD_MAX, STREAM_HDR + 16 * SAMPLE_LEN_MAX);
     }
 
@@ -223,7 +229,7 @@ mod tests {
         assert!(mask_valid(
             BIT_VMOTOR_A | BIT_VMOTOR_B | BIT_VDIFF | BIT_VBUS
         ));
-        assert!(!mask_valid(1 << 9));
+        assert!(!mask_valid(1 << 11));
         assert!(!mask_valid(1 << 15));
         // 7+ fields outruns the batch's tick window at 3 Mbaud
         assert!(!mask_valid(MASK_SIX | BIT_CURRENT_RAW));
@@ -250,6 +256,8 @@ mod tests {
             current_raw: 0x0100 + i as u16,
             vmotor_a: 0x0A00 + i as u16,
             vmotor_b: 0x0B00 + i as u16,
+            vbus_raw: 0x0C00 + i as u16,
+            ntc_raw: 0x0D00 + i as u16,
             window_valid: i.is_multiple_of(2),
             // varies across samples; the goldens below pin that it never
             // reaches the payload
@@ -289,6 +297,8 @@ mod tests {
             s.current_raw = take(BIT_CURRENT_RAW);
             s.vmotor_a = take(BIT_VMOTOR_A);
             s.vmotor_b = take(BIT_VMOTOR_B);
+            s.vbus_raw = take(BIT_VBUS_RAW);
+            s.ntc_raw = take(BIT_NTC_RAW);
             out.push(s).unwrap();
         }
         (seq, flags, valid, out)
@@ -378,7 +388,13 @@ mod tests {
 
     #[test]
     fn round_trip_all_masks() {
-        for mask in [MASK_SIX, MASK_RAW, 0x1B, BIT_VBUS | BIT_VMOTOR_A] {
+        for mask in [
+            MASK_SIX,
+            MASK_RAW,
+            0x1B,
+            BIT_VBUS | BIT_VMOTOR_A,
+            BIT_VBUS_RAW | BIT_NTC_RAW | BIT_POS,
+        ] {
             let samples: heapless::Vec<TelSample, 16> = (0..5).map(sample).collect();
             let mut buf = [0u8; STREAM_PAYLOAD_MAX];
             let n = encode_stream(mask, 9, true, &samples, &mut buf);
@@ -403,6 +419,8 @@ mod tests {
                 );
                 assert_eq!(g.vmotor_a as i32, m(BIT_VMOTOR_A, w.vmotor_a as i32));
                 assert_eq!(g.vmotor_b as i32, m(BIT_VMOTOR_B, w.vmotor_b as i32));
+                assert_eq!(g.vbus_raw as i32, m(BIT_VBUS_RAW, w.vbus_raw as i32));
+                assert_eq!(g.ntc_raw as i32, m(BIT_NTC_RAW, w.ntc_raw as i32));
             }
         }
     }

--- a/firmware/lib/integration/src/sim/servo.rs
+++ b/firmware/lib/integration/src/sim/servo.rs
@@ -7,7 +7,8 @@ use std::rc::Rc;
 
 use osc_servo_core::tel::{TelSample, TelStream};
 use osc_servo_core::{
-    BaudRate, BootMode, CalibSense, ConfigDefaults, ControlTable, RegionStorage, Session, Shared,
+    BaudRate, BootMode, CalibSense, CalibSenseExt, ConfigDefaults, ControlTable, RegionStorage,
+    Session, Shared,
 };
 use osc_servo_drivers::bus::{LinkDiag, ServoBus};
 use osc_servo_drivers::tel::{TelChannel, TelFeed};
@@ -58,16 +59,26 @@ impl SimServo {
         // After boot_load, mirroring chip bringup: the calib overlay copies
         // the whole region, so RO board facts land last and win over a
         // stale saved image.
-        shared.table.seed_calib_sense(&CalibSense {
-            shunt_r_mohm: 33,
-            gain_milli: 15000,
-            vmotor_div_top: 10000,
-            vmotor_div_bot: 10000,
-            vdd_mv: 3300,
-            tick_hz: 20000,
-            i_window_min_ticks: 240,
-            v_window_min_ticks: 300,
-        });
+        shared.table.seed_calib_sense(
+            &CalibSense {
+                shunt_r_mohm: 33,
+                gain_milli: 15000,
+                vmotor_div_top: 10000,
+                vmotor_div_bot: 10000,
+                vdd_mv: 3300,
+                tick_hz: 20000,
+                i_window_min_ticks: 240,
+                v_window_min_ticks: 300,
+            },
+            &CalibSenseExt {
+                vbus_div_top_ohm: 20000,
+                vbus_div_bot_ohm: 10000,
+                ntc_pullup_ohm: 10000,
+                ntc_r25_ohm: 10000,
+                ntc_beta: 3950,
+                vmotor_bias_nom_counts: 773,
+            },
+        );
         // Default UID: the id repeated -- distinct per servo, predictable for
         // ENUM tests; override via `seed_uid` where prefix structure matters.
         shared.seed_uid([id; 16]);

--- a/firmware/lib/integration/src/sim/support.rs
+++ b/firmware/lib/integration/src/sim/support.rs
@@ -63,6 +63,8 @@ pub fn tel_sample(i: u32) -> TelSample {
         current_raw: 0x0100u16.wrapping_add(i as u16),
         vmotor_a: 0x0A00u16.wrapping_add(i as u16),
         vmotor_b: 0x0B00u16.wrapping_add(i as u16),
+        vbus_raw: 0x0C00u16.wrapping_add(i as u16),
+        ntc_raw: 0x0D00u16.wrapping_add(i as u16),
         window_valid: i.is_multiple_of(2),
         fault: false,
     }

--- a/firmware/servo-ch32/src/cfg/board_wiring.rs
+++ b/firmware/servo-ch32/src/cfg/board_wiring.rs
@@ -64,6 +64,16 @@ impl CurrentSenseConfig {
 pub struct AdcPins {
     pub pos: AnalogChannel,
     pub vmotor: (AnalogChannel, AnalogChannel),
+    /// Direct supply-rail divider tap.
+    pub vbus: AnalogChannel,
+    /// NTC divider tap.
+    pub ntc: AnalogChannel,
+}
+
+impl AdcPins {
+    const fn all(&self) -> [AnalogChannel; 5] {
+        [self.pos, self.vmotor.0, self.vmotor.1, self.vbus, self.ntc]
+    }
 }
 
 /// `V_adc = V_in * bot_ohm / (top_ohm + bot_ohm)`.
@@ -73,11 +83,25 @@ pub struct Divider {
     pub bot_ohm: u32,
 }
 
+/// NTC to GND under a pull-up to VDD: `V_adc = VDD * R_ntc / (pullup + R_ntc)`.
+#[derive(Copy, Clone)]
+pub struct Ntc {
+    pub pullup_ohm: u32,
+    pub r25_ohm: u32,
+    pub beta: u16,
+}
+
 /// Schematic-derived constants identical across every unit of a PCB design.
 #[derive(Copy, Clone)]
 pub struct Calibration {
     pub shunt_r_mohm: u16,
     pub vmotor_divider: Divider,
+    /// Direct supply-rail divider (`vbus_raw`).
+    pub vbus_divider: Divider,
+    pub ntc: Ntc,
+    /// Nominal bias both motor-terminal dividers return to, ADC counts; the
+    /// fallback when the boot measurement's two taps disagree.
+    pub vmotor_bias_nom_counts: u16,
     /// DMM-measured VDD at the chip pin; the v006 ADC reference is VDD itself.
     pub vdd_mv: u16,
     /// Shortest drive window (TIM1 ticks) with a valid shunt sample.
@@ -106,6 +130,7 @@ impl BoardWiring {
         self.assert_bus_distinct();
         self.assert_current_output_readable();
         self.assert_sensors_distinct();
+        self.assert_sensors_clear_of_opa_inputs();
     }
 
     const fn assert_current_output_readable(&self) {
@@ -130,11 +155,14 @@ impl BoardWiring {
     }
 
     const fn assert_sensors_distinct(&self) {
-        let chs: [AnalogChannel; 4] = [
+        let s = self.sensors.all();
+        let chs: [AnalogChannel; 6] = [
             self.current_sense.current_channel(),
-            self.sensors.pos,
-            self.sensors.vmotor.0,
-            self.sensors.vmotor.1,
+            s[0],
+            s[1],
+            s[2],
+            s[3],
+            s[4],
         ];
         let n = chs.len();
         let mut i = 0;
@@ -145,6 +173,21 @@ impl BoardWiring {
                     panic!("BoardWiring: duplicate sensor AnalogChannel");
                 }
                 j += 1;
+            }
+            i += 1;
+        }
+    }
+
+    /// An OPA input pad (PA2 = A0, PA1 = A1, ...) is the amplifier's, not a
+    /// sensor's: its analog switch would load the divider.
+    const fn assert_sensors_clear_of_opa_inputs(&self) {
+        let (opa_pos, opa_neg, _) = self.current_sense.opa.pins();
+        let s = self.sensors.all();
+        let mut i = 0;
+        while i < s.len() {
+            let pin = s[i].pin() as u8;
+            if pin == opa_pos as u8 || pin == opa_neg as u8 {
+                panic!("BoardWiring: sensor AnalogChannel shares a pin with an OPA input");
             }
             i += 1;
         }

--- a/firmware/servo-ch32/src/cfg/chip.rs
+++ b/firmware/servo-ch32/src/cfg/chip.rs
@@ -18,15 +18,6 @@ pub const BUS_LINE_PIN: Pin = BUS_USART_MAPPING.tx_pin();
 #[cfg(not(feature = "half-duplex"))]
 pub const BUS_LINE_PIN: Pin = BUS_USART_MAPPING.rx_pin();
 
-// === TEL stream (USART2 remap 5, TX-only on PC4) ===
-//
-// PC4 is the TEL pad on rev-2A and the /VNTC net (JP1 center) on rev B --
-// chip-fixed here like the bus mapping. It doubles as ADC A2; boards that
-// wire a sensor to A2 cannot also stream TEL.
-
-pub const TEL_USART_MAPPING: UsartMapping = UsartMapping::Usart2Remap5;
-pub const TEL_BAUD: u32 = 3_000_000;
-
 // === Motor + STAT (TIM1 Remap8) ===
 //
 // Remap8, not Remap7: identical pins for every channel this board uses
@@ -65,11 +56,13 @@ pub const ADC_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
 pub const ADC_SHUNT_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES3;
 
 /// ADC channels available as board-configurable sensor inputs on the V006F8P6.
-/// Excludes A0 (PA2): the pin is reserved for OPA input routing, which is
-/// board wiring, not a sensor slot.
+/// A0 (PA2) doubles as an OPA positive-input route (PSEL=00), so a board
+/// gets it as a sensor only with the amplifier's input elsewhere
+/// (`BoardWiring::assert_valid`).
 #[derive(Copy, Clone)]
 #[repr(u8)]
 pub enum AnalogChannel {
+    A0,
     A1,
     A2,
     A3,
@@ -82,6 +75,7 @@ pub enum AnalogChannel {
 impl AnalogChannel {
     pub const fn channel(self) -> adc::Channel {
         match self {
+            Self::A0 => adc::Channel::IN0,
             Self::A1 => adc::Channel::IN1,
             Self::A2 => adc::Channel::IN2,
             Self::A3 => adc::Channel::IN3,
@@ -94,6 +88,7 @@ impl AnalogChannel {
 
     pub const fn pin(self) -> Pin {
         match self {
+            Self::A0 => Pin::PA2,
             Self::A1 => Pin::PA1,
             Self::A2 => Pin::PC4,
             Self::A3 => Pin::PD2,
@@ -129,6 +124,7 @@ mod tests {
     #[test]
     fn analog_channel_pin_map_matches_v006_silicon() {
         const MAP: &[(AnalogChannel, adc::Channel, Pin)] = &[
+            (AnalogChannel::A0, adc::Channel::IN0, Pin::PA2),
             (AnalogChannel::A1, adc::Channel::IN1, Pin::PA1),
             (AnalogChannel::A2, adc::Channel::IN2, Pin::PC4),
             (AnalogChannel::A3, adc::Channel::IN3, Pin::PD2),

--- a/firmware/servo-ch32/src/cfg/mod.rs
+++ b/firmware/servo-ch32/src/cfg/mod.rs
@@ -3,7 +3,9 @@ pub mod chip;
 
 #[cfg(not(feature = "half-duplex"))]
 pub use board_wiring::BusWiring;
-pub use board_wiring::{AdcPins, BoardWiring, Calibration, CurrentSenseConfig, Divider, DrvEn};
+pub use board_wiring::{
+    AdcPins, BoardWiring, Calibration, CurrentSenseConfig, Divider, DrvEn, Ntc,
+};
 pub use chip::{AnalogChannel, DigitalPin};
 
 use osc_servo_core::estimator::bemf::RECIP_ARR_SHIFT;
@@ -39,6 +41,13 @@ impl Precomputed {
         // Const-eval quotients per the KernelTiming field docs; the divides
         // fold at compile time so no soft-div symbol ever links.
         let med_hz = chip::MOTOR_PWM_FREQ_HZ / DECIM_MED as u32;
+        let (rail, term) = (
+            &cfg.calibration.vbus_divider,
+            &cfg.calibration.vmotor_divider,
+        );
+        let vbus_scale_q15 = ((rail.top_ohm + rail.bot_ohm) as u64 * term.bot_ohm as u64 * 32768
+            / (rail.bot_ohm as u64 * (term.top_ohm + term.bot_ohm) as u64))
+            as u32;
         Self {
             pwm_psc,
             pwm_arr,
@@ -49,6 +58,7 @@ impl Precomputed {
                 tick_hz: chip::MOTOR_PWM_FREQ_HZ as u16,
                 dt_med_q32: ((1u64 << 32) / med_hz as u64) as u32,
                 med_ticks_per_ms_q16: ((med_hz as u64 * 65536) / 1000) as u32,
+                vbus_scale_q15,
             },
         }
     }

--- a/firmware/servo-ch32/src/control/sensors/mod.rs
+++ b/firmware/servo-ch32/src/control/sensors/mod.rs
@@ -10,8 +10,8 @@ use osc_servo_core::{SensorFrame, Sensors as SensorsTrait};
 use crate::runtime::statics::read_sample_tick;
 
 use scan::{
-    SCAN_IDX_POS, SCAN_IDX_SHUNT_POST, SCAN_IDX_VCAL, SCAN_IDX_VMOTOR_A, SCAN_IDX_VMOTOR_B,
-    SCAN_PEAK_OFFSET, SCAN_TROUGH_OFFSET, scan_slot,
+    SCAN_IDX_NTC, SCAN_IDX_POS, SCAN_IDX_SHUNT_POST, SCAN_IDX_VBUS, SCAN_IDX_VCAL,
+    SCAN_IDX_VMOTOR_A, SCAN_IDX_VMOTOR_B, SCAN_PEAK_OFFSET, SCAN_TROUGH_OFFSET, scan_slot,
 };
 
 #[derive(Default)]
@@ -40,6 +40,8 @@ impl SensorsTrait for Ch32Sensors {
             vmotor_b: scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_VMOTOR_B),
             vmotor_b_trough,
             vcal: scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_VCAL),
+            vbus_raw: scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_VBUS),
+            ntc_raw: scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_NTC),
         }
     }
 }

--- a/firmware/servo-ch32/src/control/sensors/scan.rs
+++ b/firmware/servo-ch32/src/control/sensors/scan.rs
@@ -2,18 +2,26 @@
 //! PWM (peak + trough); UG fires TRGO at CNT=0 before CEN=1 so the trough
 //! scan lands at offset 0 and the peak scan lands at `ADC_SCAN_LEN`. Slot
 //! indices within a scan reflect the configured RSQR sequence.
+//!
+//! Budget at ADCCLK 12 MHz (TCONV = sampling + 12.5, RM sec 9.3): a scan is
+//! 6 x 21.5 + 15.5 = 144.5 cycles = 12.0 us. The peak scan's TC lands 12 us
+//! after its trigger and the trough trigger follows 25 us after it, so the
+//! TC ISR has ~14 us to drain the trough slots before slot 0 is rewritten;
+//! the peak slots stand until the next peak trigger.
 
 use core::cell::SyncUnsafeCell;
 
-/// In `AdcPins` field order: pos, vmotor.0, vmotor.1.
-pub(crate) const ADC_SENSOR_COUNT: usize = 3;
+/// In `AdcPins` field order: pos, vmotor.0, vmotor.1, vbus, ntc.
+pub(crate) const ADC_SENSOR_COUNT: usize = 5;
 
 /// Slot 0 is the current-sense amplifier output, read on whichever external
 /// channel the board routes the OPA output to; then both motor terminals
-/// (drive-window-critical, so they convert early), then pos, then Vcal.
-/// On osc-dev-v006 that is
-/// `[IN7/PD4 current, IN5/PD5 vmA, IN6/PD6 vmB, IN3/PD2 pos, IN10/Vcal]`.
-pub(crate) const ADC_SCAN_LEN: usize = 5;
+/// (drive-window-critical, so they convert early), then pos, then Vcal,
+/// then the slow board taps (rail, NTC) appended last so the bench-validated
+/// terminal window floors keep their meaning. On osc-dev-v006 that is
+/// `[IN7/PD4 current, IN5/PD5 vmA, IN6/PD6 vmB, IN3/PD2 pos, IN10/Vcal,
+/// IN0/PA2 vbus, IN2/PC4 ntc]`.
+pub(crate) const ADC_SCAN_LEN: usize = 7;
 
 /// Two scans per PWM period (peak + trough under center-aligned PWM, RCR=0).
 pub(crate) const ADC_DMA_BUF_LEN: usize = ADC_SCAN_LEN * 2;
@@ -29,6 +37,8 @@ pub(super) const SCAN_IDX_VMOTOR_A: usize = 1;
 pub(super) const SCAN_IDX_VMOTOR_B: usize = 2;
 pub(super) const SCAN_IDX_POS: usize = 3;
 pub(super) const SCAN_IDX_VCAL: usize = 4;
+pub(super) const SCAN_IDX_VBUS: usize = 5;
+pub(super) const SCAN_IDX_NTC: usize = 6;
 
 /// Read trough slots before peak; DMA overwrites trough first after TC.
 #[inline(always)]

--- a/firmware/servo-ch32/src/prelude.rs
+++ b/firmware/servo-ch32/src/prelude.rs
@@ -4,7 +4,7 @@ pub use osc_servo_drivers::Level;
 pub use crate::cfg::BusWiring;
 pub use crate::cfg::{
     AdcPins, AnalogChannel, BoardConfig, BoardWiring, Calibration, CurrentSenseConfig, DigitalPin,
-    Divider, DrvEn,
+    Divider, DrvEn, Ntc,
 };
 pub use crate::hal::{Pin, opa};
 pub use crate::{BaudRate, ConfigDefaults};

--- a/firmware/servo-ch32/src/runtime/init.rs
+++ b/firmware/servo-ch32/src/runtime/init.rs
@@ -1,5 +1,5 @@
 use ch32_metapac::{ADC, adc::vals::Extsel, dma::vals::Dir};
-use osc_servo_core::{CalibSense, ConfigDefaults};
+use osc_servo_core::{CalibSense, CalibSenseExt, ConfigDefaults};
 #[cfg(not(feature = "half-duplex"))]
 use osc_servo_drivers::Level;
 
@@ -24,8 +24,13 @@ const VCAL_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
 
 /// Boot bias averaging: a power-of-two count so the mean is a shift, never a
 /// divide (the linker must stay free of __udivsi3).
-const CURRENT_BIAS_SHIFT: u32 = 4;
-const CURRENT_BIAS_SAMPLES: u32 = 1 << CURRENT_BIAS_SHIFT;
+const BIAS_SHIFT: u32 = 4;
+const BIAS_SAMPLES: u32 = 1 << BIAS_SHIFT;
+
+/// Both terminal taps sit at the same bias with the driver parked; a wider
+/// split means a tap is not at rest (or a leg is missing) and the nominal
+/// stands in.
+const VMOTOR_BIAS_AGREE_COUNTS: u16 = 64;
 
 pub fn bringup(
     wiring: &BoardWiring,
@@ -50,19 +55,25 @@ pub fn bringup(
     // After boot_load: the calib overlay copies the whole region, so the RO
     // board facts (tick_hz, window floors) must land last to win over a
     // stale saved image.
-    SHARED
-        .table
-        .seed_calib_sense(&calib_sense(wiring, calibration));
+    SHARED.table.seed_calib_sense(
+        &calib_sense(wiring, calibration),
+        &calib_sense_ext(calibration),
+    );
     SHARED.seed_uid(esig::uid());
 
     bring_up_analog_chain(&wiring.current_sense);
     crate::log::debug!("opa settled");
 
     // Bridge is quiet here: PWM starts at the end of bringup and DRV_EN was
-    // parked inactive in `configure_pins`, so the shunt carries no current.
+    // parked inactive in `configure_pins`, so the shunt carries no current
+    // and both motor terminals float at the divider bias.
     SHARED
         .table
         .seed_current_bias(measure_current_bias(&wiring.current_sense));
+    SHARED.table.seed_vmotor_bias(measure_vmotor_bias(
+        &wiring.sensors,
+        calibration.vmotor_bias_nom_counts,
+    ));
 
     // SysTick drives both `Monotonic` (LED blinker) and the transport
     // deadline compare. Initialize *after* `bring_up_analog_chain` because
@@ -116,9 +127,20 @@ fn calib_sense(wiring: &BoardWiring, cal: &Calibration) -> CalibSense {
     }
 }
 
-// Order must mirror the scan tail in `configure_adc_dma_scan`.
+fn calib_sense_ext(cal: &Calibration) -> CalibSenseExt {
+    CalibSenseExt {
+        vbus_div_top_ohm: cal.vbus_divider.top_ohm.min(u16::MAX as u32) as u16,
+        vbus_div_bot_ohm: cal.vbus_divider.bot_ohm.min(u16::MAX as u32) as u16,
+        ntc_pullup_ohm: cal.ntc.pullup_ohm.min(u16::MAX as u32) as u16,
+        ntc_r25_ohm: cal.ntc.r25_ohm.min(u16::MAX as u32) as u16,
+        ntc_beta: cal.ntc.beta,
+        vmotor_bias_nom_counts: cal.vmotor_bias_nom_counts,
+    }
+}
+
+// Order mirrors the scan tail in `configure_adc_dma_scan` (Vcal aside).
 fn sensor_channels(s: &AdcPins) -> [AnalogChannel; ADC_SENSOR_COUNT] {
-    [s.vmotor.0, s.vmotor.1, s.pos]
+    [s.vmotor.0, s.vmotor.1, s.pos, s.vbus, s.ntc]
 }
 
 fn enable_clocks_and_remaps(w: &BoardWiring) {
@@ -210,13 +232,13 @@ fn bring_up_analog_chain(cs: &CurrentSenseConfig) {
     delay_ms(OPA_SETTLE_MS);
 }
 
-/// Zero-current output of the sense chain, averaged over
-/// `CURRENT_BIAS_SAMPLES` polled conversions. Leaves the ADC powered down so
-/// `configure_adc_dma_scan` still sees the off->on ADON transition it needs;
-/// every other register it touches is rewritten there.
-fn measure_current_bias(cs: &CurrentSenseConfig) -> u16 {
-    let ch = cs.current_channel().channel();
-    adc::set_sample_time(ch, chip::ADC_SHUNT_SAMPLE_TIME);
+/// `BIAS_SAMPLES` polled conversions of `ch`, averaged; `None` when EOC
+/// never arrives (a converter that never signals must not stall bringup).
+/// Leaves the ADC powered down so `configure_adc_dma_scan` still sees the
+/// off->on ADON transition it needs; every other register it touches is
+/// rewritten there.
+fn measure_rest(ch: adc::Channel, t: adc::SampleTime) -> Option<u16> {
+    adc::set_sample_time(ch, t);
     adc::set_low_power(false);
     adc::set_scan_mode(false);
     adc::set_dma(false);
@@ -227,7 +249,7 @@ fn measure_current_bias(cs: &CurrentSenseConfig) -> u16 {
 
     let mut sum: u32 = 0;
     let mut taken: u32 = 0;
-    while taken < CURRENT_BIAS_SAMPLES {
+    while taken < BIAS_SAMPLES {
         let Some(counts) = adc::convert_once(ch) else {
             break;
         };
@@ -236,13 +258,34 @@ fn measure_current_bias(cs: &CurrentSenseConfig) -> u16 {
     }
     adc::disable();
 
-    if taken == CURRENT_BIAS_SAMPLES {
-        (sum >> CURRENT_BIAS_SHIFT) as u16
+    if taken == BIAS_SAMPLES {
+        Some((sum >> BIAS_SHIFT) as u16)
     } else {
-        // SAFETY: a converter that never signals EOC must not stall bringup.
-        // Zero bias leaves current reading uncorrected rather than wrong.
-        crate::log::debug!("current bias: adc timeout after {} samples", taken);
-        0
+        crate::log::debug!("rest measure: adc timeout after {} samples", taken);
+        None
+    }
+}
+
+/// Zero-current output of the sense chain. Zero on timeout leaves current
+/// uncorrected rather than wrong.
+fn measure_current_bias(cs: &CurrentSenseConfig) -> u16 {
+    measure_rest(cs.current_channel().channel(), chip::ADC_SHUNT_SAMPLE_TIME).unwrap_or(0)
+}
+
+/// Terminal-divider bias: with the driver parked both terminals float, so
+/// each tap reads the bias directly. The taps must agree within
+/// `VMOTOR_BIAS_AGREE_COUNTS`, else the board nominal stands in.
+fn measure_vmotor_bias(s: &AdcPins, nominal: u16) -> u16 {
+    let a = measure_rest(s.vmotor.0.channel(), chip::ADC_SAMPLE_TIME);
+    let b = measure_rest(s.vmotor.1.channel(), chip::ADC_SAMPLE_TIME);
+    match (a, b) {
+        (Some(a), Some(b)) if a.abs_diff(b) <= VMOTOR_BIAS_AGREE_COUNTS => {
+            ((a as u32 + b as u32) >> 1) as u16
+        }
+        _ => {
+            crate::log::debug!("vmotor bias: taps disagree, nominal {}", nominal);
+            nominal
+        }
     }
 }
 
@@ -255,6 +298,8 @@ fn configure_adc_dma_scan(w: &BoardWiring) {
     adc::set_sample_time(sensors.vmotor.0.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.vmotor.1.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(adc::Channel::Vcal, VCAL_SAMPLE_TIME);
+    adc::set_sample_time(sensors.vbus.channel(), chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(sensors.ntc.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_low_power(false);
 
     let seq = [
@@ -263,6 +308,8 @@ fn configure_adc_dma_scan(w: &BoardWiring) {
         sensors.vmotor.1.channel(),
         sensors.pos.channel(),
         adc::Channel::Vcal,
+        sensors.vbus.channel(),
+        sensors.ntc.channel(),
     ];
     adc::set_sequence(&seq);
     adc::set_scan_mode(true);

--- a/ident/src/exp/testkit.rs
+++ b/ident/src/exp/testkit.rs
@@ -242,6 +242,8 @@ impl FakeServo {
                 } else {
                     0
                 }),
+                vbus_raw: sel(1 << 9).then_some(self.vbus as u16),
+                ntc_raw: sel(1 << 10).then_some(2048),
             });
         }
         self.t_ms += samples as f64 * dt * 1000.0;

--- a/ident/src/frame.rs
+++ b/ident/src/frame.rs
@@ -113,7 +113,9 @@ pub const TEL_BIT_VBUS: u16 = 1 << 5;
 pub const TEL_BIT_CURRENT_RAW: u16 = 1 << 6;
 pub const TEL_BIT_VMOTOR_A: u16 = 1 << 7;
 pub const TEL_BIT_VMOTOR_B: u16 = 1 << 8;
-pub const TEL_MASK_ALL: u16 = 0x1FF;
+pub const TEL_BIT_VBUS_RAW: u16 = 1 << 9;
+pub const TEL_BIT_NTC_RAW: u16 = 1 << 10;
+pub const TEL_MASK_ALL: u16 = 0x7FF;
 
 /// Wire budget mirror: at most 6 selected fields sustain 20 kHz at 3 Mbaud.
 pub const TEL_FIELDS_MAX: u32 = 6;
@@ -151,6 +153,8 @@ pub struct TelFrame {
     pub current_raw: Option<u16>,
     pub vmotor_a: Option<u16>,
     pub vmotor_b: Option<u16>,
+    pub vbus_raw: Option<u16>,
+    pub ntc_raw: Option<u16>,
 }
 
 /// Decode one stream payload into per-tick frames; sample i lands at
@@ -193,6 +197,8 @@ pub fn decode_stream_payload(mask: u16, payload: &[u8], tick_base: u64) -> Optio
             current_raw: take(TEL_BIT_CURRENT_RAW).map(u16::from_le_bytes),
             vmotor_a: take(TEL_BIT_VMOTOR_A).map(u16::from_le_bytes),
             vmotor_b: take(TEL_BIT_VMOTOR_B).map(u16::from_le_bytes),
+            vbus_raw: take(TEL_BIT_VBUS_RAW).map(u16::from_le_bytes),
+            ntc_raw: take(TEL_BIT_NTC_RAW).map(u16::from_le_bytes),
         });
     }
     Some(out)
@@ -269,10 +275,10 @@ mod tests {
     use super::*;
     use crate::regs::telemetry as t;
 
-    /// Mirror of the core tel.rs test vector generator: sample(i) with all
-    /// six fields, window_valid on even i.
+    /// Mirror of the core tel.rs test vector generator: sample(i) with every
+    /// field, window_valid on even i.
     fn sample_bytes(mask: u16, i: u16) -> Vec<u8> {
-        let fields: [(u16, u16); 9] = [
+        let fields: [(u16, u16); 11] = [
             (TEL_BIT_POS, 0x1000 + i),
             (TEL_BIT_CURRENT, (-(i as i16) - 1) as u16),
             (TEL_BIT_CURRENT_TROUGH, 0xB000 + i),
@@ -282,6 +288,8 @@ mod tests {
             (TEL_BIT_CURRENT_RAW, 0x0100 + i),
             (TEL_BIT_VMOTOR_A, 0x0A00 + i),
             (TEL_BIT_VMOTOR_B, 0x0B00 + i),
+            (TEL_BIT_VBUS_RAW, 0x0C00 + i),
+            (TEL_BIT_NTC_RAW, 0x0D00 + i),
         ];
         let mut out = Vec::new();
         for (bit, v) in fields {
@@ -436,9 +444,10 @@ mod tests {
     #[test]
     fn assembler_rejects_bad_masks() {
         assert!(StreamAssembler::new(0).is_none());
-        assert!(StreamAssembler::new(1 << 9).is_none());
-        // all nine fields blows the wire budget; six is the cap
+        assert!(StreamAssembler::new(1 << 11).is_none());
+        // every field blows the wire budget; six is the cap
         assert!(StreamAssembler::new(TEL_MASK_ALL).is_none());
+        assert!(StreamAssembler::new(TEL_BIT_VBUS_RAW | TEL_BIT_NTC_RAW).is_some());
         assert!(StreamAssembler::new(0x3F).is_some());
         assert!(StreamAssembler::new(TEL_MASK_RAW).is_some());
     }
@@ -455,7 +464,7 @@ mod tests {
     #[test]
     fn telemetry_snapshot_parses_a_synthetic_region() {
         let base = 0x0200u16;
-        let mut bytes = vec![0u8; 0x60];
+        let mut bytes = vec![0u8; 0x66];
         let put = |b: &mut [u8], r: crate::regs::Reg, v: &[u8]| {
             let off = (r.addr - base) as usize;
             b[off..off + v.len()].copy_from_slice(v);

--- a/ident/src/regs.rs
+++ b/ident/src/regs.rs
@@ -68,6 +68,12 @@ pub mod calib {
     pub const ANGLE_MIN_CDEG: Reg = reg(0x011a, 2);
     pub const ANGLE_MAX_CDEG: Reg = reg(0x011c, 2);
     pub const GEAR_RATIO_CENTI: Reg = reg(0x011e, 2);
+    pub const VBUS_DIV_TOP_OHM: Reg = reg(0x0120, 2);
+    pub const VBUS_DIV_BOT_OHM: Reg = reg(0x0122, 2);
+    pub const NTC_PULLUP_OHM: Reg = reg(0x0124, 2);
+    pub const NTC_R25_OHM: Reg = reg(0x0126, 2);
+    pub const NTC_BETA: Reg = reg(0x0128, 2);
+    pub const VMOTOR_BIAS_NOM_COUNTS: Reg = reg(0x012a, 2);
 }
 
 pub mod control {
@@ -105,12 +111,15 @@ pub mod telemetry {
     pub const CURRENT: Reg = reg(0x0242, 2);
     pub const CURRENT_TROUGH: Reg = reg(0x0250, 2);
     pub const CURRENT_BIAS_COUNTS: Reg = reg(0x0252, 2);
-    pub const I_MEAN_COUNTS: Reg = reg(0x0254, 2);
-    pub const I_MIN_COUNTS: Reg = reg(0x0256, 2);
-    pub const I_MAX_COUNTS: Reg = reg(0x0258, 2);
-    pub const VDIFF_MEAN: Reg = reg(0x025a, 2);
-    pub const DUTY_MEAN_Q15: Reg = reg(0x025c, 2);
-    pub const AGG_SEQ: Reg = reg(0x025e, 2);
+    pub const VBUS_RAW: Reg = reg(0x0254, 2);
+    pub const NTC_RAW: Reg = reg(0x0256, 2);
+    pub const VMOTOR_BIAS_COUNTS: Reg = reg(0x0258, 2);
+    pub const I_MEAN_COUNTS: Reg = reg(0x025a, 2);
+    pub const I_MIN_COUNTS: Reg = reg(0x025c, 2);
+    pub const I_MAX_COUNTS: Reg = reg(0x025e, 2);
+    pub const VDIFF_MEAN: Reg = reg(0x0260, 2);
+    pub const DUTY_MEAN_Q15: Reg = reg(0x0262, 2);
+    pub const AGG_SEQ: Reg = reg(0x0264, 2);
 }
 
 /// Every const above with its descriptor field name - the cross-check
@@ -162,6 +171,12 @@ pub const ALL: &[(&str, Reg)] = &[
     ("angle_min_cdeg", calib::ANGLE_MIN_CDEG),
     ("angle_max_cdeg", calib::ANGLE_MAX_CDEG),
     ("gear_ratio_centi", calib::GEAR_RATIO_CENTI),
+    ("vbus_div_top_ohm", calib::VBUS_DIV_TOP_OHM),
+    ("vbus_div_bot_ohm", calib::VBUS_DIV_BOT_OHM),
+    ("ntc_pullup_ohm", calib::NTC_PULLUP_OHM),
+    ("ntc_r25_ohm", calib::NTC_R25_OHM),
+    ("ntc_beta", calib::NTC_BETA),
+    ("vmotor_bias_nom_counts", calib::VMOTOR_BIAS_NOM_COUNTS),
     ("torque_enable", control::TORQUE_ENABLE),
     ("tel_mask", control::TEL_MASK),
     ("mode", control::MODE),
@@ -189,6 +204,9 @@ pub const ALL: &[(&str, Reg)] = &[
     ("current", telemetry::CURRENT),
     ("current_trough", telemetry::CURRENT_TROUGH),
     ("current_bias_counts", telemetry::CURRENT_BIAS_COUNTS),
+    ("vbus_raw", telemetry::VBUS_RAW),
+    ("ntc_raw", telemetry::NTC_RAW),
+    ("vmotor_bias_counts", telemetry::VMOTOR_BIAS_COUNTS),
     ("i_mean_counts", telemetry::I_MEAN_COUNTS),
     ("i_min_counts", telemetry::I_MIN_COUNTS),
     ("i_max_counts", telemetry::I_MAX_COUNTS),

--- a/tools/osc/src/rig/csvio.rs
+++ b/tools/osc/src/rig/csvio.rs
@@ -92,13 +92,13 @@ pub(crate) fn write_tel_frames(dir: &OutDir, name: &str, frames: &[TelFrame]) ->
     let mut w = dir.file(name)?;
     writeln!(
         w,
-        "tick,window_valid,pos,current,current_trough,duty_q15,vdiff,vbus,current_raw,vmotor_a,vmotor_b"
+        "tick,window_valid,pos,current,current_trough,duty_q15,vdiff,vbus,current_raw,vmotor_a,vmotor_b,vbus_raw,ntc_raw"
     )?;
     let opt = |v: Option<i32>| v.map(|v| v.to_string()).unwrap_or_default();
     for f in frames {
         writeln!(
             w,
-            "{},{},{},{},{},{},{},{},{},{},{}",
+            "{},{},{},{},{},{},{},{},{},{},{},{},{}",
             f.tick,
             f.window_valid as u8,
             opt(f.pos.map(|v| v as i32)),
@@ -110,6 +110,8 @@ pub(crate) fn write_tel_frames(dir: &OutDir, name: &str, frames: &[TelFrame]) ->
             opt(f.current_raw.map(|v| v as i32)),
             opt(f.vmotor_a.map(|v| v as i32)),
             opt(f.vmotor_b.map(|v| v as i32)),
+            opt(f.vbus_raw.map(|v| v as i32)),
+            opt(f.ntc_raw.map(|v| v as i32)),
         )?;
     }
     Ok(())
@@ -129,7 +131,7 @@ pub(crate) fn read_tel_frames(path: &Path) -> Result<Vec<TelFrame>> {
         }
     }
     let mut out = Vec::new();
-    for parts in rows(path, 11)? {
+    for parts in rows(path, 13)? {
         out.push(TelFrame {
             tick: parts[0].parse()?,
             window_valid: parts[1] == "1",
@@ -142,6 +144,8 @@ pub(crate) fn read_tel_frames(path: &Path) -> Result<Vec<TelFrame>> {
             current_raw: opt(&parts[8])?,
             vmotor_a: opt(&parts[9])?,
             vmotor_b: opt(&parts[10])?,
+            vbus_raw: opt(&parts[11])?,
+            ntc_raw: opt(&parts[12])?,
         });
     }
     Ok(out)
@@ -325,6 +329,8 @@ mod tests {
                 current_raw: Some(620),
                 vmotor_a: Some(1710),
                 vmotor_b: Some(12),
+                vbus_raw: Some(2290),
+                ntc_raw: None,
             },
             TelFrame {
                 tick: 17,
@@ -338,6 +344,8 @@ mod tests {
                 current_raw: None,
                 vmotor_a: None,
                 vmotor_b: Some(3),
+                vbus_raw: None,
+                ntc_raw: Some(2050),
             },
         ];
         write_tel_frames(&dir, "tel.csv", &frames).unwrap();

--- a/tools/osc/src/rig/pump.rs
+++ b/tools/osc/src/rig/pump.rs
@@ -317,8 +317,8 @@ mod tests {
     #[test]
     fn telemetry_span_covers_the_ident_block() {
         assert_eq!(TEL_BASE, 0x200);
-        assert_eq!(TEL_LEN, 0x60);
-        assert_eq!(IDENT_BASE, 0x254);
+        assert_eq!(TEL_LEN, 0x66);
+        assert_eq!(IDENT_BASE, 0x25a);
         assert_eq!(IDENT_LEN, 12);
     }
 

--- a/tools/osc/src/sweep.rs
+++ b/tools/osc/src/sweep.rs
@@ -269,7 +269,7 @@ fn write_rows(
     for f in frames {
         writeln!(
             w,
-            "{seg},{cmd_duty_q15},{dir},{},{},{},{},{},{},{},{},{},{},{}",
+            "{seg},{cmd_duty_q15},{dir},{},{},{},{},{},{},{},{},{},{},{},{},{}",
             f.tick,
             f.window_valid as u8,
             opt(f.pos.map(|v| v as i32)),
@@ -281,6 +281,8 @@ fn write_rows(
             opt(f.current_raw.map(|v| v as i32)),
             opt(f.vmotor_a.map(|v| v as i32)),
             opt(f.vmotor_b.map(|v| v as i32)),
+            opt(f.vbus_raw.map(|v| v as i32)),
+            opt(f.ntc_raw.map(|v| v as i32)),
         )?;
     }
     Ok(())
@@ -363,7 +365,7 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
     );
     writeln!(
         w,
-        "seg,cmd_duty_q15,dir,tick,window_valid,pos,current,current_trough,duty_q15,vdiff,vbus,current_raw,vmotor_a,vmotor_b"
+        "seg,cmd_duty_q15,dir,tick,window_valid,pos,current,current_trough,duty_q15,vdiff,vbus,current_raw,vmotor_a,vmotor_b,vbus_raw,ntc_raw"
     )?;
 
     let seek_duty = pct_q15(args.seek_duty_pct);


### PR DESCRIPTION
- ADC scan grows to 7 slots: PA2/A0 supply-sense divider and PC4/A2 NTC appended after vcal; SensorFrame, telemetry (vbus_raw, ntc_raw, vmotor_bias_counts) and TEL bits 9/10 carry them raw
- vbus estimator fed from the direct channel through a board-data scale; the driven-terminal EWMA path and its unseeded boot state are gone; undervolt compares the live rail
- terminal-divider bias (dividers now return to a 0.62 V bias) measured at boot from the taps at rest
- CalibSense gains an RO extension block in reserved space (vbus divider, NTC constants, nominal bias); calib image version unchanged
- descriptor, ident register constants and the sweep CSV follow