### PR TITLE
fw: adc at 24 mhz with 13.5-cycle apertures

### DIFF
--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -69,15 +69,18 @@ fn main() -> ! {
             vdd_mv: 3300,
             // Scan order is [shunt, vmA, vmB, pos, vcal, vbus, ntc]. The i floor is
             // amp-settling-bound: arm-B network measured true from duty 13%
-            // (bringup docs/armb-comp-sizing.md). The v floor covers
-            // vmotor_b's S/H close, 44 ticks (0.91 us) after the crest
-            // trigger at ADCCLK 48 MHz (vmotor_a's at 24 ticks, 0.49 us),
-            // plus settling: on the 6k8/3k3 + 150 pF dividers both terminals
-            // read the rail within 1% from 96 ticks (duty 8%, edge grid both
-            // directions), 24 ticks margin. A v floor below the true edge lets
-            // off-phase samples seed the vbus EWMA and latch a false undervolt.
+            // (bringup docs/armb-comp-sizing.md); the shunt S/H closes 27
+            // ticks after the trigger, far inside it. The v floor covers
+            // vmotor_b's S/H close, 131 ticks (2.73 us) after the crest
+            // trigger at ADCCLK 24 MHz with 13.5-cycle apertures (vmotor_a's
+            // at 79 ticks, 1.65 us), 29 ticks margin. Divider settling is no
+            // longer the binding term - on the 6k8/3k3 + 150 pF taps both
+            // terminals read the rail within 1% from 96 ticks (duty 8%, edge
+            // grid both directions), and the slower scan now samples them
+            // well past that. A v floor below the true edge lets off-phase
+            // samples seed the vbus EWMA and latch a false undervolt.
             i_window_min_ticks: 160,
-            v_window_min_ticks: 120,
+            v_window_min_ticks: 160,
         },
         defaults: ConfigDefaults {
             pos_min_phys_counts: 0,

--- a/firmware/servo-ch32/src/cfg/chip.rs
+++ b/firmware/servo-ch32/src/cfg/chip.rs
@@ -49,16 +49,28 @@ const fn tim1_channel_pin(m: Tim1Mapping, c: timer::Channel) -> Pin {
 
 // === ADC ===
 
-// Apertures at ADCCLK 48 MHz, sized to each source's impedance (V006
-// datasheet RAIN table: 3.5 cycles holds under 1.5 kOhm, 7.5 under 3 kOhm).
-// TCONV = aperture + 12.5.
+// Apertures at ADCCLK 24 MHz. TCONV = aperture + 12.5, so 13.5 cycles puts
+// every channel at 1.083 us, fS 0.92 MHz. That is the binding constraint:
+// V006 datasheet Table 3-23 allows VDD down to 2.4 V only while fS stays at
+// or under 1 MHz, and this board's MCU rail is 3.3 V. Above the line the
+// part wants 4.5 V. 13.5 cycles also clears every source impedance here by a
+// wide margin (RAIN table: 3.5 cycles already holds under 1.5 kOhm, 7.5
+// under 3 kOhm), which is free once the rate ceiling sets the aperture.
+//
+// Widening the aperture used to triple rest current noise, because the
+// telemetry bus couples into the amplifier output and a longer window
+// catches more of it (a board-level defect, fixed in rev 2A by an RC at the
+// ADC pin). That was an artefact of running at 48 MHz: measured at 24 MHz a
+// 562 ns aperture holds the phase-locked part to 0.76 counts against 0.68
+// for 146 ns, where at 48 MHz going from 73 to 865 ns took it from 0.42 to
+// 5.11.
 
-/// OPA output, low-Z: 3.5 cycles.
-pub const ADC_SHUNT_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES3;
-/// Motor-terminal dividers, under 3 kOhm with reservoir caps: 7.5 cycles.
-pub const ADC_TERMINAL_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
-/// Cap-backed or internal taps (pot, rail, NTC, Vcal): 7.5 cycles.
-pub const ADC_RESERVOIR_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
+/// OPA output, low-Z.
+pub const ADC_SHUNT_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES15;
+/// Motor-terminal dividers, under 3 kOhm with reservoir caps.
+pub const ADC_TERMINAL_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES15;
+/// Cap-backed or internal taps (pot, rail, NTC, Vcal).
+pub const ADC_RESERVOIR_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES15;
 
 /// ADC channels available as board-configurable sensor inputs on the V006F8P6.
 /// A0 (PA2) doubles as an OPA positive-input route (PSEL=00), so a board

--- a/firmware/servo-ch32/src/hal/clocks.rs
+++ b/firmware/servo-ch32/src/hal/clocks.rs
@@ -1,4 +1,4 @@
-use ch32_metapac::rcc::vals::Hpre;
+use ch32_metapac::rcc::vals::{Adcpre, Hpre};
 
 pub const HSI_HZ: u32 = 24_000_000;
 /// V006 RM sec 3, RCC_CTLR: each HSITRIM step shifts HSI by ~60 kHz.
@@ -11,13 +11,32 @@ pub const HPRE_DIV: u32 = 1;
 pub const HCLK_HZ: u32 = SYSCLK_HZ / HPRE_DIV;
 pub const PCLK_HZ: u32 = HCLK_HZ;
 pub const TIM_CLK_HZ: u32 = HCLK_HZ;
-/// ADC_CLK_MODE = 1 feeds the converter the undivided HB clock (ADCPRE is
-/// ignored). fADC is rated 16-48 MHz (V006 datasheet Table 3-23); the
-/// sampling-rate ceiling is the source impedance (RAIN table), set per
-/// channel through its aperture, not the clock.
-pub const ADCCLK_HZ: u32 = HCLK_HZ;
+/// ADC_CLK_MODE = 0 takes the divided HB clock, ADC_CLK_ADJ stays at its
+/// 1/2-duty reset. fADC is rated 16-48 MHz (V006 datasheet Table 3-23) but
+/// the top of that range is unusable with the low-power comparator buffer
+/// (ADC_LP = 1, RM sec 9.3.14): at 48 MHz a bit trial gets 20.8 ns and the
+/// buffer does not settle, so codes go missing. Measured on a pot sweep,
+/// 48 MHz reports 63% of the codes the wiper crosses and dumps the range it
+/// loses into a neighbour, leaving code 1024 seventy times too wide and the
+/// 55 codes under it unreachable; 24 MHz reports 96% and code 1024 clean.
+/// Acquisition length is not the lever - 41.5 cycles at 48 MHz measured the
+/// same 63% as 3.5.
+pub const ADC_PRE_DIV: u32 = 2;
+pub const ADCCLK_HZ: u32 = HCLK_HZ / ADC_PRE_DIV;
 pub const SYSTICK_TICKS_PER_US: u32 = HCLK_HZ / 1_000_000;
 pub const SYSTICK_TICKS_PER_MS: u32 = HCLK_HZ / 1_000;
+
+pub const fn adcpre_val() -> Adcpre {
+    match ADC_PRE_DIV {
+        2 => Adcpre::DIV2,
+        4 => Adcpre::DIV4,
+        6 => Adcpre::DIV6,
+        8 => Adcpre::DIV8,
+        12 => Adcpre::DIV12,
+        16 => Adcpre::DIV16,
+        _ => panic!("unsupported ADC_PRE_DIV"),
+    }
+}
 
 pub const fn hpre_val() -> Hpre {
     match HPRE_DIV {

--- a/firmware/servo-ch32/src/hal/rcc/v00x.rs
+++ b/firmware/servo-ch32/src/hal/rcc/v00x.rs
@@ -3,19 +3,21 @@ use ch32_metapac::{
     rcc::vals::{Pllsrc, Sw},
 };
 
-use crate::hal::clocks::{HSI_HZ, HSI_TRIM_STEP_HZ, hpre_val};
+use crate::hal::clocks::{HSI_HZ, HSI_TRIM_STEP_HZ, adcpre_val, hpre_val};
 
 pub fn init_pll() {
     const HPRE: ch32_metapac::rcc::vals::Hpre = hpre_val();
+    const ADCPRE: ch32_metapac::rcc::vals::Adcpre = adcpre_val();
 
     FLASH.actlr().modify(|w| w.set_latency(2));
 
     RCC.cfgr0().modify(|w| {
         w.set_pllsrc(Pllsrc::HSI);
         w.set_hpre(HPRE);
-        // undivided HB clock to the ADC (`clocks::ADCCLK_HZ`); ADC_CLK_ADJ
-        // stays at its 1/2-duty reset
-        w.set_adc_clk_mode(true);
+        // divided HB clock to the ADC (`clocks::ADCCLK_HZ`); ADCPRE is only
+        // read when ADC_CLK_MODE is 0
+        w.set_adc_clk_mode(false);
+        w.set_adcpre(ADCPRE);
     });
 
     RCC.ctlr().modify(|w| w.set_pllon(true));


### PR DESCRIPTION
The 48 MHz ADC configuration loses position codes. Measured across five bench
variants on one duty sweep each, scoring only codes the pot actually traversed:

| variant | fADC | aperture | buffer | pot codes | rest i sd | tick%16 |
|---|---|---|---|---|---|---|
| A (main) | 48 MHz | 73 ns | low | 62.7% | 1.03 | 0.42 |
| B | 48 MHz | 865 ns | low | 63.2% | 2.60 | 5.11 |
| D | 48 MHz | 73 ns | high | 97.2% | 3.21 | 4.71 |
| C | 24 MHz | 146 ns | low | 95.7% | 1.28 | 0.68 |
| E (this) | 24 MHz | 562 ns | low | 96.3% | 1.32 | 0.76 |

A against B rules out acquisition: twelve times the aperture changes nothing.
D isolates it to the conversion phase, since only the comparator buffer moved.
So the low-power buffer cannot settle a bit trial in a 48 MHz period, and the
reference manual's 1 Msps framing for ADC_LP does not describe the real limit -
B is at 0.89 Msps and still loses the codes.

The damage is not just resolution. The range a missing code loses is absorbed
by a neighbour, so the pot reads a constant while the shaft turns. The sharpest
signature is the run of missing codes touching a binary boundary: 55 consecutive
codes are unreachable immediately below 1024 on both 48 MHz variants, against 0
on every 24 MHz capture and 1 with the high-power buffer. Same shape at 3072,
42 missing above at 48 MHz against 0 to 5. Notebook 06 measured 139 fake
standstills against zero on the retired chain, which put gear play out by 3.5x.

E is also the only configuration inside every rated limit at once. Datasheet
Table 3-23 ties VDD to sampling rate, not to the buffer bit: fS at or under
1 MHz allows 2.4 V, above it wants 4.5 V. This board's MCU rail is 3.3 V, and
26 cycles at 24 MHz is fS 0.92 MHz. Main today runs 3.00 MHz on that rail.

The wider aperture is a rate-ceiling consequence, not a preference, and it is
safe here: widening used to triple rest current noise through telemetry bus
coupling into the amplifier output, but that was a 48 MHz artefact. At 24 MHz
a 562 ns window holds the phase-locked error to 0.76 counts against 0.68 for
146 ns, where at 48 MHz the same stretch went 0.42 to 5.11.

The slower scan moves the terminal sample-and-holds, so `v_window_min_ticks`
goes 120 to 160. One ADC cycle is now 2 TIM ticks and TCONV is 26 cycles, so
vmB's S/H closes 131 ticks after the crest trigger, above the old floor. A
floor under the true edge lets off-phase samples seed the vbus EWMA and latch
a false undervolt. Divider settling (96 ticks) is no longer the binding term.
`i_window_min_ticks` is unchanged, amp-settling-bound at 160 with the shunt
S/H closing at 27.

Bench: the configuration in this commit is the one captured as variant E, and
the merged build reproduces the boundary fix on the bench.

Correction to an earlier revision of this description, which claimed code 1024
took 3.1% of moving samples and was "70x too wide". That was inflated by an
analysis bug - position was diffed across sweep segment boundaries, where ticks
carry no ordering. Scored within segments it is 0.3% against a 0.04% even
spread. The missing-run counts above are unaffected and are the better measure.