### PR TITLE
fw: adc at 24 MHz in low-power mode, current defaults from board sense constants

### DIFF
--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -67,10 +67,11 @@ fn main() -> ! {
             // Scan order is [shunt, vmA, vmB, pos, vcal, vbus, ntc]. The i floor is
             // amp-settling-bound: arm-B network measured true from duty 13%
             // (bringup docs/armb-comp-sizing.md). The v floor covers
-            // vmotor_b's S/H close ~182 ticks after the crest trigger plus
-            // margin; a v floor below the true edge lets off-phase samples
-            // seed the vbus EWMA and latch a false undervolt. Both floors
-            // pending bench re-validation on the new order.
+            // vmotor_b's S/H close ~131 ticks (2.7 us) after the crest
+            // trigger plus margin; a v floor below the true edge lets
+            // off-phase samples seed the vbus EWMA and latch a false
+            // undervolt. Both floors pending bench re-validation at the new
+            // ADC clock.
             i_window_min_ticks: 160,
             v_window_min_ticks: 210,
         },

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -29,7 +29,8 @@ fn main() -> ! {
             #[cfg(not(feature = "half-duplex"))]
             bus: BusWiring { tx_en: Pin::PC2 },
             // Rev B arm-B bodge: bare OPA closed by an external 1k/15k
-            // network (G = 15.0) off a 33 mohm shunt.
+            // network (G = 15.0) off a 60 mohm 1206 shunt: 0.9 V/A, 0.9 mA
+            // per count.
             current_sense: CurrentSenseConfig {
                 opa: opa::Config {
                     pos: opa::PositiveInput::PD3,
@@ -46,7 +47,7 @@ fn main() -> ! {
             },
         },
         calibration: Calibration {
-            shunt_r_mohm: 33,
+            shunt_r_mohm: 60,
             vmotor_divider: Divider {
                 top_ohm: 20_000,
                 bot_ohm: 10_000,

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -25,7 +25,7 @@ pub use control_table::{
 };
 pub use kernel::{Kernel, KernelTiming};
 pub use persist::{ConfigStore, StoreError};
-pub use regions::config::{BaudRate, ConfigDefaults};
+pub use regions::config::{BaudRate, ConfigDefaults, CurrentDefaults};
 pub use regions::{
     BootMode, CalibKinematics, CalibMotor, CalibRegs, CalibSense, CalibSenseExt, CalibWinding,
     ConfigCommon, ConfigFaultCfg, ConfigFusion, ConfigLimits, ConfigLoopCurrent,

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -357,7 +357,7 @@ pub fn boot_overlay_calib(table: &ControlTableCell, slot_a: &[u8], slot_b: &[u8]
 mod tests {
     use super::*;
     use crate::regions::config::addr;
-    use crate::{ConfigDefaults, RegionStorage};
+    use crate::{ConfigDefaults, CurrentDefaults, RegionStorage};
 
     /// A plausible table snapshot: pattern data in rule-free fields, valid
     /// (zero) bytes in every enum/bool field.
@@ -419,10 +419,13 @@ mod tests {
 
     fn seeded_table() -> crate::ControlTableCell {
         let table = crate::ControlTableCell::new();
-        table.seed_config_defaults(&ConfigDefaults {
-            id: 1,
-            ..Default::default()
-        });
+        table.seed_config_defaults(
+            &ConfigDefaults {
+                id: 1,
+                ..Default::default()
+            },
+            &CurrentDefaults::from_sense(33, 15_000, 3300),
+        );
         table
     }
 

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -151,15 +151,19 @@ pub struct ConfigLimits {
 }
 
 // Permissive-safe SG90-class limits: core-owned policy seeded at boot,
-// host-tunable per rig.
-pub const DEFAULT_CURRENT_LIMIT_COUNTS: u16 = 1200;
+// host-tunable per rig. Current thresholds are physical (mA) and reach the
+// table in counts through `CurrentDefaults::from_sense`.
+pub const DEFAULT_CURRENT_LIMIT_MA: u16 = 1953;
 pub const DEFAULT_DRIVE_POLARITY: bool = true;
 pub const DEFAULT_STALL_OMEGA_MAX_CPS: u16 = 500;
 pub const DEFAULT_STALL_TIME_MS: u16 = 500;
-pub const DEFAULT_STALL_YIELD_COUNTS: u16 = 300;
-pub const DEFAULT_STALL_RELEASE_COUNTS: u16 = 150;
-pub const DEFAULT_STALL_TAU_TRIP_COUNTS: u16 = 1200;
-pub const DEFAULT_OC_TRIP_COUNTS: u16 = 2400;
+pub const DEFAULT_STALL_YIELD_MA: u16 = 488;
+pub const DEFAULT_STALL_RELEASE_MA: u16 = 244;
+pub const DEFAULT_STALL_TAU_TRIP_MA: u16 = 1953;
+// 3.0 A sits above any SG90-class stall on 2S (2.1 A) and below the
+// arm-B chain's saturation on a 60 mOhm shunt (~3.4 A), so the trip stays
+// measurable on both rig shunts.
+pub const DEFAULT_OC_TRIP_MA: u16 = 3000;
 pub const DEFAULT_OC_TRIP_TICKS: u8 = 8;
 
 /// Thermal derate/cutoff, undervolt floor, winding-R estimator gates.
@@ -186,7 +190,7 @@ pub const DEFAULT_RECOVER_CC: i16 = 9000;
 // move on a factory-fresh board. Pack-health thresholds are per-product
 // tuning, written by the host.
 pub const DEFAULT_V_UNDERVOLT_COUNTS: u16 = 1200;
-pub const DEFAULT_RTHERM_I_MIN_COUNTS: u16 = 300;
+pub const DEFAULT_RTHERM_I_MIN_MA: u16 = 488;
 pub const DEFAULT_RTHERM_OMEGA_MAX_CPS: u16 = 400;
 
 /// Fusion observer correction gains; l_bemf 0 = bemf blend off.
@@ -249,4 +253,96 @@ pub struct ConfigDefaults {
     pub id: u8,
     pub baud: BaudRate,
     pub response_deadline_us: u16,
+}
+
+/// Count-domain seeds for the current thresholds: the `DEFAULT_*_MA` policy
+/// scaled through the board's sense chain (`CalibSense` inputs). Const-eval
+/// only; the chip has no divide.
+#[derive(Copy, Clone, Debug)]
+pub struct CurrentDefaults {
+    pub current_limit_counts: u16,
+    pub stall_yield_counts: u16,
+    pub stall_release_counts: u16,
+    pub stall_tau_trip_counts: u16,
+    pub oc_trip_counts: u16,
+    pub rtherm_i_min_counts: u16,
+}
+
+impl CurrentDefaults {
+    pub const fn from_sense(shunt_r_mohm: u16, gain_milli: u16, vdd_mv: u16) -> Self {
+        Self {
+            current_limit_counts: current_counts(
+                DEFAULT_CURRENT_LIMIT_MA,
+                shunt_r_mohm,
+                gain_milli,
+                vdd_mv,
+            ),
+            stall_yield_counts: current_counts(
+                DEFAULT_STALL_YIELD_MA,
+                shunt_r_mohm,
+                gain_milli,
+                vdd_mv,
+            ),
+            stall_release_counts: current_counts(
+                DEFAULT_STALL_RELEASE_MA,
+                shunt_r_mohm,
+                gain_milli,
+                vdd_mv,
+            ),
+            stall_tau_trip_counts: current_counts(
+                DEFAULT_STALL_TAU_TRIP_MA,
+                shunt_r_mohm,
+                gain_milli,
+                vdd_mv,
+            ),
+            oc_trip_counts: current_counts(DEFAULT_OC_TRIP_MA, shunt_r_mohm, gain_milli, vdd_mv),
+            rtherm_i_min_counts: current_counts(
+                DEFAULT_RTHERM_I_MIN_MA,
+                shunt_r_mohm,
+                gain_milli,
+                vdd_mv,
+            ),
+        }
+    }
+}
+
+const ADC_COUNTS_PER_VDD: u64 = 4096;
+
+/// counts = mA x gain x R_shunt x 4096 / VDD, rounded: the chain puts
+/// gain x R_shunt volts per amp onto a VDD-referenced 12-bit ADC. The arm-B
+/// rig (33 mOhm, G 15.000, 3300 mV) is 614.4 counts/A, where the mA defaults
+/// round back onto the seeds they replaced: 1953 -> 1200, 488 -> 300,
+/// 244 -> 150; the OC trip was lowered from 2400 counts (3.9 A) to 3.0 A.
+pub const fn current_counts(ma: u16, shunt_r_mohm: u16, gain_milli: u16, vdd_mv: u16) -> u16 {
+    let num = ma as u64 * gain_milli as u64 * shunt_r_mohm as u64 * ADC_COUNTS_PER_VDD;
+    let den = vdd_mv as u64 * 1_000_000;
+    let counts = (num + den / 2) / den;
+    if counts > u16::MAX as u64 {
+        u16::MAX
+    } else {
+        counts as u16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arm_b_rig_reproduces_the_count_seeds() {
+        let d = CurrentDefaults::from_sense(33, 15_000, 3300);
+        assert_eq!(d.current_limit_counts, 1200);
+        assert_eq!(d.stall_yield_counts, 300);
+        assert_eq!(d.stall_release_counts, 150);
+        assert_eq!(d.stall_tau_trip_counts, 1200);
+        assert_eq!(d.oc_trip_counts, 1843);
+        assert_eq!(d.rtherm_i_min_counts, 300);
+    }
+
+    #[test]
+    fn current_counts_scales_with_the_shunt_and_saturates() {
+        assert_eq!(current_counts(1953, 60, 15_000, 3300), 2182);
+        assert_eq!(current_counts(0, 60, 15_000, 3300), 0);
+        assert_eq!(current_counts(u16::MAX, u16::MAX, u16::MAX, 1), u16::MAX);
+    }
 }

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -36,7 +36,7 @@ pub use telemetry::{
     TelemetrySensors,
 };
 
-use crate::regions::config::ConfigDefaults;
+use crate::regions::config::{ConfigDefaults, CurrentDefaults};
 use control_table::{RegionStorage, Table};
 
 pub const CONFIG_REGION_SIZE: u16 = 128;
@@ -67,7 +67,7 @@ pub struct ControlTable {
 impl ControlTableCell {
     /// Soft limits init to physical limits per control-table doc.
     /// Caller must be sole writer (install-time, pre-IRQ).
-    pub fn seed_config_defaults(&self, defaults: &ConfigDefaults) {
+    pub fn seed_config_defaults(&self, defaults: &ConfigDefaults, current: &CurrentDefaults) {
         crate::log::debug!(
             "seed CONFIG: phys=[{}, {}] counts  id={}  baud_idx={}",
             defaults.pos_min_phys_counts,
@@ -93,20 +93,20 @@ impl ControlTableCell {
             cfg.loop_position.velocity_limit_cps = config::DEFAULT_VELOCITY_LIMIT_CPS;
             cfg.loop_position.accel_limit_q88 = config::DEFAULT_ACCEL_LIMIT_Q88;
             cfg.loop_position.pos_deadband_counts = config::DEFAULT_POS_DEADBAND_COUNTS;
-            cfg.limits.current_limit_counts = config::DEFAULT_CURRENT_LIMIT_COUNTS;
+            cfg.limits.current_limit_counts = current.current_limit_counts;
             cfg.limits.drive_polarity = config::DEFAULT_DRIVE_POLARITY;
             cfg.limits.stall_omega_max_cps = config::DEFAULT_STALL_OMEGA_MAX_CPS;
             cfg.limits.stall_time_ms = config::DEFAULT_STALL_TIME_MS;
-            cfg.limits.stall_yield_counts = config::DEFAULT_STALL_YIELD_COUNTS;
-            cfg.limits.stall_release_counts = config::DEFAULT_STALL_RELEASE_COUNTS;
-            cfg.limits.stall_tau_trip_counts = config::DEFAULT_STALL_TAU_TRIP_COUNTS;
-            cfg.limits.oc_trip_counts = config::DEFAULT_OC_TRIP_COUNTS;
+            cfg.limits.stall_yield_counts = current.stall_yield_counts;
+            cfg.limits.stall_release_counts = current.stall_release_counts;
+            cfg.limits.stall_tau_trip_counts = current.stall_tau_trip_counts;
+            cfg.limits.oc_trip_counts = current.oc_trip_counts;
             cfg.limits.oc_trip_ticks = config::DEFAULT_OC_TRIP_TICKS;
             cfg.thermal.derate_start_cc = config::DEFAULT_DERATE_START_CC;
             cfg.thermal.cutoff_cc = config::DEFAULT_CUTOFF_CC;
             cfg.thermal.recover_cc = config::DEFAULT_RECOVER_CC;
             cfg.thermal.v_undervolt_counts = config::DEFAULT_V_UNDERVOLT_COUNTS;
-            cfg.thermal.rtherm_i_min_counts = config::DEFAULT_RTHERM_I_MIN_COUNTS;
+            cfg.thermal.rtherm_i_min_counts = current.rtherm_i_min_counts;
             cfg.thermal.rtherm_omega_max_cps = config::DEFAULT_RTHERM_OMEGA_MAX_CPS;
             cfg.fault_cfg.pos_error_counts = config::DEFAULT_POS_ERROR_COUNTS;
             cfg.fault_cfg.pos_error_time_ms = config::DEFAULT_POS_ERROR_TIME_MS;

--- a/firmware/lib/integration/src/sim/servo.rs
+++ b/firmware/lib/integration/src/sim/servo.rs
@@ -7,8 +7,8 @@ use std::rc::Rc;
 
 use osc_servo_core::tel::{TelSample, TelStream};
 use osc_servo_core::{
-    BaudRate, BootMode, CalibSense, CalibSenseExt, ConfigDefaults, ControlTable, RegionStorage,
-    Session, Shared,
+    BaudRate, BootMode, CalibSense, CalibSenseExt, ConfigDefaults, ControlTable, CurrentDefaults,
+    RegionStorage, Session, Shared,
 };
 use osc_servo_drivers::bus::{LinkDiag, ServoBus};
 use osc_servo_drivers::tel::{TelChannel, TelFeed};
@@ -19,6 +19,18 @@ use super::providers::{
     SimRing, SimWire,
 };
 use super::store::RamStore;
+
+/// The v006 arm-B sense chain the sim mirrors.
+const SENSE: CalibSense = CalibSense {
+    shunt_r_mohm: 33,
+    gain_milli: 15000,
+    vmotor_div_top: 10000,
+    vmotor_div_bot: 10000,
+    vdd_mv: 3300,
+    tick_hz: 20000,
+    i_window_min_ticks: 240,
+    v_window_min_ticks: 300,
+};
 
 pub struct SimServo {
     shared: Shared,
@@ -46,12 +58,15 @@ impl SimServo {
         let deadline = DeadlineState::new();
 
         let shared = Shared::new();
-        shared.table.seed_config_defaults(&ConfigDefaults {
-            id,
-            baud: rate,
-            response_deadline_us,
-            ..Default::default()
-        });
+        shared.table.seed_config_defaults(
+            &ConfigDefaults {
+                id,
+                baud: rate,
+                response_deadline_us,
+                ..Default::default()
+            },
+            &CurrentDefaults::from_sense(SENSE.shunt_r_mohm, SENSE.gain_milli, SENSE.vdd_mv),
+        );
         if let Some(store) = store {
             store.boot_load(&shared.table);
             shared.seed_store(store);
@@ -60,16 +75,7 @@ impl SimServo {
         // the whole region, so RO board facts land last and win over a
         // stale saved image.
         shared.table.seed_calib_sense(
-            &CalibSense {
-                shunt_r_mohm: 33,
-                gain_milli: 15000,
-                vmotor_div_top: 10000,
-                vmotor_div_bot: 10000,
-                vdd_mv: 3300,
-                tick_hz: 20000,
-                i_window_min_ticks: 240,
-                v_window_min_ticks: 300,
-            },
+            &SENSE,
             &CalibSenseExt {
                 vbus_div_top_ohm: 20000,
                 vbus_div_bot_ohm: 10000,

--- a/firmware/servo-ch32/src/cfg/chip.rs
+++ b/firmware/servo-ch32/src/cfg/chip.rs
@@ -49,11 +49,11 @@ const fn tim1_channel_pin(m: Tim1Mapping, c: timer::Channel) -> Pin {
 
 // === ADC ===
 
-pub const ADC_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
-
-/// OPA output is low-Z, so the short aperture is safe; the divider/pot
-/// channels need `ADC_SAMPLE_TIME`.
-pub const ADC_SHUNT_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES3;
+/// 13.5 sampling + 12.5 conversion = 26 ADCCLK cycles per slot, 0.92 Msps at
+/// 24 MHz: the longest aperture that still keeps every channel (the OPA
+/// output included) under the low-power buffer's 1 Msps ceiling; the >= 1
+/// Msps buffer is rated for VDD >= 4.5 V only (RM sec 9.3.14).
+pub const ADC_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES15;
 
 /// ADC channels available as board-configurable sensor inputs on the V006F8P6.
 /// A0 (PA2) doubles as an OPA positive-input route (PSEL=00), so a board

--- a/firmware/servo-ch32/src/cfg/mod.rs
+++ b/firmware/servo-ch32/src/cfg/mod.rs
@@ -10,7 +10,7 @@ pub use chip::{AnalogChannel, DigitalPin};
 
 use osc_servo_core::estimator::bemf::RECIP_ARR_SHIFT;
 use osc_servo_core::kernel::DECIM_MED;
-use osc_servo_core::{ConfigDefaults, KernelTiming};
+use osc_servo_core::{ConfigDefaults, CurrentDefaults, KernelTiming};
 
 use crate::providers::usart_baud;
 
@@ -33,6 +33,7 @@ pub struct Precomputed {
     pub pwm_arr: u16,
     pub usart_brr: u32,
     pub kernel_timing: KernelTiming,
+    pub current_defaults: CurrentDefaults,
 }
 
 impl Precomputed {
@@ -60,6 +61,11 @@ impl Precomputed {
                 med_ticks_per_ms_q16: ((med_hz as u64 * 65536) / 1000) as u32,
                 vbus_scale_q15,
             },
+            current_defaults: CurrentDefaults::from_sense(
+                cfg.calibration.shunt_r_mohm,
+                cfg.wiring.current_sense.gain_milli,
+                cfg.calibration.vdd_mv,
+            ),
         }
     }
 }

--- a/firmware/servo-ch32/src/control/sensors/scan.rs
+++ b/firmware/servo-ch32/src/control/sensors/scan.rs
@@ -3,10 +3,10 @@
 //! scan lands at offset 0 and the peak scan lands at `ADC_SCAN_LEN`. Slot
 //! indices within a scan reflect the configured RSQR sequence.
 //!
-//! Budget at ADCCLK 12 MHz (TCONV = sampling + 12.5, RM sec 9.3): a scan is
-//! 6 x 21.5 + 15.5 = 144.5 cycles = 12.0 us. The peak scan's TC lands 12 us
+//! Budget at ADCCLK 24 MHz (TCONV = 13.5 sampling + 12.5, RM sec 9.3): a
+//! scan is 7 x 26 = 182 cycles = 7.58 us. The peak scan's TC lands 7.6 us
 //! after its trigger and the trough trigger follows 25 us after it, so the
-//! TC ISR has ~14 us to drain the trough slots before slot 0 is rewritten;
+//! TC ISR has ~18 us to drain the trough slots before slot 0 is rewritten;
 //! the peak slots stand until the next peak trigger.
 
 use core::cell::SyncUnsafeCell;

--- a/firmware/servo-ch32/src/hal/adc/v00x.rs
+++ b/firmware/servo-ch32/src/hal/adc/v00x.rs
@@ -94,7 +94,8 @@ pub fn set_dma(enable: bool) {
 }
 
 /// CTLR3.ADC_LP (RM sec 9.3.14). Reset default is set (low-power, sub-1M
-/// sampling); clearing it picks the high-power converter.
+/// sampling); clearing it picks the high-power converter, which the
+/// datasheet rates for VDD >= 4.5 V only.
 pub fn set_low_power(enable: bool) {
     ADC.ctlr3().modify(|w| w.set_adc_lp(enable));
 }
@@ -111,7 +112,7 @@ pub fn disable() {
     ADC.ctlr2().modify(|w| w.set_adon(false));
 }
 
-/// Polls for EOC this many times before giving up. A conversion is ~20 ADCCLK
+/// Polls for EOC this many times before giving up. A conversion is ~26 ADCCLK
 /// cycles, so exceeding this means the converter is not running.
 const EOC_POLL_LIMIT: u32 = 100_000;
 

--- a/firmware/servo-ch32/src/hal/clocks.rs
+++ b/firmware/servo-ch32/src/hal/clocks.rs
@@ -7,7 +7,9 @@ pub const PLL_MUL: u32 = 2;
 pub const SYSCLK_HZ: u32 = HSI_HZ * PLL_MUL;
 
 pub const HPRE_DIV: u32 = 1;
-pub const ADCPRE_DIV: u32 = 4;
+/// fADC is rated 16-48 MHz (V006 datasheet Table 3-23); /2 is the only
+/// divider from the 48 MHz bus that lands inside it.
+pub const ADCPRE_DIV: u32 = 2;
 
 pub const HCLK_HZ: u32 = SYSCLK_HZ / HPRE_DIV;
 pub const PCLK_HZ: u32 = HCLK_HZ;

--- a/firmware/servo-ch32/src/runtime/init.rs
+++ b/firmware/servo-ch32/src/runtime/init.rs
@@ -20,7 +20,6 @@ use crate::cfg::{
 };
 
 const OPA_SETTLE_MS: u32 = 1;
-const VCAL_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
 
 /// Boot bias averaging: a power-of-two count so the mean is a shift, never a
 /// divide (the linker must stay free of __udivsi3).
@@ -239,7 +238,7 @@ fn bring_up_analog_chain(cs: &CurrentSenseConfig) {
 /// rewritten there.
 fn measure_rest(ch: adc::Channel, t: adc::SampleTime) -> Option<u16> {
     adc::set_sample_time(ch, t);
-    adc::set_low_power(false);
+    adc::set_low_power(true);
     adc::set_scan_mode(false);
     adc::set_dma(false);
     // Arm the software trigger before ADON so EXTTRIG is already live when
@@ -269,7 +268,7 @@ fn measure_rest(ch: adc::Channel, t: adc::SampleTime) -> Option<u16> {
 /// Zero-current output of the sense chain. Zero on timeout leaves current
 /// uncorrected rather than wrong.
 fn measure_current_bias(cs: &CurrentSenseConfig) -> u16 {
-    measure_rest(cs.current_channel().channel(), chip::ADC_SHUNT_SAMPLE_TIME).unwrap_or(0)
+    measure_rest(cs.current_channel().channel(), chip::ADC_SAMPLE_TIME).unwrap_or(0)
 }
 
 /// Terminal-divider bias: with the driver parked both terminals float, so
@@ -293,14 +292,14 @@ fn configure_adc_dma_scan(w: &BoardWiring) {
     let sensors = &w.sensors;
     let current = w.current_sense.current_channel().channel();
 
-    adc::set_sample_time(current, chip::ADC_SHUNT_SAMPLE_TIME);
+    adc::set_sample_time(current, chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.pos.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.vmotor.0.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.vmotor.1.channel(), chip::ADC_SAMPLE_TIME);
-    adc::set_sample_time(adc::Channel::Vcal, VCAL_SAMPLE_TIME);
+    adc::set_sample_time(adc::Channel::Vcal, chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.vbus.channel(), chip::ADC_SAMPLE_TIME);
     adc::set_sample_time(sensors.ntc.channel(), chip::ADC_SAMPLE_TIME);
-    adc::set_low_power(false);
+    adc::set_low_power(true);
 
     let seq = [
         current,

--- a/firmware/servo-ch32/src/runtime/init.rs
+++ b/firmware/servo-ch32/src/runtime/init.rs
@@ -48,7 +48,9 @@ pub fn bringup(
     // Sole writer to CONFIG: pre-IRQ, pre-`Drivers::install`. Board defaults
     // first, then the saved image overlays them (protocol sec 9.4) -- `Drivers::install`
     // reads the effective comms block from the table.
-    SHARED.table.seed_config_defaults(defaults);
+    SHARED
+        .table
+        .seed_config_defaults(defaults, &pre.current_defaults);
     SHARED.table.seed_identity(model, hw_rev);
     config_store::ConfigStore::boot_load();
     // After boot_load: the calib overlay copies the whole region, so the RO


### PR DESCRIPTION
ADC clock moves from 12 MHz to 24 MHz with the low-power buffer and a 13.5-cycle aperture on every slot, inside the datasheet's rated range at 3.3 V. Count-domain current defaults become milliamp policy converted at compile time from the board's shunt, gain and VDD; the overcurrent trip policy is 3.0 A. Rig board file records the 60 mOhm shunt.

https://claude.ai/code/session_019qMDrK7b61Rj6X9awLEsak