### PR TITLE
board: osc-dev-v006 board d supply divider as fitted, 15k over 10k

### DIFF
--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -51,9 +51,9 @@ fn main() -> ! {
                 top_ohm: 20_000,
                 bot_ohm: 10_000,
             },
-            // Board D bodge; rev-2A lands 20_000/10_000.
+            // Board D bodge as fitted (15k/10k); rev-2A lands 20_000/10_000.
             vbus_divider: Divider {
-                top_ohm: 22_000,
+                top_ohm: 15_000,
                 bot_ohm: 10_000,
             },
             ntc: Ntc {


### PR DESCRIPTION
- vbus_divider 22k/10k -> 15k/10k to match the resistor actually fitted on the bench board; rev-2A stays 20k/10k