### PR TITLE
fw: adc at 48 MHz with per-channel apertures, live current bias from the trough sample

### DIFF
--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -68,11 +68,11 @@ fn main() -> ! {
             // Scan order is [shunt, vmA, vmB, pos, vcal, vbus, ntc]. The i floor is
             // amp-settling-bound: arm-B network measured true from duty 13%
             // (bringup docs/armb-comp-sizing.md). The v floor covers
-            // vmotor_b's S/H close ~131 ticks (2.7 us) after the crest
-            // trigger plus margin; a v floor below the true edge lets
-            // off-phase samples seed the vbus EWMA and latch a false
-            // undervolt. Both floors pending bench re-validation at the new
-            // ADC clock.
+            // vmotor_b's S/H close, 44 ticks (0.91 us) after the crest
+            // trigger at ADCCLK 48 MHz (vmotor_a's at 24 ticks, 0.49 us),
+            // plus margin; a v floor below the true edge lets off-phase
+            // samples seed the vbus EWMA and latch a false undervolt. Both
+            // floors pending the edge grid on the hacked dividers.
             i_window_min_ticks: 160,
             v_window_min_ticks: 210,
         },

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -48,9 +48,11 @@ fn main() -> ! {
         },
         calibration: Calibration {
             shunt_r_mohm: 60,
+            // Hacked board D: 6k8 0805 top / 3k3 THT bottom returned to VB,
+            // ~150 pF reservoir at each tap (2.2 kohm source, fast aperture).
             vmotor_divider: Divider {
-                top_ohm: 20_000,
-                bot_ohm: 10_000,
+                top_ohm: 6_800,
+                bot_ohm: 3_300,
             },
             // Board D bodge as fitted (15k/10k); rev-2A lands 20_000/10_000.
             vbus_divider: Divider {
@@ -62,8 +64,8 @@ fn main() -> ! {
                 r25_ohm: 10_000,
                 beta: 3950,
             },
-            // Terminal-divider bias VB from 3V3 through 430/100: 4095 x 100 / 530.
-            vmotor_bias_nom_counts: 773,
+            // Terminal-divider bias VB from 3V3 through 200/47: 4095 x 47 / 247.
+            vmotor_bias_nom_counts: 779,
             vdd_mv: 3300,
             // Scan order is [shunt, vmA, vmB, pos, vcal, vbus, ntc]. The i floor is
             // amp-settling-bound: arm-B network measured true from duty 13%

--- a/firmware/lib/core/src/estimator/bias.rs
+++ b/firmware/lib/core/src/estimator/bias.rs
@@ -1,0 +1,93 @@
+//! Shunt zero-current bias tracker.
+
+/// Zero-current output of the current-sense chain, in raw ADC counts:
+/// seeded from the boot rest measurement, then followed as an EWMA of the
+/// Slow-decay trough shunt sample (`window::trough_is_brake` gates the
+/// feed). Alpha = 1/128; `state_q8` keeps 8 sub-LSB bits so the dead band
+/// where the update rounds to zero is under half a count, and `counts`
+/// rounds to nearest, so a constant input is reproduced exactly.
+#[derive(Default)]
+pub struct BiasTracker {
+    state_q8: i32,
+    seeded: bool,
+}
+
+impl BiasTracker {
+    pub const fn new() -> Self {
+        Self {
+            state_q8: 0,
+            seeded: false,
+        }
+    }
+
+    pub fn seed(&mut self, counts: u16) {
+        self.state_q8 = (counts as i32) << 8;
+        self.seeded = true;
+    }
+
+    /// Folds one offset sample in; the first sample seeds if nothing has.
+    pub fn update(&mut self, trough: u16) -> u16 {
+        let x = (trough as i32) << 8;
+        if !self.seeded {
+            self.state_q8 = x;
+            self.seeded = true;
+        } else {
+            self.state_q8 += (x - self.state_q8) >> 7;
+        }
+        self.counts()
+    }
+
+    pub fn counts(&self) -> u16 {
+        ((self.state_q8 + (1 << 7)) >> 8) as u16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeds_from_boot_value() {
+        let mut b = BiasTracker::new();
+        b.seed(1234);
+        assert_eq!(b.counts(), 1234);
+        assert_eq!(b.update(1234), 1234);
+    }
+
+    #[test]
+    fn first_sample_seeds_when_unseeded() {
+        let mut b = BiasTracker::new();
+        assert_eq!(b.update(2000), 2000);
+        assert_eq!(b.update(2000), 2000);
+    }
+
+    #[test]
+    fn constant_input_steady_state() {
+        let mut b = BiasTracker::new();
+        b.seed(2048);
+        for _ in 0..512 {
+            assert_eq!(b.update(2048), 2048);
+        }
+    }
+
+    #[test]
+    fn step_converges_at_one_over_128() {
+        for (from, to) in [(2048u16, 2088u16), (2088, 2048), (0, 2048)] {
+            let mut b = BiasTracker::new();
+            b.seed(from);
+            let mut v = 0;
+            for _ in 0..128 {
+                v = b.update(to) as i32;
+            }
+            // one time constant: 1 - (127/128)^128 = 63.4% of the step
+            let expect = from as i32 + ((to as i32 - from as i32) * 634) / 1000;
+            assert!((v - expect).abs() <= 1, "{from}->{to}: {v} vs {expect}");
+            // 10 tau leaves under 0.1 count of the largest step: inside the
+            // half-count dead band, rounded away
+            for _ in 128..1280 {
+                v = b.update(to) as i32;
+            }
+            assert_eq!(v, to as i32, "{from}->{to} after 10 tau");
+        }
+    }
+}

--- a/firmware/lib/core/src/estimator/mod.rs
+++ b/firmware/lib/core/src/estimator/mod.rs
@@ -1,6 +1,7 @@
 //! Count-domain estimator blocks the kernel runs on a `SensorFrame`.
 
 pub mod bemf;
+pub mod bias;
 pub mod fusion;
 pub mod thermal;
 pub mod vbus;
@@ -8,6 +9,7 @@ pub mod vcal;
 pub mod window;
 
 pub use bemf::BemfObs;
+pub use bias::BiasTracker;
 pub use fusion::{FusionGains, FusionObs};
 pub use thermal::{ThermAnchor, ThermGates, WindingTherm};
 pub use vbus::VbusEst;

--- a/firmware/lib/core/src/estimator/window.rs
+++ b/firmware/lib/core/src/estimator/window.rs
@@ -66,6 +66,21 @@ pub fn vdiff_from_frame(frame: &SensorFrame, sel: WindowSel) -> Option<i32> {
     Some(va as i32 - vb as i32)
 }
 
+/// True when the trough scan sampled a Slow-decay brake phase: both
+/// low-side FETs on, the winding current recirculating inside the bridge
+/// and none of it crossing the return-path shunt, so the shunt reading is
+/// pure amplifier offset. Fast decay puts the drive window at the trough,
+/// zero ticks is Coast/Brake/Disabled (no PWM edge), and the brake half-
+/// width must clear the same settling floor as the drive window, or the
+/// trough sample still carries the amplifier's tail from the drive current.
+pub fn trough_is_brake(decay: DecayMode, drive_ticks: u32, pwm_arr: u16, i_floor: u16) -> bool {
+    let brake_ticks = (pwm_arr as u32).saturating_sub(drive_ticks);
+    matches!(decay, DecayMode::Slow)
+        && drive_ticks != 0
+        && brake_ticks != 0
+        && brake_ticks >= i_floor as u32
+}
+
 /// Mirrors chip-side `effort_to_ticks` (`mag * arr / 32767` approximated as
 /// round(`mag * arr >> 15`)) so validity floors compare against the same
 /// width the motor write programs.
@@ -178,6 +193,23 @@ mod tests {
             use_trough: false,
         };
         assert_eq!(vdiff_from_frame(&f, sel), None);
+    }
+
+    #[test]
+    fn trough_is_brake_only_inside_a_settled_slow_brake_phase() {
+        assert!(trough_is_brake(DecayMode::Slow, 1, 1200, 160));
+        assert!(trough_is_brake(DecayMode::Slow, 600, 1200, 160));
+        assert!(trough_is_brake(DecayMode::Slow, 1040, 1200, 160));
+        assert!(!trough_is_brake(DecayMode::Slow, 1041, 1200, 160));
+        assert!(!trough_is_brake(DecayMode::Fast, 600, 1200, 160));
+        assert!(!trough_is_brake(DecayMode::Slow, 0, 1200, 160));
+        assert!(!trough_is_brake(DecayMode::Slow, 1200, 1200, 0));
+        assert!(!trough_is_brake(
+            DecayMode::Slow,
+            drive_ticks(i16::MAX, 1200),
+            1200,
+            0
+        ));
     }
 
     #[test]

--- a/firmware/lib/core/src/kernel/mod.rs
+++ b/firmware/lib/core/src/kernel/mod.rs
@@ -23,8 +23,8 @@ pub use trajectory::{TrajCfg, TrajGen};
 pub use velocity::{VelocityGains, VelocityLoop};
 
 use crate::estimator::{
-    BemfObs, FusionGains, FusionObs, ThermAnchor, ThermGates, VbusEst, VcalLpf, WindingTherm, bemf,
-    window,
+    BemfObs, BiasTracker, FusionGains, FusionObs, ThermAnchor, ThermGates, VbusEst, VcalLpf,
+    WindingTherm, bemf, window,
 };
 use crate::math::{q_mul, q_mul_u};
 use crate::regions::config::DecaySelect;
@@ -78,6 +78,9 @@ pub struct Kernel<I: ControlIo, T: TelStream = ()> {
     decim_med: u8,
     decim_slow: u8,
     vcal_lpf: VcalLpf,
+    /// Shunt zero-current offset in use; its value is republished to
+    /// `current_bias_counts` every tick.
+    bias: BiasTracker,
     traj: TrajGen,
     fusion: FusionObs,
     cur: CurrentLoop,
@@ -138,6 +141,7 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
             decim_med: DECIM_MED - 1,
             decim_slow: DECIM_SLOW - 1,
             vcal_lpf: VcalLpf::new(),
+            bias: BiasTracker::new(),
             traj: TrajGen::new(),
             fusion: FusionObs::new(),
             cur: CurrentLoop::new(),
@@ -174,7 +178,7 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
         // SAFETY: reads of transport-owned regions - raw-pointer volatile
         // block copies, no `&T` formed, aligned repr(C) blocks inside the
         // static table (single-writer contract in the type doc).
-        let (life, loop_cur, lim_cfg, therm_cfg, sense, motor_cal, bias) = unsafe {
+        let (life, loop_cur, lim_cfg, therm_cfg, sense, motor_cal) = unsafe {
             (
                 (&raw const (*p).control.lifecycle).read_volatile(),
                 (&raw const (*p).config.loop_current).read_volatile(),
@@ -182,13 +186,18 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
                 (&raw const (*p).config.thermal).read_volatile(),
                 (&raw const (*p).calib.sense).read_volatile(),
                 (&raw const (*p).calib.motor).read_volatile(),
-                (&raw const (*p).telemetry.sensors.current_bias_counts).read_volatile(),
             )
         };
 
         if !self.booted {
             self.booted = true;
             self.fusion.seed(frame.pos);
+            // SAFETY: same volatile read contract; install stamped the boot
+            // rest measurement here before the first tick, and from here on
+            // this kernel is the field's sole writer.
+            self.bias.seed(unsafe {
+                (&raw const (*p).telemetry.sensors.current_bias_counts).read_volatile()
+            });
         }
         let vcal_lpf = self.vcal_lpf.update(frame.vcal);
 
@@ -228,6 +237,20 @@ impl<I: ControlIo, T: TelStream> Kernel<I, T> {
             sense.i_window_min_ticks,
             sense.v_window_min_ticks,
         );
+        let bias = if window::trough_is_brake(
+            self.decay,
+            ticks,
+            self.timing.pwm_arr,
+            sense.i_window_min_ticks,
+        ) {
+            self.bias.update(frame.current_trough)
+        } else {
+            self.bias.counts()
+        };
+        // SAFETY: sole-telemetry-writer contract (type doc); volatile store.
+        unsafe {
+            (&raw mut (*p).telemetry.sensors.current_bias_counts).write_volatile(bias);
+        }
         let i_meas = window::i_from_frame(&frame, sel, fwd, bias);
         if let Some(i) = i_meas {
             self.i_meas_last = i.clamp(i16::MIN as i32, i16::MAX as i32) as i16;

--- a/firmware/lib/core/src/kernel/tests.rs
+++ b/firmware/lib/core/src/kernel/tests.rs
@@ -132,11 +132,13 @@ fn vbus_raw(vmotor: u16) -> u16 {
     ((vmotor as u32 * 32768).div_ceil(VBUS_SCALE_Q15)) as u16
 }
 
+/// Slow-decay frames: the trough scan lands in the brake phase, so the shunt
+/// reads its offset there.
 fn frame(pos: u16, current: u16) -> SensorFrame {
     SensorFrame {
         pos,
         current,
-        current_trough: current,
+        current_trough: BIAS,
         vmotor_a: 3000,
         vmotor_a_trough: 3000,
         vmotor_b: 40,
@@ -602,6 +604,115 @@ fn publishes_land_in_the_table() {
     });
 }
 
+fn published_bias(sh: &Shared) -> u16 {
+    sh.table.with(|t| t.telemetry.sensors.current_bias_counts)
+}
+
+#[test]
+fn trough_bias_tracks_only_inside_slow_drive_windows() {
+    let sh = Shared::new();
+    seed(&sh);
+    let mut k = kernel();
+    let shifted = || {
+        let mut f = frame(2000, BIAS);
+        f.current_trough = BIAS + 500;
+        f
+    };
+    // tick 1 already runs on the boot seed
+    k.on_tick(shifted(), &sh);
+    assert_eq!(published_bias(&sh), BIAS);
+    // Disabled: no PWM, no brake phase
+    for _ in 0..300 {
+        k.on_tick(shifted(), &sh);
+    }
+    assert!(matches!(last_cmd(&k), MotorCmd::Disabled));
+    assert_eq!(published_bias(&sh), BIAS);
+    // Fast decay: the trough IS the drive window
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 8000;
+        t.config.limits.openloop_decay = DecaySelect::Fast;
+    });
+    for _ in 0..300 {
+        k.on_tick(shifted(), &sh);
+    }
+    assert!(matches!(
+        last_cmd(&k),
+        MotorCmd::Drive {
+            decay: DecayMode::Fast,
+            ..
+        }
+    ));
+    assert_eq!(published_bias(&sh), BIAS);
+    // full-scale Slow: idle leg never leaves CCR 0, no off phase
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.goal_duty = i16::MAX;
+        t.config.limits.openloop_decay = DecaySelect::Slow;
+    });
+    for _ in 0..300 {
+        k.on_tick(shifted(), &sh);
+    }
+    assert!(matches!(last_cmd(&k), MotorCmd::Drive { duty, .. } if duty.0 == i16::MAX));
+    assert_eq!(published_bias(&sh), BIAS);
+    // Brake as a command
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.goal_duty = 0;
+        t.config.limits.openloop_zero_brake = true;
+    });
+    for _ in 0..300 {
+        k.on_tick(shifted(), &sh);
+    }
+    assert!(matches!(last_cmd(&k), MotorCmd::Brake));
+    assert_eq!(published_bias(&sh), BIAS);
+    // a partial Slow window: the trough is the brake phase, the tracker follows
+    sh.table.with_mut(|t| t.control.lifecycle.goal_duty = 8000);
+    for _ in 0..1500 {
+        k.on_tick(shifted(), &sh);
+    }
+    assert!(matches!(
+        last_cmd(&k),
+        MotorCmd::Drive {
+            decay: DecayMode::Slow,
+            ..
+        }
+    ));
+    assert_eq!(published_bias(&sh), BIAS + 500);
+}
+
+#[test]
+fn drifting_trough_bias_leaves_i_meas_flat() {
+    let sh = Shared::new();
+    seed(&sh);
+    sh.table.with_mut(|t| {
+        t.control.lifecycle.torque_enable = true;
+        t.control.lifecycle.mode = Mode::OpenLoop;
+        t.control.lifecycle.goal_duty = 8000;
+    });
+    let mut k = kernel();
+    // offset walks 100 counts over 4000 ticks (1 count per 40 ticks, well
+    // under the 128-tick tracker time constant); the true current is a
+    // constant 300 counts above it
+    let mut b = BIAS;
+    for n in 0..4000u16 {
+        b = BIAS + n / 40;
+        let mut f = frame(2000, b + 300);
+        f.current_trough = b;
+        k.on_tick(f, &sh);
+        if n >= 300 {
+            let i = k.i_meas_last as i32;
+            assert!((i - 300).abs() <= 5, "tick {n}: i_meas {i}, bias {b}");
+        }
+    }
+    assert!(
+        published_bias(&sh).abs_diff(b) <= 5,
+        "{}",
+        published_bias(&sh)
+    );
+    // the untracked boot value would have read 400 here
+    assert_eq!(b, BIAS + 99);
+}
+
 // --- Ident aggregates -----------------------------------------------------
 
 fn ident_setup(sh: &Shared) {
@@ -754,7 +865,7 @@ impl Plant {
         SensorFrame {
             pos,
             current: sample,
-            current_trough: sample,
+            current_trough: BIAS,
             vmotor_a: va,
             vmotor_a_trough: va,
             vmotor_b: vb,
@@ -1217,7 +1328,7 @@ fn tel_stream_gated_by_sink_active() {
     assert_eq!(k.tel.samples.len(), 20);
     let s = k.tel.samples.last().unwrap();
     assert_eq!(s.pos, 2100);
-    assert_eq!(s.current_trough, BIAS + 40);
+    assert_eq!(s.current_trough, BIAS);
     // previous-tick alignment: the sampled duty is the command whose window
     // this frame measured
     assert_eq!(s.duty_q15, 8000);

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -141,7 +141,7 @@ impl ControlTableCell {
     }
 
     /// Stamp the boot-measured zero-current output of the sense chain, in raw
-    /// ADC counts -- the offset every `sensors.current` reading is relative to.
+    /// ADC counts: the seed the kernel's bias tracker starts from.
     /// Caller must be sole writer (install-time, pre-IRQ).
     pub fn seed_current_bias(&self, counts: u16) {
         crate::log::debug!("seed current bias: {} counts", counts);

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -102,7 +102,8 @@ pub struct TelemetrySensors {
     pub enc_b: u16,
     #[ct_field(access = ro)]
     pub current_trough: u16,
-    /// Boot-measured zero-current sense-chain output, raw ADC counts.
+    /// Zero-current sense-chain output in use, raw ADC counts: the boot
+    /// rest measurement, then tracked from the Slow-decay trough sample.
     #[ct_field(access = ro)]
     pub current_bias_counts: u16,
     /// Direct supply divider tap, raw ADC counts (the rail `vbus_counts`

--- a/firmware/servo-ch32/src/cfg/chip.rs
+++ b/firmware/servo-ch32/src/cfg/chip.rs
@@ -49,11 +49,16 @@ const fn tim1_channel_pin(m: Tim1Mapping, c: timer::Channel) -> Pin {
 
 // === ADC ===
 
-/// 13.5 sampling + 12.5 conversion = 26 ADCCLK cycles per slot, 0.92 Msps at
-/// 24 MHz: the longest aperture that still keeps every channel (the OPA
-/// output included) under the low-power buffer's 1 Msps ceiling; the >= 1
-/// Msps buffer is rated for VDD >= 4.5 V only (RM sec 9.3.14).
-pub const ADC_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES15;
+// Apertures at ADCCLK 48 MHz, sized to each source's impedance (V006
+// datasheet RAIN table: 3.5 cycles holds under 1.5 kOhm, 7.5 under 3 kOhm).
+// TCONV = aperture + 12.5.
+
+/// OPA output, low-Z: 3.5 cycles.
+pub const ADC_SHUNT_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES3;
+/// Motor-terminal dividers, under 3 kOhm with reservoir caps: 7.5 cycles.
+pub const ADC_TERMINAL_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
+/// Cap-backed or internal taps (pot, rail, NTC, Vcal): 7.5 cycles.
+pub const ADC_RESERVOIR_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
 
 /// ADC channels available as board-configurable sensor inputs on the V006F8P6.
 /// A0 (PA2) doubles as an OPA positive-input route (PSEL=00), so a board

--- a/firmware/servo-ch32/src/control/sensors/scan.rs
+++ b/firmware/servo-ch32/src/control/sensors/scan.rs
@@ -3,11 +3,15 @@
 //! scan lands at offset 0 and the peak scan lands at `ADC_SCAN_LEN`. Slot
 //! indices within a scan reflect the configured RSQR sequence.
 //!
-//! Budget at ADCCLK 24 MHz (TCONV = 13.5 sampling + 12.5, RM sec 9.3): a
-//! scan is 7 x 26 = 182 cycles = 7.58 us. The peak scan's TC lands 7.6 us
-//! after its trigger and the trough trigger follows 25 us after it, so the
-//! TC ISR has ~18 us to drain the trough slots before slot 0 is rewritten;
-//! the peak slots stand until the next peak trigger.
+//! Budget at ADCCLK 48 MHz (TCONV = aperture + 12.5, RM sec 9.3; apertures
+//! in `cfg::chip`): the shunt slot is 3.5 + 12.5 = 16 cycles = 0.33 us, the
+//! other six 7.5 + 12.5 = 20 cycles = 0.42 us each, so a scan is 136 cycles
+//! = 2.83 us. vmA's S/H closes 16 + 7.5 = 23.5 cycles = 0.49 us = 24 TIM1
+//! ticks after the trigger, vmB's at 43.5 cycles = 0.91 us = 44 ticks. The
+//! peak scan's TC lands 2.8 us after its trigger and the trough trigger
+//! follows 25 us after it, so the TC ISR has ~22 us to drain the trough
+//! slots before slot 0 is rewritten; the peak slots stand until the next
+//! peak trigger.
 
 use core::cell::SyncUnsafeCell;
 

--- a/firmware/servo-ch32/src/hal/adc/v00x.rs
+++ b/firmware/servo-ch32/src/hal/adc/v00x.rs
@@ -112,8 +112,8 @@ pub fn disable() {
     ADC.ctlr2().modify(|w| w.set_adon(false));
 }
 
-/// Polls for EOC this many times before giving up. A conversion is ~26 ADCCLK
-/// cycles, so exceeding this means the converter is not running.
+/// Polls for EOC this many times before giving up. A conversion is at most
+/// 54 ADCCLK cycles, so exceeding this means the converter is not running.
 const EOC_POLL_LIMIT: u32 = 100_000;
 
 /// One software-triggered conversion of `channel`, polled. Overwrites the

--- a/firmware/servo-ch32/src/hal/clocks.rs
+++ b/firmware/servo-ch32/src/hal/clocks.rs
@@ -1,4 +1,4 @@
-use ch32_metapac::rcc::vals::{Adcpre, Hpre};
+use ch32_metapac::rcc::vals::Hpre;
 
 pub const HSI_HZ: u32 = 24_000_000;
 /// V006 RM sec 3, RCC_CTLR: each HSITRIM step shifts HSI by ~60 kHz.
@@ -7,14 +7,15 @@ pub const PLL_MUL: u32 = 2;
 pub const SYSCLK_HZ: u32 = HSI_HZ * PLL_MUL;
 
 pub const HPRE_DIV: u32 = 1;
-/// fADC is rated 16-48 MHz (V006 datasheet Table 3-23); /2 is the only
-/// divider from the 48 MHz bus that lands inside it.
-pub const ADCPRE_DIV: u32 = 2;
 
 pub const HCLK_HZ: u32 = SYSCLK_HZ / HPRE_DIV;
 pub const PCLK_HZ: u32 = HCLK_HZ;
 pub const TIM_CLK_HZ: u32 = HCLK_HZ;
-pub const ADCCLK_HZ: u32 = HCLK_HZ / ADCPRE_DIV;
+/// ADC_CLK_MODE = 1 feeds the converter the undivided HB clock (ADCPRE is
+/// ignored). fADC is rated 16-48 MHz (V006 datasheet Table 3-23); the
+/// sampling-rate ceiling is the source impedance (RAIN table), set per
+/// channel through its aperture, not the clock.
+pub const ADCCLK_HZ: u32 = HCLK_HZ;
 pub const SYSTICK_TICKS_PER_US: u32 = HCLK_HZ / 1_000_000;
 pub const SYSTICK_TICKS_PER_MS: u32 = HCLK_HZ / 1_000;
 
@@ -34,23 +35,5 @@ pub const fn hpre_val() -> Hpre {
         128 => Hpre::DIV128,
         256 => Hpre::DIV256,
         _ => panic!("unsupported HPRE_DIV"),
-    }
-}
-
-pub const fn adcpre_val() -> Adcpre {
-    match ADCPRE_DIV {
-        2 => Adcpre::DIV2,
-        4 => Adcpre::DIV4,
-        6 => Adcpre::DIV6,
-        8 => Adcpre::DIV8,
-        12 => Adcpre::DIV12,
-        16 => Adcpre::DIV16,
-        24 => Adcpre::DIV24,
-        32 => Adcpre::DIV32,
-        48 => Adcpre::DIV48,
-        64 => Adcpre::DIV64,
-        96 => Adcpre::DIV96,
-        128 => Adcpre::DIV128,
-        _ => panic!("unsupported ADCPRE_DIV"),
     }
 }

--- a/firmware/servo-ch32/src/hal/rcc/v00x.rs
+++ b/firmware/servo-ch32/src/hal/rcc/v00x.rs
@@ -3,18 +3,19 @@ use ch32_metapac::{
     rcc::vals::{Pllsrc, Sw},
 };
 
-use crate::hal::clocks::{HSI_HZ, HSI_TRIM_STEP_HZ, adcpre_val, hpre_val};
+use crate::hal::clocks::{HSI_HZ, HSI_TRIM_STEP_HZ, hpre_val};
 
 pub fn init_pll() {
     const HPRE: ch32_metapac::rcc::vals::Hpre = hpre_val();
-    const ADCPRE: ch32_metapac::rcc::vals::Adcpre = adcpre_val();
 
     FLASH.actlr().modify(|w| w.set_latency(2));
 
     RCC.cfgr0().modify(|w| {
         w.set_pllsrc(Pllsrc::HSI);
         w.set_hpre(HPRE);
-        w.set_adcpre(ADCPRE);
+        // undivided HB clock to the ADC (`clocks::ADCCLK_HZ`); ADC_CLK_ADJ
+        // stays at its 1/2-duty reset
+        w.set_adc_clk_mode(true);
     });
 
     RCC.ctlr().modify(|w| w.set_pllon(true));

--- a/firmware/servo-ch32/src/runtime/init.rs
+++ b/firmware/servo-ch32/src/runtime/init.rs
@@ -270,15 +270,15 @@ fn measure_rest(ch: adc::Channel, t: adc::SampleTime) -> Option<u16> {
 /// Zero-current output of the sense chain. Zero on timeout leaves current
 /// uncorrected rather than wrong.
 fn measure_current_bias(cs: &CurrentSenseConfig) -> u16 {
-    measure_rest(cs.current_channel().channel(), chip::ADC_SAMPLE_TIME).unwrap_or(0)
+    measure_rest(cs.current_channel().channel(), chip::ADC_SHUNT_SAMPLE_TIME).unwrap_or(0)
 }
 
 /// Terminal-divider bias: with the driver parked both terminals float, so
 /// each tap reads the bias directly. The taps must agree within
 /// `VMOTOR_BIAS_AGREE_COUNTS`, else the board nominal stands in.
 fn measure_vmotor_bias(s: &AdcPins, nominal: u16) -> u16 {
-    let a = measure_rest(s.vmotor.0.channel(), chip::ADC_SAMPLE_TIME);
-    let b = measure_rest(s.vmotor.1.channel(), chip::ADC_SAMPLE_TIME);
+    let a = measure_rest(s.vmotor.0.channel(), chip::ADC_TERMINAL_SAMPLE_TIME);
+    let b = measure_rest(s.vmotor.1.channel(), chip::ADC_TERMINAL_SAMPLE_TIME);
     match (a, b) {
         (Some(a), Some(b)) if a.abs_diff(b) <= VMOTOR_BIAS_AGREE_COUNTS => {
             ((a as u32 + b as u32) >> 1) as u16
@@ -294,13 +294,13 @@ fn configure_adc_dma_scan(w: &BoardWiring) {
     let sensors = &w.sensors;
     let current = w.current_sense.current_channel().channel();
 
-    adc::set_sample_time(current, chip::ADC_SAMPLE_TIME);
-    adc::set_sample_time(sensors.pos.channel(), chip::ADC_SAMPLE_TIME);
-    adc::set_sample_time(sensors.vmotor.0.channel(), chip::ADC_SAMPLE_TIME);
-    adc::set_sample_time(sensors.vmotor.1.channel(), chip::ADC_SAMPLE_TIME);
-    adc::set_sample_time(adc::Channel::Vcal, chip::ADC_SAMPLE_TIME);
-    adc::set_sample_time(sensors.vbus.channel(), chip::ADC_SAMPLE_TIME);
-    adc::set_sample_time(sensors.ntc.channel(), chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(current, chip::ADC_SHUNT_SAMPLE_TIME);
+    adc::set_sample_time(sensors.pos.channel(), chip::ADC_RESERVOIR_SAMPLE_TIME);
+    adc::set_sample_time(sensors.vmotor.0.channel(), chip::ADC_TERMINAL_SAMPLE_TIME);
+    adc::set_sample_time(sensors.vmotor.1.channel(), chip::ADC_TERMINAL_SAMPLE_TIME);
+    adc::set_sample_time(adc::Channel::Vcal, chip::ADC_RESERVOIR_SAMPLE_TIME);
+    adc::set_sample_time(sensors.vbus.channel(), chip::ADC_RESERVOIR_SAMPLE_TIME);
+    adc::set_sample_time(sensors.ntc.channel(), chip::ADC_RESERVOIR_SAMPLE_TIME);
     adc::set_low_power(true);
 
     let seq = [


### PR DESCRIPTION
ADC clock to 48 MHz (undivided bus clock, low-power buffer) with per-channel apertures: 3.5 cycles on the shunt, 7.5 on the terminal dividers and the reservoir-backed taps. The current bias is tracked as a slow average of the slow-decay trough shunt sample, gated on a brake phase that clears the settling floor, seeded from the boot measurement and republished in the same register.

https://claude.ai/code/session_019qMDrK7b61Rj6X9awLEsak