### PR TITLE
osc: keep the rung-retry log out of the recording-failure pattern

### DIFF
--- a/tools/osc/src/sweep.rs
+++ b/tools/osc/src/sweep.rs
@@ -506,7 +506,14 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
                             st.frames, st.samples, st.holes, st.garble
                         );
                         if st.holes > 0 || st.garble > 0 {
-                            dirty = Some(line.clone());
+                            // Deliberately NOT the seg wording above: callers
+                            // scrape stdout for "N seq holes" to judge a
+                            // recording, so a retry line quoting it makes a
+                            // rung we RECOVERED read as a failed capture.
+                            dirty = Some(format!(
+                                "  seg {seg} ({what}) dirty: holes={} garble={}",
+                                st.holes, st.garble
+                            ));
                         }
                         pending.push((seg, duty, frames, line));
                         if feeds(steps, k) {
@@ -521,13 +528,13 @@ pub fn run(args: &Args, baud: String, id: u8) -> Result<()> {
                     }
                     match dirty {
                         None => break,
-                        Some(line) if attempt < args.rung_tries => {
-                            println!("  RETRY rung (attempt {attempt}):{}", line.trim_start());
+                        Some(why) if attempt < args.rung_tries => {
+                            println!("  retry rung, attempt {attempt}:{}", why.trim_start());
                         }
-                        Some(line) => bail!(
+                        Some(why) => bail!(
                             "rung failed {} attempts, giving up:{}",
                             args.rung_tries,
-                            line.trim_start()
+                            why.trim_start()
                         ),
                     }
                 }


### PR DESCRIPTION
Follow-up to #92. The per-rung retry works, but its log line defeats the layer
above it.

`captures/chain3/campaign.sh` decides a recording is bad by scraping the
sweep's stdout for `N seq holes` / `N garble bytes` with a nonzero count. The
retry message quoted the failed attempt's segment line verbatim, so a rung that
was successfully **recovered** still left a nonzero-holes line on stdout, and
the recording was discarded anyway - the exact waste #92 set out to remove. It
also inflated the segment count, which is why one rejection reported `segs=42`
against a 41-segment schedule.

Two of ten recordings in the 2S campaign hit this.

The retry now reports `seg N (duty X%) dirty: holes=H garble=G` and the retry
line reads `retry rung, attempt N: ...`, neither of which matches the scrape.
Comment added at the format site so the coupling is visible to whoever edits it
next, since the two live in different repos and nothing else connects them.

No behavioural change to capture or retry logic; only what gets printed.